### PR TITLE
Esqueleto da solution .NET, e o dominio incapaz de compilar EF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# Esteira base: compila e testa. Os gates especializados (segredo #47, KISS/DRY
+# #75) sao workflows proprios e assumem este aqui de pe.
+#
+# Sem Postgres no job de proposito: a suite roda offline por decisao
+# (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=fake). Servico so entra junto com o
+# primeiro teste de integracao que precisar dele.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# O minimo. Workflow com permissao de escrita e superficie de ataque a toa.
+permissions:
+  contents: read
+
+# Push seguido no mesmo PR nao precisa de duas maquinas: a execucao anterior
+# vira resultado velho no instante em que a nova comeca.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-e-teste:
+    name: Build e teste
+    runs-on: ubuntu-latest
+    # Job travado nao pode queimar minuto ate o teto da conta.
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar o SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          # Mesma faixa do desenvolvimento (9.0.203). Esteira compilando com SDK
+          # diferente do da maquina e verde que nao vale nada.
+          dotnet-version: '9.0.x'
+
+      # A chave e o Directory.Packages.props porque e la que a versao mora — o
+      # gerenciamento central de pacote tirou o numero de dentro dos .csproj.
+      - name: Cache de pacote NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restaurar
+        run: dotnet restore
+
+      - name: Compilar
+        run: dotnet build --no-restore --configuration Release --nologo
+
+      - name: Testar
+        run: dotnet test --no-build --configuration Release --nologo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,196 @@
+# CLAUDE.md
+
+Orientacao para o Claude Code (claude.ai/code) trabalhando neste repositorio.
+
+O projeto se chama **Copiloto** (a pasta e `copiloto-crm/`). Codigo, documentacao,
+commits e issues sao em **portugues** — mantenha. `README.md` e `docs/` usam
+acento; **corpo de issue e mensagem de commit sao ASCII sem acento**, que e o
+padrao ja estabelecido no historico.
+
+---
+
+## A tese, que manda em tudo
+
+**O robo nao fala com o cliente.** Ele le a conversa e entrega ao vendedor um
+dossie de contexto: estagio, objecao (mesmo velada) e — o mais util — o que
+ainda **nao** sabemos sobre aquele cliente. Quem escreve a mensagem e o vendedor.
+
+Isso nao e limitacao tecnica, e o produto. Sugestao de fala pronta falha **na
+frente do cliente** e queima a confianca do vendedor para sempre; leitura de
+conversa falha **na tela**, antes de qualquer dano — o vendedor discorda, ajusta
+e segue usando.
+
+Consequencia de engenharia: o sistema e otimizado para **precisao de leitura**,
+nao para fluencia de escrita. Qualquer ideia que termine em "e ai o sistema manda
+a mensagem" esta fora de escopo por decisao, nao por falta de tempo.
+
+---
+
+## Estado real do repositorio
+
+> Esta secao envelhece rapido. **Quem fecha uma issue atualiza ela no mesmo PR.**
+
+- **Nao existe uma linha de C#.** Sem `.sln`, sem `.csproj`, sem front.
+- O que existe: `README.md`, `docs/ARQUITETURA.md` (13 secoes de decisao),
+  `docker-compose.yml`, `.env.example`, templates de issue.
+- `prompts/tecnicas/` e `seed/` existem e estao **vazias**.
+- **89 issues abertas, nenhuma fechada**, em 9 milestones (M0 Fundacao -> M8 LGPD).
+- Ordem acordada: **alicerce antes de morador** — estrutura primeiro, funcionalidade
+  depois.
+
+Enquanto nao houver `.sln`, `dotnet build` **nao tem o que compilar**, e isso e
+resposta valida (ver "nao deu pra checar" abaixo), nunca um erro a esconder.
+
+---
+
+## Comandos
+
+Passam a valer a partir do esqueleto da solution; antes disso, nao existem.
+
+```bash
+dotnet build                              # compila a solution
+dotnet test                               # suite xUnit
+dotnet format --verify-no-changes         # estilo: reprova sem alterar arquivo
+dotnet run --project src/Copiloto.Api     # sobe a API
+
+docker compose up -d                      # so o Postgres (padrao)
+docker compose --profile distribuido up -d  # + Redis e RabbitMQ
+docker compose ps
+```
+
+`.env` **nao existe por padrao** — e `cp .env.example .env` e preencher.
+`POSTGRES_PASSWORD` sem valor derruba o compose de proposito.
+
+---
+
+## Regras que nao se negociam
+
+- **A IA nunca escreve para o cliente.** Ver a tese acima.
+- **Regra de ancoragem.** Escassez, prova social, desconto e prazo so viram
+  sugestao se existir dado no CRM que sustente. Sem dado, o agente devolve como
+  **pergunta ao vendedor**, nunca como fala pronta. Sugerir "restam 2 unidades"
+  quando existem 200 e publicidade enganosa, cria passivo para a empresa que usa
+  o produto e queima o vendedor com o cliente (#15, #16).
+- **Todo sinal do dossie cita a fala que o originou.** Sem citacao, o bloco nao e
+  exibido. E o que transforma "a IA ta ruim" de reclamacao subjetiva em defeito
+  verificavel.
+- **`Copiloto.Dominio` nao tem `PackageReference`.** Nenhum. E a prova mecanica do
+  dominio POCO da #48: sem pacote, o projeto **nao consegue** compilar um `[Table]`
+  ou um `DbContext`. Ha teste que le o `.csproj` e reprova se um pacote aparecer.
+- **Sem Semantic Kernel e sem LangChain.** Router, cascata e circuit breaker sao
+  escritos a mao — um framework de orquestracao esconderia exatamente o que este
+  projeto existe para mostrar.
+- **Sem banco vetorial dedicado.** `pgvector` roda no Postgres que ja esta aqui,
+  com o mesmo backup, a mesma transacao e a mesma credencial (#60).
+- **PII mascarada antes de sair da rede**, com teste que **falha o build** se
+  vazar em log ou payload (#43). E pseudonimizacao, nao anonimizacao: continua
+  sendo dado pessoal sob a LGPD (#83).
+- **Fake e o padrao.** `CONVERSATION_SOURCE=fake` e `MODEL_PROVIDER=fake`: a suite
+  e a demo rodam **offline e de graca**. Teste que precisa de rede ou de chave de
+  provedor esta errado por construcao.
+- **Nenhuma dependencia adotada de memoria.** Antes de fixar pacote em `.csproj`
+  ou em issue, validar no terminal e **registrar a versao verificada**.
+
+---
+
+## KISS e DRY: os gatilhos
+
+Bateu qualquer um, para e decide (#74):
+
+| Gatilho | Limite |
+|---|---|
+| Tamanho de arquivo | ~300 linhas |
+| Tamanho de metodo | ~40 linhas |
+| Parametros por metodo | 4 |
+| Niveis de aninhamento | 3 |
+| Repeticao do mesmo bloco logico | 3a aparicao |
+| Interface com uma implementacao | so com teste que a justifique |
+
+**A regra dos tres:** nao abstrair na segunda ocorrencia — duas coisas parecidas
+ainda nao mostraram qual e o padrao entre elas, e abstracao errada e mais cara de
+desfazer que duplicacao.
+
+**Duplicacao acidental nao e duplicacao.** Teste antes de unificar: *"se um desses
+mudar, o outro tem que mudar junto, sempre?"* Se nao for um sim claro, deixa
+duplicado.
+
+**Ao bater um gatilho: abre issue com `kiss-dry` + `refatoracao` e SEGUE o
+trabalho.** Refatoracao misturada com feature produz diff que ninguem revisa.
+Excecao: limpeza trivial no arquivo ja tocado, em **commit separado**.
+
+**Excecoes conscientes ja decididas:** `IConversationSource`, `IModelProvider`,
+`IDistributedState` e `IQueue` nascem com mais de uma implementacao **real**
+(#17, #27, #66) — nao sao abstracao prematura.
+
+---
+
+## Fluxo de trabalho
+
+**Uma issue por branch, uma branch por PR.** As 89 issues sao o plano; trabalho
+que nao tem issue, abre issue antes.
+
+```bash
+git switch -c 17-conversation-source     # <numero>-<slug>
+# ... commits ...
+gh pr create --fill                      # corpo com "Closes #17"
+```
+
+Commit: `tipo: o efeito`, em portugues sem acento, descrevendo **o que mudou para
+quem usa** — nao quais arquivos foram editados. O corpo conta o achado, a causa e
+por que a correcao foi feita ali.
+
+```
+feat: Redis e RabbitMQ atras de interface, com in-memory como padrao
+```
+
+---
+
+## Documento que afirma o que o codigo faz precisa de quem confira
+
+`README.md` e `docs/ARQUITETURA.md` descrevem router, ledger, MCP e RAG que **ainda
+nao existem**. Hoje isso e tese declarada, e esta tudo bem. O que nao pode e virar
+promessa desatualizada em silencio.
+
+Regra: **ao fechar uma issue, se o documento passou a divergir do codigo, corrige
+no mesmo PR.** Esses dois arquivos circulam fora do produto — sao a primeira coisa
+que alguem le, e a ultima que alguem confere.
+
+---
+
+## Quem confere o que
+
+**Build e teste sao trabalho da esteira, nao de agente.** O GitHub Actions roda
+`dotnet build` e `dotnet test` em todo push e todo PR: ele nao esquece, nao
+parafraseia mensagem de compilador, roda igual para todo mundo e nao custa token.
+Agente rodando suite so repete — mais caro e menos confiavel — o que a esteira ja
+faz de graca.
+
+Os gates da esteira, cada um com issue propria:
+
+| Gate | Politica de falha |
+|---|---|
+| `build` + `test` | reprova o PR |
+| Varredura de segredo (#47) | reprova o PR |
+| Estilo e formatacao (#75) | reprova o PR |
+| Gatilho de tamanho e duplicacao (#75) | **avisa e exige issue aberta**, nao reprova |
+
+A ultima linha e deliberada: gate que reprova build por um metodo de 42 linhas vira
+gate que todo mundo aprende a contornar — e a partir dai ele nao mede mais nada.
+
+**Nada entra na `main` sem a esteira verde.** E esteira que nao rodou nao e verde:
+verde por nao ter olhado e pior que vermelho, porque vermelho manda consertar e
+verde falso manda seguir.
+
+O que sobra para o agente (Opus) e exatamente o que a esteira nao sabe fazer:
+escrever o codigo, decidir desenho, e julgar se uma mudanca fere um invariante que
+nenhum analisador conhece — a IA nao escreve ao cliente, o sinal cita a fala, a
+sugestao tem dado do CRM que a sustente.
+
+---
+
+## Fora de escopo, por decisao
+
+Multi-tenant · importacao de planilha · relatorios · permissao granular ·
+transcricao de audio · **envio automatico de mensagem ao cliente**.
+
+O ultimo e a tese do produto, nao uma limitacao. O vendedor escreve.

--- a/Copiloto.sln
+++ b/Copiloto.sln
@@ -1,0 +1,69 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Copiloto.Dominio", "src\Copiloto.Dominio\Copiloto.Dominio.csproj", "{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Copiloto.Api", "src\Copiloto.Api\Copiloto.Api.csproj", "{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Copiloto.Testes", "testes\Copiloto.Testes\Copiloto.Testes.csproj", "{63B70471-FA1B-4623-AC0F-143226E91FF3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|x64.Build.0 = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Debug|x86.Build.0 = Debug|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|x64.ActiveCfg = Release|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|x64.Build.0 = Release|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|x86.ActiveCfg = Release|Any CPU
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C}.Release|x86.Build.0 = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|x64.Build.0 = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9}.Release|x86.Build.0 = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|x64.Build.0 = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Debug|x86.Build.0 = Debug|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|x64.ActiveCfg = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|x64.Build.0 = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|x86.ActiveCfg = Release|Any CPU
+		{63B70471-FA1B-4623-AC0F-143226E91FF3}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FFFCAD26-2B47-4305-AC3F-45E18D3ED18C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C4C4B0EC-0234-4734-8A36-5ECD7075BCF9} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{63B70471-FA1B-4623-AC0F-143226E91FF3} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<!--
+  Propriedades de TODOS os projetos, num lugar so.
+
+  Duplicar TargetFramework em cada .csproj funciona ate o dia em que um deles
+  fica para tras numa atualizacao — e o erro so aparece quando algum tipo novo
+  do framework nao compila num projeto e compila nos outros.
+
+  A politica de analisador e de aviso-como-erro NAO entra aqui ainda: ela e da
+  #75, que define os limiares e a politica de falha. Este arquivo existe para
+  que ela tenha um lugar so onde ligar.
+-->
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,23 @@
+<!--
+  Versao de pacote declarada UMA vez, para a solution inteira.
+
+  O motivo e concreto neste projeto: Api e Testes vao referenciar EF Core e
+  Npgsql juntos, e versao divergente entre o projeto e o teste dele produz o
+  pior tipo de falha — o teste passa e a aplicacao quebra.
+
+  Versoes conferidas no terminal (SDK 9.0.203), nao adotadas de memoria.
+-->
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+</Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Uma origem de pacote so, declarada no repositorio.
+
+  Duas razoes, e a segunda e de seguranca:
+
+  1. Reprodutibilidade. Sem <clear/>, o restore herda as origens configuradas na
+     maquina de quem clonou. "Compila na minha maquina" passa a depender de um
+     arquivo que nao esta no repositorio.
+
+  2. Confusao de dependencia. Com mais de uma origem e sem mapeamento, o NuGet
+     consulta todas e aceita a que responder — entao um pacote publico com o
+     mesmo nome de um pacote privado pode entrar no lugar dele. E o aviso
+     NU1507 apontando exatamente isso.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -174,6 +174,35 @@ o que este projeto existe para mostrar.
 
 ---
 
+## Como rodar
+
+Precisa de **.NET 9 SDK** e **Docker**. Nada além disso — a suíte e a demo rodam
+offline, sem chave de provedor e sem rede.
+
+```bash
+cp .env.example .env        # e preencha POSTGRES_PASSWORD
+docker compose up -d        # sobe só o Postgres
+
+dotnet build
+dotnet test
+dotnet run --project src/Copiloto.Api
+```
+
+A solution tem três projetos, e a divisão é mecânica antes de ser estética:
+
+```
+src/Copiloto.Dominio     POCO puro — ZERO PackageReference, e há teste que confere
+src/Copiloto.Api         Minimal API: EF, SignalR, adaptadores, orquestração
+testes/Copiloto.Testes   xUnit
+```
+
+`Copiloto.Dominio` não tem pacote nenhum de propósito: sem `PackageReference` o
+projeto **não consegue** compilar um `[Table]` ou um `DbContext`. Numa pasta dentro
+da API, "domínio POCO" seria uma promessa que o próximo `using` quebra em silêncio,
+com todos os testes verdes.
+
+---
+
 ## Fontes de conversa
 
 Tudo entra por `IConversationSource`, com três implementações trocáveis por configuração:

--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+</Project>

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/src/Copiloto.Api/Properties/launchSettings.json
+++ b/src/Copiloto.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5264",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7153;http://localhost:5264",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Copiloto.Api/appsettings.json
+++ b/src/Copiloto.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Copiloto.Dominio/Copiloto.Dominio.csproj
+++ b/src/Copiloto.Dominio/Copiloto.Dominio.csproj
@@ -1,0 +1,16 @@
+<!--
+  O dominio e POCO puro (#48), e este arquivo e a PROVA disso.
+
+  Sem PackageReference, o projeto nao consegue compilar um [Table], um
+  DbContext ou um JsonPropertyName. Numa pasta dentro da Api, "POCO puro"
+  seria uma promessa que o proximo `using` quebra em silencio, com todos os
+  testes verdes.
+
+  Ha teste que le este arquivo e reprova se um pacote aparecer aqui:
+  testes/Copiloto.Testes/DominioSemPacoteTeste.cs
+
+  A referencia anda num sentido so: Api -> Dominio. O contrario, nunca.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/testes/Copiloto.Testes/Copiloto.Testes.csproj
+++ b/testes/Copiloto.Testes/Copiloto.Testes.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Copiloto.Dominio\Copiloto.Dominio.csproj" />
+    <ProjectReference Include="..\..\src\Copiloto.Api\Copiloto.Api.csproj" />
+  </ItemGroup>
+
+  <!--
+    A raiz do repositorio chega ao teste como metadado do assembly, resolvida
+    pelo MSBuild em tempo de compilacao.
+
+    O teste precisa ler um .csproj em tempo de execucao, e subir com "../../.."
+    a partir do binario quebra na primeira mudanca de layout (Debug/Release,
+    TargetFramework novo, pasta de saida diferente) — e quebra devolvendo
+    "arquivo nao encontrado", que e facil de confundir com "nao ha pacote".
+  -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>RaizDoRepositorio</_Parameter1>
+      <_Parameter2>$(MSBuildThisFileDirectory)..\..\</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/testes/Copiloto.Testes/DominioSemPacoteTeste.cs
+++ b/testes/Copiloto.Testes/DominioSemPacoteTeste.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O dominio e POCO puro (#48). A ausencia de pacote e o que prova isso — e
+/// prova que ninguem confere apodrece, entao aqui esta quem confere.
+/// </summary>
+public class DominioSemPacoteTeste
+{
+    [Fact]
+    public void Dominio_nao_referencia_pacote_nenhum()
+    {
+        var pacotes = ElementosDoDominio("PackageReference");
+
+        Assert.True(
+            pacotes.Count == 0,
+            $"Copiloto.Dominio ganhou pacote: {string.Join(", ", pacotes)}. " +
+            "O dominio e POCO puro por decisao (#48): sem PackageReference ele " +
+            "nao consegue compilar um [Table] nem um DbContext, e e essa " +
+            "impossibilidade que sustenta a regra. Mapeamento e persistencia " +
+            "moram na Api.");
+    }
+
+    [Fact]
+    public void Dominio_nao_depende_de_nenhum_outro_projeto()
+    {
+        var projetos = ElementosDoDominio("ProjectReference");
+
+        Assert.True(
+            projetos.Count == 0,
+            $"Copiloto.Dominio passou a depender de: {string.Join(", ", projetos)}. " +
+            "A referencia anda num sentido so, Api -> Dominio. O contrario " +
+            "transforma o dominio em mais uma camada de aplicacao.");
+    }
+
+    private static List<string> ElementosDoDominio(string nome)
+    {
+        var caminho = Path.Combine(
+            RaizDoRepositorio(), "src", "Copiloto.Dominio", "Copiloto.Dominio.csproj");
+
+        // Arquivo ausente nao pode virar "nenhum pacote encontrado": um teste
+        // que passa por nao ter achado o que conferir e pior que teste nenhum.
+        Assert.True(File.Exists(caminho), $"csproj do dominio nao encontrado em {caminho}");
+
+        return XDocument.Load(caminho)
+            .Descendants(nome)
+            .Select(e => e.Attribute("Include")?.Value ?? "(sem Include)")
+            .ToList();
+    }
+
+    private static string RaizDoRepositorio()
+    {
+        var raiz = typeof(DominioSemPacoteTeste).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "RaizDoRepositorio")
+            ?.Value;
+
+        Assert.False(
+            string.IsNullOrWhiteSpace(raiz),
+            "Metadado RaizDoRepositorio ausente — ele e escrito pelo " +
+            "Copiloto.Testes.csproj em tempo de compilacao.");
+
+        return raiz!;
+    }
+}


### PR DESCRIPTION
Fecha #90.

Alicerce e nada alem dele: sem regra de negocio, sem endpoint, sem EF.

```
Copiloto.sln
Directory.Build.props        TargetFramework, Nullable, ImplicitUsings — num lugar so
Directory.Packages.props     versao de pacote declarada uma vez (CPM)
NuGet.config                 uma origem so, com <clear/>
src/Copiloto.Dominio/        POCO puro — ZERO PackageReference
src/Copiloto.Api/            Minimal API (vazia)
testes/Copiloto.Testes/      xUnit — 2 testes, e os dois sao do invariante
```

### O que foi verificado, nao suposto

- `dotnet build` — **0 erro, 0 aviso**, 1,6s
- `dotnet test` — **2 aprovados**, 10ms
- **O teste do invariante foi visto vermelho antes de verde.** Enxertei
  `Npgsql.EntityFrameworkCore.PostgreSQL` no dominio do jeito que alguem faria de
  verdade (PackageReference + PackageVersion) e a suite reprovou 1 de 2; revertido,
  voltou ao verde. Teste que nunca fica vermelho nao protege nada.

### Duas coisas que apareceram no caminho

**`NU1507`, duas origens de pacote.** Esta maquina tinha `nuget.org` e `github`
configuradas, e com mais de uma origem sem mapeamento o NuGet aceita a que responder
primeiro — que e como um pacote publico entra no lugar de um privado. O
`NuGet.config` com `<clear/>` resolve o aviso e a exposicao junto, e ainda tira o
restore da dependencia de um arquivo que nao esta no repositorio.

**Gerenciamento central de pacote ja barra antes do teste.** Pacote sem
`PackageVersion` reprova no restore (`NU1008`). E uma protecao a mais, nao uma
substituta: quem adiciona nos dois arquivos passa pelo restore, e ai quem pega e o
teste.

### Fora, de proposito

Front (`web/`, nada a renderizar antes da #50), projeto separado para MCP (M6, #56,
hospeda dentro da Api), Dockerfile da aplicacao, qualquer pacote na Api (EF e Npgsql
entram na #48 com a migration que os justifica) e `TreatWarningsAsErrors` — a
politica de falha e da #75, e o `Directory.Build.props` existe para ela ter onde ligar.

### Vai junto: `CLAUDE.md` (commit separado)

Nao tem issue propria, e entra aqui porque so passa a valer a partir da primeira
linha de C#. Registra a tese, os invariantes, os gatilhos de KISS/DRY e o fluxo de
uma issue por branch. A secao "quem confere o que" fixa a decisao de que **build e
teste sao trabalho da esteira, nao de agente**.

Se preferir, separo num PR proprio.