### PR TITLE
Politica de KISS e DRY aplicada durante o desenvolvimento

### DIFF
--- a/.github/ISSUE_TEMPLATE/refatoracao.yml
+++ b/.github/ISSUE_TEMPLATE/refatoracao.yml
@@ -10,6 +10,14 @@ body:
         interface com uma implementação só e sem teste que a justifique ·
         abstração criada "por precaução".
 
+        A política completa está em [CONTRIBUTING.md](../../CONTRIBUTING.md) —
+        inclusive a regra dos três, o teste para saber se a duplicação é real, e
+        as exceções que este projeto já abriu de propósito.
+
+        **Bateu um gatilho no meio de outra tarefa? Abra esta issue e SIGA o
+        trabalho.** Refatoração misturada com feature produz um diff que ninguém
+        revisa.
+
   - type: input
     id: onde
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Como contribuir
+
+Este documento é a política de **KISS e DRY** aplicada *durante* o
+desenvolvimento — não depois, quando o código já ficou ruim.
+
+Ele vale a partir da primeira linha de C#. O label `kiss-dry` e o template de
+refatoração continuam existindo, mas eles são a rede embaixo do trapézio: o
+trabalho é não cair.
+
+---
+
+## Os gatilhos
+
+São objetivos de propósito. Sem número, "esse método tá grande" vira discussão de
+gosto, e a decisão acaba indo para quem fala mais alto. Com número, vira
+constatação.
+
+| Gatilho | Limite |
+|---|---|
+| Tamanho de arquivo | ~300 linhas |
+| Tamanho de método | ~40 linhas |
+| Parâmetros por método | 4 |
+| Níveis de aninhamento | 3 |
+| Repetição do mesmo bloco lógico | 3ª aparição |
+| Interface com uma implementação | só com teste que a justifique |
+
+Bateu qualquer um: **para e decide**.
+
+---
+
+## A regra dos três
+
+**Não abstraia na segunda ocorrência.**
+
+Duas coisas parecidas ainda não mostraram qual é o padrão entre elas. Abstrair ali
+normalmente produz a abstração errada — e abstração errada é mais cara de desfazer
+que duplicação, porque a duplicação está à vista e a abstração errada está
+escondida atrás de um nome que parece certo.
+
+Na terceira aparição o padrão já apareceu. Aí sim.
+
+---
+
+## Duplicação acidental não é duplicação
+
+Dois trechos idênticos que **mudam por razões diferentes** não são duplicação: são
+coincidência.
+
+Unificar acopla duas regras que precisam evoluir separadas, e a próxima mudança vai
+exigir um `if` para diferenciar — que é a duplicação de volta, só que pior, porque
+agora está escondida dentro de uma abstração.
+
+**O teste, antes de unificar:**
+
+> *"Se um desses mudar, o outro tem que mudar junto, sempre?"*
+
+Se a resposta não for um sim claro, deixa duplicado.
+
+---
+
+## Quando KISS e DRY brigam, KISS ganha
+
+Código direto e repetido é melhor que código elegante que ninguém entende.
+
+DRY existe para **reduzir custo de manutenção**. Quando a desduplicação aumenta
+esse custo, ela perdeu o próprio propósito e virou enfeite.
+
+---
+
+## Onde este projeto já abre exceção, de propósito
+
+`IConversationSource`, `IModelProvider`, `IDistributedState` e `IQueue` nascem com
+**mais de uma implementação real** (#17, #27, #66) — Fake/WAHA/CloudAPI,
+Fake/provedor real, InMemory/Redis, Channel/RabbitMQ.
+
+Não são abstração prematura. A regra é *"interface sem segunda implementação e sem
+teste que a justifique"*, e essas têm as duas coisas.
+
+Registrar isso aqui evita que a própria política seja usada contra decisões que já
+foram tomadas com motivo. Quando cada interface nascer, o motivo dela vai escrito
+no XML doc, junto do código — não só nesta lista.
+
+---
+
+## O que fazer ao bater um gatilho
+
+**Abra issue com `kiss-dry` + `refatoracao` e SIGA o trabalho.**
+
+Não refatore no meio de outra tarefa. Dois motivos:
+
+1. Refatoração misturada com feature produz um diff que ninguém consegue revisar —
+   e esconde mudança de comportamento dentro de mudança cosmética.
+2. Quem decide a ordem das coisas é o dono do projeto, não quem esbarrou no
+   arquivo.
+
+**Exceção (escoteiro limitado):** limpeza trivial no arquivo que você já está
+tocando — renomear variável obscura, remover código morto, apagar comentário óbvio
+— pode ir junto, desde que em **commit separado**.
+
+---
+
+## Comentário e nomeação
+
+- Comentário explica **por quê**, nunca **o quê**.
+- Código morto é removido, não comentado. O histórico do git guarda.
+- Nome que precisa de comentário para ser entendido é nome errado.
+
+---
+
+## O fluxo
+
+Uma issue por branch, uma branch por PR. Trabalho que não tem issue: abra a issue
+antes.
+
+```bash
+git switch -c 17-conversation-source     # <número>-<slug>
+# ... commits ...
+gh pr create --fill                      # com "Closes #17" no corpo
+```
+
+**Mensagem de commit:** `tipo: o efeito`, em português sem acento, descrevendo **o
+que mudou para quem usa** — não quais arquivos foram editados. O corpo conta o
+achado, a causa e por que a correção foi feita ali.
+
+```
+feat: Redis e RabbitMQ atras de interface, com in-memory como padrao
+```
+
+**Nada entra na `main` sem a esteira verde.** Build e teste são trabalho do CI
+(#92), não de conferência manual e não de agente: a esteira não esquece, roda igual
+para todo mundo e não interpreta mensagem de compilador.
+
+---
+
+## O que a esteira mede, e como ela falha
+
+| Gate | Política de falha |
+|---|---|
+| `build` + `test` (#92) | reprova o PR |
+| Varredura de segredo (#47) | reprova o PR |
+| Estilo e formatação (#75) | reprova o PR |
+| Gatilho de tamanho e duplicação (#75) | **avisa e exige issue aberta**, não reprova |
+
+A última linha é deliberada. Um gate que reprova o build por um método de 42 linhas
+vira um gate que todo mundo aprende a contornar — e a partir daí ele não mede mais
+nada.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,19 @@ O núcleo não sabe nem se importa de onde a mensagem veio.
 
 ---
 
+## Como trabalhamos aqui
+
+KISS e DRY não são slogan neste projeto: são **gatilhos numéricos** (arquivo ~300
+linhas, método ~40, 4 parâmetros, 3 níveis de aninhamento, 3ª repetição) e uma regra
+que diz o que fazer quando um deles dispara — abrir issue e **seguir** o trabalho,
+nunca refatorar no meio de outra tarefa.
+
+Estão em [`CONTRIBUTING.md`](CONTRIBUTING.md), junto com as três coisas que a
+política existe para impedir: abstrair na segunda ocorrência, unificar duplicação
+que só é coincidência, e desduplicar até ninguém mais entender.
+
+---
+
 ## Status
 
 Em construção. Acompanhe pelos [milestones](../../milestones) e pelas


### PR DESCRIPTION
Fecha #74.

Documento em `CONTRIBUTING.md`, com o README e o template de refatoracao apontando
para ele. Branch sai da `main` e nao empilha nos PRs abertos: e texto, nao depende
do esqueleto.

### Criterios de aceite

- [x] `CONTRIBUTING.md` com tudo o que a issue lista
- [x] Secao de KISS/DRY referenciada no `README`
- [x] Template de refatoracao apontando para o documento
- [ ] **Lista de excecoes conscientes mantida junto das interfaces** — ver abaixo

O ultimo nao da para cumprir hoje: `IConversationSource`, `IModelProvider`,
`IDistributedState` e `IQueue` **ainda nao existem** (#17, #27, #66). A lista esta
no `CONTRIBUTING.md`, e o documento ja diz que, quando cada interface nascer, o
motivo dela vai no XML doc junto do codigo. Marcar como feito seria marcar uma
promessa.

### Duas coisas que eu escrevi com o porque, e nao so como regra

**A regra dos tres.** Nao abstrair na segunda ocorrencia, porque duas coisas
parecidas ainda nao mostraram qual e o padrao entre elas — e abstracao errada e mais
cara de desfazer que duplicacao: a duplicacao esta a vista, a abstracao errada esta
escondida atras de um nome que parece certo.

**Duplicacao acidental.** Dois trechos identicos que mudam por razoes diferentes sao
coincidencia. Unificar acopla duas regras que precisam evoluir separadas, e a
proxima mudanca vai pedir um `if` para diferenciar — que e a duplicacao de volta, so
que pior, porque agora esta escondida dentro de uma abstracao.

### Follow-up conhecido

O `CLAUDE.md` (que vem no #91) repete hoje a tabela de gatilhos. Quando os dois
entrarem, ele passa a **apontar** para o `CONTRIBUTING.md` em vez de repetir — que e
a propria regra de DRY aplicada aos nossos documentos. Nao fiz agora porque o
arquivo ainda nao existe na `main` e viraria conflito.

### Sobre a esteira neste PR

O check `Build e teste` e exigido na `main`, mas o workflow so entra com o #91. Ate
la este PR nao tem como produzir o check — depois que o #91 entrar, um rebase resolve.