### PR TITLE
Esteira de CI: build e teste em todo push e pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# Esteira base: compila e testa. Os gates especializados (segredo #47, KISS/DRY
+# #75) sao workflows proprios e assumem este aqui de pe.
+#
+# Sem Postgres no job de proposito: a suite roda offline por decisao
+# (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=fake). Servico so entra junto com o
+# primeiro teste de integracao que precisar dele.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# O minimo. Workflow com permissao de escrita e superficie de ataque a toa.
+permissions:
+  contents: read
+
+# Push seguido no mesmo PR nao precisa de duas maquinas: a execucao anterior
+# vira resultado velho no instante em que a nova comeca.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-e-teste:
+    name: Build e teste
+    runs-on: ubuntu-latest
+    # Job travado nao pode queimar minuto ate o teto da conta.
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar o SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          # Mesma faixa do desenvolvimento (9.0.203). Esteira compilando com SDK
+          # diferente do da maquina e verde que nao vale nada.
+          dotnet-version: '9.0.x'
+
+      # A chave e o Directory.Packages.props porque e la que a versao mora — o
+      # gerenciamento central de pacote tirou o numero de dentro dos .csproj.
+      - name: Cache de pacote NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restaurar
+        run: dotnet restore
+
+      - name: Compilar
+        run: dotnet build --no-restore --configuration Release --nologo
+
+      - name: Testar
+        run: dotnet test --no-build --configuration Release --nologo


### PR DESCRIPTION
Fecha #92.

Base neste PR e a branch da #90 (e nao a `main`), porque a esteira precisa de uma
solution para compilar. O GitHub reaponta para `main` sozinho quando o #91 entrar.

Um arquivo: `.github/workflows/ci.yml`.

### Quatro decisoes que nao sao padrao de template

| Decisao | Por que |
|---|---|
| `permissions: contents: read` | O default do repositorio pode dar escrita. Workflow que escreve no repo e superficie de ataque sem contrapartida. |
| `concurrency` + `cancel-in-progress` | Push seguido no mesmo PR transforma a execucao anterior em resultado velho no instante em que a nova comeca. |
| `timeout-minutes: 10` | Job travado queima minuto ate o teto da conta, e o sintoma e uma esteira que "demora" em vez de uma que falhou. |
| Cache com chave no `Directory.Packages.props` | Com gerenciamento central, o numero da versao saiu dos `.csproj` — hash de csproj nao invalidaria o cache quando a versao mudasse. |

### Fora, de proposito

**Postgres no job:** a suite roda offline por decisao (`MODEL_PROVIDER=fake`,
`CONVERSATION_SOURCE=fake`), e servico so entra junto com o primeiro teste de
integracao que precisar dele. **`TreatWarningsAsErrors` e analisador:** sao da #75,
que define limiar e politica de falha.

### Ainda em aberto neste PR

- [ ] Prova de que a esteira reprova de verdade (commit que nao compila)
- [ ] Protecao de branch exigindo o check na `main`

Ambos ficam registrados na #92 assim que a primeira execucao terminar.