### PR TITLE
Varredura de segredo no CI, cobrindo o historico

### DIFF
--- a/.github/workflows/segredo.yml
+++ b/.github/workflows/segredo.yml
@@ -1,0 +1,41 @@
+# Varredura de segredo. Repositorio publico: chave commitada esta vazada no
+# segundo seguinte, e apagar o commit nao resolve — quem clonou, clonou.
+#
+# Este gate reprova o PR. Ele nao substitui o .gitignore nem a regra de nunca
+# commitar .env: e a rede embaixo do trapezio, e rede tem furo (ver #47).
+name: Segredo
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: segredo-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  varredura:
+    name: Varredura de segredo
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Historico inteiro, nao so o diff. Segredo que entrou ha dez commits
+          # continua vazado hoje, e e exatamente o que uma varredura so do diff
+          # deixa de ver para sempre.
+          fetch-depth: 0
+
+      # Versao fixada, e nao :latest. As regras do gitleaks mudam entre versoes:
+      # com :latest, o gate pode passar a reprovar (ou a deixar passar) sem que
+      # ninguem tenha mudado uma linha deste repositorio.
+      - name: gitleaks
+        run: |
+          docker run --rm -v "$PWD:/repo" \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 \
+            detect --source /repo --redact --no-banner --verbose


### PR DESCRIPTION
Fecha #47.

Um arquivo: `.github/workflows/segredo.yml`, rodando **gitleaks v8.30.1** em push
para `main` e em todo PR.

### Criterios de aceite

- [x] Workflow de CI rodando a varredura
- [x] Pipeline falha ao encontrar segredo — **provado**, ver abaixo
- [x] `.env.example` nao gera falso positivo — **provado**
- [x] Cobre o historico, nao so o diff (`fetch-depth: 0`)

### Verificado no terminal antes de fixar

```
gitleaks v8.30.1
12 commits scanned. no leaks found       <- este repositorio, hoje
```

O `.env.example` passa limpo: `POSTGRES_PASSWORD=troque-esta-senha` e `JWT_SECRET=`
nao viram achado.

**A prova de que ele acha foi feita num repositorio descartavel, nunca neste.** E
proposital, e vale registrar como armadilha: como a varredura cobre o historico,
plantar um segredo de mentira aqui para "testar o gate" deixaria o CI vermelho
**para sempre** — ate alguem reescrever o historico. No repositorio de teste, com
`ghp_...` e `xoxb-...` plantados: `leaks found: 2`, saida diferente de zero,
reprovando o job.

### O que este gate NAO garante

Vale escrever, porque gate com fama de infalivel e pior que gate nenhum: **a rede
tem furo.** No mesmo teste, um par de chaves AWS sinteticas dentro de um `.txt`
passou batido na primeira tentativa, e so foi pego numa segunda variacao — pela
regra generica, nao pela regra especifica de AWS.

Ou seja: o gate reduz risco, nao elimina. O controle principal continua sendo o
`.gitignore` e a regra de nunca commitar `.env`. O scanner e a rede embaixo do
trapezio, e esta escrito assim no cabecalho do workflow.

### Decisoes

| Decisao | Por que |
|---|---|
| `fetch-depth: 0` | Varredura so do diff nunca ve o segredo que entrou ha dez commits — e ele continua vazado hoje. |
| Versao fixada, nao `:latest` | As regras mudam entre versoes: com `:latest` o gate passa a reprovar (ou a deixar passar) sem ninguem ter mudado uma linha aqui. |
| Imagem oficial via `docker run`, e nao a action | A action pede licenca para organizacao — um jeito de o gate morrer em silencio no dia em que este repositorio mudar de dono. |
| Workflow separado do `ci.yml` | Falha de segredo e outra conversa, com outro dono e outro tempo de resposta. Misturar esconde qual gate caiu. |

Sem `.gitleaks.toml`: nao ha falso positivo para silenciar, e arquivo de excecao
vazio so serve para alguem colocar excecao dentro depois.