### PR TITLE
Modelagem de dominio em POCO puro, com a ancoragem no construtor

### DIFF
--- a/src/Copiloto.Dominio/Conversas/Conversa.cs
+++ b/src/Copiloto.Dominio/Conversas/Conversa.cs
@@ -1,0 +1,45 @@
+namespace Copiloto.Dominio.Conversas;
+
+/// <summary>
+/// O fio de mensagens com um lead, em ordem de chegada.
+/// </summary>
+public class Conversa
+{
+    private readonly List<Mensagem> _mensagens = new();
+
+    public Conversa(Guid id, Guid leadId)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Conversa sem id.", nameof(id));
+        if (leadId == Guid.Empty) throw new ArgumentException("Conversa sem lead.", nameof(leadId));
+
+        Id = id;
+        LeadId = leadId;
+    }
+
+    public Guid Id { get; }
+    public Guid LeadId { get; }
+    public IReadOnlyList<Mensagem> Mensagens => _mensagens;
+
+    /// <summary>
+    /// Guarda a fala, mantendo a ordem cronologica.
+    ///
+    /// A ordenacao e por data de ENVIO e nao de chegada: mensagem de WhatsApp
+    /// chega fora de ordem quando o celular estava sem sinal, e o dossie que le
+    /// "vou pensar" antes de "qual o valor?" entende a conversa ao contrario.
+    /// </summary>
+    public void Registrar(Mensagem mensagem)
+    {
+        ArgumentNullException.ThrowIfNull(mensagem);
+        if (_mensagens.Any(m => m.Id == mensagem.Id)) return;   // reentrega do webhook
+
+        _mensagens.Add(mensagem);
+        _mensagens.Sort((a, b) => a.EnviadaEm.CompareTo(b.EnviadaEm));
+    }
+
+    public Mensagem? UltimaDoCliente =>
+        _mensagens.LastOrDefault(m => m.Autor == Autor.Cliente);
+
+    /// <summary>Silencio desde a ultima fala do cliente — o sinal de esfriamento.</summary>
+    public TimeSpan? SilencioDoCliente(DateTimeOffset agora) =>
+        UltimaDoCliente is null ? null : agora - UltimaDoCliente.EnviadaEm;
+}

--- a/src/Copiloto.Dominio/Conversas/Mensagem.cs
+++ b/src/Copiloto.Dominio/Conversas/Mensagem.cs
@@ -1,0 +1,31 @@
+namespace Copiloto.Dominio.Conversas;
+
+public enum Autor { Cliente = 0, Vendedor = 1 }
+
+/// <summary>
+/// Uma fala. E a unidade que o dossie CITA.
+///
+/// Imutavel por decisao: mensagem de WhatsApp nao muda depois de enviada, e o
+/// sinal do dossie aponta para ela. Sinal que cita uma fala editavel e sinal
+/// que pode passar a citar outra coisa sem ninguem perceber — a citacao existe
+/// justamente para o vendedor conferir com os proprios olhos.
+/// </summary>
+public class Mensagem
+{
+    public Mensagem(Guid id, Autor autor, string texto, DateTimeOffset enviadaEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Mensagem sem id.", nameof(id));
+        if (string.IsNullOrWhiteSpace(texto))
+            throw new ArgumentException("Mensagem sem texto nao e fala.", nameof(texto));
+
+        Id = id;
+        Autor = autor;
+        Texto = texto;
+        EnviadaEm = enviadaEm;
+    }
+
+    public Guid Id { get; }
+    public Autor Autor { get; }
+    public string Texto { get; }
+    public DateTimeOffset EnviadaEm { get; }
+}

--- a/src/Copiloto.Dominio/Dossies/Dossie.cs
+++ b/src/Copiloto.Dominio/Dossies/Dossie.cs
@@ -1,0 +1,49 @@
+namespace Copiloto.Dominio.Dossies;
+
+/// <summary>
+/// O que a IA leu da conversa, para o vendedor decidir. Nunca uma fala pronta.
+///
+/// As LACUNAS sao a parte mais util e a mais facil de esquecer: "o que ainda nao
+/// sabemos sobre este cliente" e o que faz o vendedor perguntar em vez de supor.
+/// </summary>
+public class Dossie
+{
+    private readonly List<Sinal> _sinais = new();
+    private readonly List<string> _lacunas = new();
+
+    public Dossie(Guid id, Guid dealId, DateTimeOffset geradoEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Dossie sem id.", nameof(id));
+        if (dealId == Guid.Empty) throw new ArgumentException("Dossie sem deal.", nameof(dealId));
+
+        Id = id;
+        DealId = dealId;
+        GeradoEm = geradoEm;
+    }
+
+    public Guid Id { get; }
+    public Guid DealId { get; }
+    public DateTimeOffset GeradoEm { get; }
+    public IReadOnlyList<Sinal> Sinais => _sinais;
+
+    /// <summary>O que ainda nao sabemos — perguntas, nao afirmacoes.</summary>
+    public IReadOnlyList<string> Lacunas => _lacunas;
+
+    public void Registrar(Sinal sinal)
+    {
+        ArgumentNullException.ThrowIfNull(sinal);
+        _sinais.Add(sinal);
+    }
+
+    public void RegistrarLacuna(string pergunta)
+    {
+        if (string.IsNullOrWhiteSpace(pergunta)) return;
+        _lacunas.Add(pergunta.Trim());
+    }
+
+    /// <summary>
+    /// Quantas vezes a mesma fala foi citada — o "preco citado 3x" da tela.
+    /// </summary>
+    public int VezesQueCitou(Guid mensagemId) =>
+        _sinais.Count(s => s.MensagemId == mensagemId);
+}

--- a/src/Copiloto.Dominio/Dossies/Sinal.cs
+++ b/src/Copiloto.Dominio/Dossies/Sinal.cs
@@ -1,0 +1,41 @@
+namespace Copiloto.Dominio.Dossies;
+
+/// <summary>
+/// Uma leitura da conversa, presa a fala que a originou.
+///
+/// A citacao e OBRIGATORIA no construtor, e nao um campo que alguem preenche
+/// depois. E a regra que nao se negocia: "todo sinal do dossie cita a fala que o
+/// originou; sem citacao, o bloco nao e exibido".
+///
+/// Torna-la obrigatoria aqui muda a natureza da regra. Como campo opcional, ela
+/// depende de todo caminho de criacao lembrar de preencher, e o dia em que um
+/// esquecer o sinal aparece na tela sem procedencia — que e exatamente o
+/// "a IA ta ruim" que ninguem consegue verificar. Como parametro obrigatorio, o
+/// sinal sem citacao nao COMPILA.
+/// </summary>
+public class Sinal
+{
+    public Sinal(string descricao, Guid mensagemId, string trechoCitado)
+    {
+        if (string.IsNullOrWhiteSpace(descricao))
+            throw new ArgumentException("Sinal sem descricao.", nameof(descricao));
+        if (mensagemId == Guid.Empty)
+            throw new ArgumentException(
+                "Sinal precisa apontar para a mensagem que o originou. Sem procedencia, "
+                + "o vendedor nao tem como conferir, e o sinal vira palpite com cara de dado.",
+                nameof(mensagemId));
+        if (string.IsNullOrWhiteSpace(trechoCitado))
+            throw new ArgumentException(
+                "Sinal precisa do trecho citado, e nao so do id: o vendedor le a frase na "
+                + "tela, sem abrir a conversa inteira para procurar.",
+                nameof(trechoCitado));
+
+        Descricao = descricao.Trim();
+        MensagemId = mensagemId;
+        TrechoCitado = trechoCitado.Trim();
+    }
+
+    public string Descricao { get; }
+    public Guid MensagemId { get; }
+    public string TrechoCitado { get; }
+}

--- a/src/Copiloto.Dominio/Ia/AiInvocation.cs
+++ b/src/Copiloto.Dominio/Ia/AiInvocation.cs
@@ -1,0 +1,36 @@
+namespace Copiloto.Dominio.Ia;
+
+/// <summary>
+/// Uma chamada a um modelo: qual, quanto custou, e quanto demorou.
+///
+/// Guardar o NOME do modelo junto do custo e o que permite a comparacao entre
+/// provedores depois — sem ele, o total responde "gastamos X" e nao "gastamos X
+/// com este e Y com aquele", que e a pergunta que decide a troca.
+///
+/// Imutavel: e um registro do que ja aconteceu.
+/// </summary>
+public class AiInvocation
+{
+    public AiInvocation(
+        Guid id, string modelo, decimal custoEmReais, DateTimeOffset quando)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Invocacao sem id.", nameof(id));
+        if (string.IsNullOrWhiteSpace(modelo))
+            throw new ArgumentException(
+                "Invocacao sem modelo: o custo sem o nome do modelo nao responde "
+                + "se vale trocar de provedor.", nameof(modelo));
+        if (custoEmReais < 0)
+            throw new ArgumentOutOfRangeException(nameof(custoEmReais),
+                "Custo negativo nao existe, e somado ao acumulado ele o faria DIMINUIR.");
+
+        Id = id;
+        Modelo = modelo.Trim();
+        CustoEmReais = custoEmReais;
+        Quando = quando;
+    }
+
+    public Guid Id { get; }
+    public string Modelo { get; }
+    public decimal CustoEmReais { get; }
+    public DateTimeOffset Quando { get; }
+}

--- a/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
+++ b/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
@@ -1,0 +1,67 @@
+namespace Copiloto.Dominio.Planos;
+
+/// <summary>
+/// Tatica que precisa de dado do CRM para poder ser sugerida (#15, #16).
+/// Fora desta lista, a sugestao e livre — nao ha o que ancorar.
+/// </summary>
+public enum Tatica { Escassez = 0, ProvaSocial = 1, Desconto = 2, Prazo = 3, Livre = 4 }
+
+/// <summary>
+/// Um item do plano de abordagem: ou sugestao ancorada, ou pergunta ao vendedor.
+///
+/// A REGRA DE ANCORAGEM esta no construtor privado e nos dois criadores, e nao
+/// numa validacao que alguem chama depois. Escassez, prova social, desconto e
+/// prazo so viram sugestao se existir dado no CRM que sustente; sem dado, vira
+/// PERGUNTA.
+///
+/// Sugerir "restam 2 unidades" quando existem 200 e publicidade enganosa: cria
+/// passivo para a empresa que usa o produto e queima o vendedor com o cliente.
+/// Por isso a checagem nao pode depender de quem constroi lembrar dela.
+/// </summary>
+public class BlocoSugerido
+{
+    private BlocoSugerido(Tatica tatica, string texto, string? ancora, bool ehPergunta)
+    {
+        Tatica = tatica;
+        Texto = texto;
+        Ancora = ancora;
+        EhPergunta = ehPergunta;
+    }
+
+    public Tatica Tatica { get; }
+    public string Texto { get; }
+
+    /// <summary>O dado do CRM que sustenta a sugestao. Null quando e pergunta.</summary>
+    public string? Ancora { get; }
+
+    /// <summary>Pergunta ao vendedor, e nao fala pronta.</summary>
+    public bool EhPergunta { get; }
+
+    public static bool PrecisaDeAncora(Tatica tatica) => tatica != Tatica.Livre;
+
+    /// <summary>
+    /// Sugestao ancorada. Recusa a tatica que exige dado quando a ancora falta —
+    /// devolver um bloco sem ancora aqui seria a regra existir e nao valer.
+    /// </summary>
+    public static BlocoSugerido Ancorado(Tatica tatica, string texto, string ancora)
+    {
+        if (string.IsNullOrWhiteSpace(texto))
+            throw new ArgumentException("Bloco sem texto.", nameof(texto));
+        if (PrecisaDeAncora(tatica) && string.IsNullOrWhiteSpace(ancora))
+            throw new ArgumentException(
+                $"A tatica {tatica} exige dado do CRM que a sustente. Sem ancora, "
+                + "use Perguntar() — a sugestao vira pergunta ao vendedor, nunca fala pronta.",
+                nameof(ancora));
+
+        return new BlocoSugerido(tatica, texto.Trim(), ancora?.Trim(), ehPergunta: false);
+    }
+
+    /// <summary>O caminho de saida quando o dado nao existe.</summary>
+    public static BlocoSugerido Perguntar(Tatica tatica, string pergunta)
+    {
+        if (string.IsNullOrWhiteSpace(pergunta))
+            throw new ArgumentException("Pergunta sem texto.", nameof(pergunta));
+
+        return new BlocoSugerido(tatica, pergunta.Trim(), ancora: null, ehPergunta: true);
+    }
+}

--- a/src/Copiloto.Dominio/Planos/Plano.cs
+++ b/src/Copiloto.Dominio/Planos/Plano.cs
@@ -1,0 +1,34 @@
+namespace Copiloto.Dominio.Planos;
+
+/// <summary>
+/// O plano de abordagem que o vendedor ve — blocos que ele escolhe usar ou nao.
+/// </summary>
+public class Plano
+{
+    private readonly List<BlocoSugerido> _blocos = new();
+
+    public Plano(Guid id, Guid dealId, DateTimeOffset geradoEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Plano sem id.", nameof(id));
+        if (dealId == Guid.Empty) throw new ArgumentException("Plano sem deal.", nameof(dealId));
+
+        Id = id;
+        DealId = dealId;
+        GeradoEm = geradoEm;
+    }
+
+    public Guid Id { get; }
+    public Guid DealId { get; }
+    public DateTimeOffset GeradoEm { get; }
+    public IReadOnlyList<BlocoSugerido> Blocos => _blocos;
+
+    public void Adicionar(BlocoSugerido bloco)
+    {
+        ArgumentNullException.ThrowIfNull(bloco);
+        _blocos.Add(bloco);
+    }
+
+    /// <summary>O que o vendedor precisa descobrir antes de usar o resto.</summary>
+    public IReadOnlyList<BlocoSugerido> Perguntas =>
+        _blocos.Where(b => b.EhPergunta).ToList();
+}

--- a/src/Copiloto.Dominio/Planos/Playbook.cs
+++ b/src/Copiloto.Dominio/Planos/Playbook.cs
@@ -1,0 +1,39 @@
+namespace Copiloto.Dominio.Planos;
+
+/// <summary>
+/// O jeito da casa de vender: o que a empresa autoriza sugerir, por estagio.
+///
+/// Existe para o produto nao impor tatica de vendas generica a quem ja tem a
+/// propria — e para o desconto maximo ser decisao da empresa, nao do modelo.
+/// </summary>
+public class Playbook
+{
+    private readonly List<Tatica> _taticasPermitidas = new();
+
+    public Playbook(Guid id, string nome)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Playbook sem id.", nameof(id));
+        if (string.IsNullOrWhiteSpace(nome))
+            throw new ArgumentException("Playbook sem nome.", nameof(nome));
+
+        Id = id;
+        Nome = nome.Trim();
+    }
+
+    public Guid Id { get; }
+    public string Nome { get; }
+    public IReadOnlyList<Tatica> TaticasPermitidas => _taticasPermitidas;
+
+    public void Permitir(Tatica tatica)
+    {
+        if (!_taticasPermitidas.Contains(tatica)) _taticasPermitidas.Add(tatica);
+    }
+
+    /// <summary>
+    /// Playbook vazio permite tudo: uma empresa que ainda nao configurou nada
+    /// nao pode receber um produto mudo. Restringir e uma escolha, e escolha
+    /// nao configurada nao pode virar bloqueio silencioso.
+    /// </summary>
+    public bool Autoriza(Tatica tatica) =>
+        _taticasPermitidas.Count == 0 || _taticasPermitidas.Contains(tatica);
+}

--- a/src/Copiloto.Dominio/Vendas/Deal.cs
+++ b/src/Copiloto.Dominio/Vendas/Deal.cs
@@ -1,0 +1,91 @@
+using Copiloto.Dominio.Ia;
+
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>
+/// Uma negociacao com um <see cref="Lead"/>: onde ela esta no funil e quanto de
+/// IA ja custou.
+///
+/// As transicoes moram AQUI, e nao no controller (#48). Regra de negocio dentro
+/// do controller nao cria dependencia errada nenhuma — o grafo depois do commit
+/// e identico ao de antes —, entao nenhuma analise de arquitetura acusa. O que
+/// acusa e um teste, e teste so alcanca a regra se ela estiver num lugar que o
+/// teste consegue chamar sem subir a aplicacao.
+/// </summary>
+public class Deal
+{
+    private readonly List<AiInvocation> _invocacoes = new();
+
+    public Deal(Guid id, Guid leadId, DateTimeOffset abertoEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Deal sem id.", nameof(id));
+        if (leadId == Guid.Empty) throw new ArgumentException("Deal sem lead.", nameof(leadId));
+
+        Id = id;
+        LeadId = leadId;
+        AbertoEm = abertoEm;
+        Estagio = Estagio.Novo;
+    }
+
+    public Guid Id { get; }
+    public Guid LeadId { get; }
+    public DateTimeOffset AbertoEm { get; }
+    public Estagio Estagio { get; private set; }
+    public DateTimeOffset? FechadoEm { get; private set; }
+
+    /// <summary>
+    /// O vinculo custo-negocio, e ele nasce com o Deal por decisao (#48).
+    ///
+    /// Enxertar depois obrigaria a reprocessar historico para responder "quanto
+    /// custou fechar este negocio?" — e a resposta seria uma estimativa para
+    /// sempre, justamente na conta que decide se o produto se paga.
+    /// </summary>
+    public decimal CustoIaAcumulado { get; private set; }
+
+    public IReadOnlyList<AiInvocation> Invocacoes => _invocacoes;
+
+    public bool EstaFechado => Estagio is Estagio.Ganho or Estagio.Perdido;
+
+    /// <summary>
+    /// Move o Deal de estagio. Devolve o que impediu, ou null quando moveu.
+    ///
+    /// Devolve motivo em vez de lancar excecao porque tentativa invalida aqui e
+    /// caso ESPERADO — o vendedor arrasta o card de volta, clica errado, ou o
+    /// negocio realmente reabre. Excecao para fluxo esperado obriga o chamador a
+    /// usar try/catch como if, e o motivo em texto e o que a tela mostra.
+    /// </summary>
+    public string? MoverPara(Estagio destino, DateTimeOffset quando)
+    {
+        if (EstaFechado)
+            return $"Deal ja esta {Estagio} e nao volta ao funil. Abra um novo.";
+
+        if (destino == Estagio)
+            return null;   // idempotente: reenviar a mesma transicao nao e erro
+
+        if (destino == Estagio.Novo)
+            return "Novo e o estagio de entrada e ninguem volta para ele.";
+
+        if (destino is not Estagio.Ganho and not Estagio.Perdido
+            && destino > Estagio + 1)
+            return $"Nao da para pular de {Estagio} para {destino}: o funil anda "
+                 + "de um em um, e estagio pulado e negocio sem qualificacao.";
+
+        Estagio = destino;
+        if (EstaFechado) FechadoEm = quando;
+        return null;
+    }
+
+    /// <summary>
+    /// Registra o que uma chamada de IA custou, e soma ao acumulado.
+    ///
+    /// A soma vive no Deal em vez de ser SUM() na consulta porque a pergunta que
+    /// importa ("este negocio se paga?") e feita na tela do vendedor, uma vez por
+    /// card, e nao vale varrer a tabela de invocacoes a cada render.
+    /// </summary>
+    public void RegistrarInvocacao(AiInvocation invocacao)
+    {
+        ArgumentNullException.ThrowIfNull(invocacao);
+        _invocacoes.Add(invocacao);
+        CustoIaAcumulado += invocacao.CustoEmReais;
+    }
+}

--- a/src/Copiloto.Dominio/Vendas/Estagio.cs
+++ b/src/Copiloto.Dominio/Vendas/Estagio.cs
@@ -1,0 +1,18 @@
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>
+/// O funil, na ordem em que a venda anda.
+///
+/// A ordem numerica importa: e por ela que <see cref="Deal"/> decide o que e
+/// avanco e o que e recuo, em vez de uma tabela de pares permitidos que teria
+/// de crescer ao quadrado a cada estagio novo.
+/// </summary>
+public enum Estagio
+{
+    Novo = 0,
+    Qualificacao = 1,
+    Proposta = 2,
+    Negociacao = 3,
+    Ganho = 4,
+    Perdido = 5,
+}

--- a/src/Copiloto.Dominio/Vendas/Lead.cs
+++ b/src/Copiloto.Dominio/Vendas/Lead.cs
@@ -1,0 +1,36 @@
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>
+/// Quem esta do outro lado da conversa.
+///
+/// O telefone e a identidade pratica: o WhatsApp e a origem, e la nao existe
+/// cadastro. Nome pode faltar — chega "bom dia, vi o cafe" e mais nada, e um
+/// Lead que so existe depois de alguem preencher formulario e um Lead que
+/// nunca existe.
+/// </summary>
+public class Lead
+{
+    public Lead(Guid id, string telefone, DateTimeOffset criadoEm, string? nome = null)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Lead sem id.", nameof(id));
+        if (string.IsNullOrWhiteSpace(telefone))
+            throw new ArgumentException("Lead sem telefone nao tem como ser contatado.", nameof(telefone));
+
+        Id = id;
+        Telefone = telefone.Trim();
+        CriadoEm = criadoEm;
+        Nome = string.IsNullOrWhiteSpace(nome) ? null : nome.Trim();
+    }
+
+    public Guid Id { get; }
+    public string Telefone { get; }
+    public string? Nome { get; private set; }
+    public DateTimeOffset CriadoEm { get; }
+
+    /// <summary>Nome descoberto no meio da conversa, que e como ele costuma chegar.</summary>
+    public void Identificar(string nome)
+    {
+        if (string.IsNullOrWhiteSpace(nome)) return;
+        Nome = nome.Trim();
+    }
+}

--- a/src/Copiloto.Dominio/Vendas/Usuario.cs
+++ b/src/Copiloto.Dominio/Vendas/Usuario.cs
@@ -1,0 +1,22 @@
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>O vendedor. Quem decide, e a quem o dossie se dirige.</summary>
+public class Usuario
+{
+    public Usuario(Guid id, string nome, string email)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Usuario sem id.", nameof(id));
+        if (string.IsNullOrWhiteSpace(nome))
+            throw new ArgumentException("Usuario sem nome.", nameof(nome));
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Usuario sem email.", nameof(email));
+
+        Id = id;
+        Nome = nome.Trim();
+        Email = email.Trim();
+    }
+
+    public Guid Id { get; }
+    public string Nome { get; }
+    public string Email { get; }
+}

--- a/testes/Copiloto.Testes/AncoragemTeste.cs
+++ b/testes/Copiloto.Testes/AncoragemTeste.cs
@@ -1,0 +1,129 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Dossies;
+using Copiloto.Dominio.Planos;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// As duas regras que o CLAUDE.md diz que nao se negociam, e o teste que as
+/// torna verificaveis.
+/// </summary>
+public class AncoragemTeste
+{
+    private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Sinal_sem_mensagem_de_origem_nao_existe()
+    {
+        // "Todo sinal do dossie cita a fala que o originou." Como parametro
+        // obrigatorio, a violacao nao chega a virar linha na tela.
+        Assert.Throws<ArgumentException>(
+            () => new Sinal("preco citado 3x", Guid.Empty, "puxado hein"));
+    }
+
+    [Fact]
+    public void Sinal_sem_o_trecho_citado_nao_existe()
+    {
+        // O id sozinho nao serve: o vendedor le a frase na tela, sem abrir a
+        // conversa inteira para procurar do que a IA estava falando.
+        Assert.Throws<ArgumentException>(
+            () => new Sinal("objecao velada", Guid.NewGuid(), "   "));
+    }
+
+    [Fact]
+    public void Tatica_que_exige_dado_nao_vira_sugestao_sem_ancora()
+    {
+        // Sugerir "restam 2 unidades" quando existem 200 e publicidade enganosa.
+        var erro = Assert.Throws<ArgumentException>(
+            () => BlocoSugerido.Ancorado(Tatica.Escassez, "restam 2 unidades", ""));
+
+        Assert.Contains("Perguntar", erro.Message);
+    }
+
+    [Fact]
+    public void Sem_dado_a_tatica_vira_pergunta_ao_vendedor()
+    {
+        var bloco = BlocoSugerido.Perguntar(
+            Tatica.Escassez, "Temos estoque baixo desse cafe? Se sim, quanto?");
+
+        Assert.True(bloco.EhPergunta);
+        Assert.Null(bloco.Ancora);
+    }
+
+    [Fact]
+    public void Com_dado_do_CRM_a_sugestao_sai_ancorada()
+    {
+        var bloco = BlocoSugerido.Ancorado(
+            Tatica.Escassez, "restam 2 unidades", "estoque=2 em 01/09");
+
+        Assert.False(bloco.EhPergunta);
+        Assert.Equal("estoque=2 em 01/09", bloco.Ancora);
+    }
+
+    [Fact]
+    public void Tatica_livre_nao_precisa_de_ancora()
+    {
+        var bloco = BlocoSugerido.Ancorado(Tatica.Livre, "perguntar sobre o prazo", "");
+
+        Assert.False(bloco.EhPergunta);
+    }
+
+    [Fact]
+    public void Playbook_vazio_autoriza_tudo()
+    {
+        // Empresa que ainda nao configurou nada nao pode receber produto mudo.
+        var playbook = new Playbook(Guid.NewGuid(), "padrao");
+
+        Assert.True(playbook.Autoriza(Tatica.Desconto));
+    }
+
+    [Fact]
+    public void Playbook_configurado_restringe_ao_que_a_empresa_permitiu()
+    {
+        var playbook = new Playbook(Guid.NewGuid(), "casa");
+        playbook.Permitir(Tatica.ProvaSocial);
+
+        Assert.True(playbook.Autoriza(Tatica.ProvaSocial));
+        Assert.False(playbook.Autoriza(Tatica.Desconto));
+    }
+
+    [Fact]
+    public void Conversa_ordena_por_envio_e_nao_por_chegada()
+    {
+        // Celular sem sinal entrega fora de ordem, e o dossie que le "vou pensar"
+        // antes de "qual o valor?" entende a conversa ao contrario.
+        var conversa = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        var depois = new Mensagem(Guid.NewGuid(), Autor.Cliente, "vou pensar", Agora.AddMinutes(5));
+        var antes = new Mensagem(Guid.NewGuid(), Autor.Cliente, "qual o valor?", Agora);
+
+        conversa.Registrar(depois);
+        conversa.Registrar(antes);
+
+        Assert.Equal("qual o valor?", conversa.Mensagens[0].Texto);
+        Assert.Equal("vou pensar", conversa.Mensagens[1].Texto);
+    }
+
+    [Fact]
+    public void Reentrega_do_webhook_nao_duplica_mensagem()
+    {
+        var conversa = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        var m = new Mensagem(Guid.NewGuid(), Autor.Cliente, "bom dia", Agora);
+
+        conversa.Registrar(m);
+        conversa.Registrar(m);
+
+        Assert.Single(conversa.Mensagens);
+    }
+
+    [Fact]
+    public void Silencio_do_cliente_conta_da_ultima_fala_dele()
+    {
+        // O "sumiu ha 4 dias" da tela. Fala do vendedor nao zera o silencio:
+        // quem parou de responder foi o cliente.
+        var conversa = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "vou pensar", Agora));
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Vendedor, "claro!", Agora.AddDays(1)));
+
+        Assert.Equal(TimeSpan.FromDays(4), conversa.SilencioDoCliente(Agora.AddDays(4)));
+    }
+}

--- a/testes/Copiloto.Testes/DealTeste.cs
+++ b/testes/Copiloto.Testes/DealTeste.cs
@@ -1,0 +1,106 @@
+using Copiloto.Dominio.Ia;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// As transicoes de estagio, e elas moram no dominio (#48).
+///
+/// Regra de negocio dentro do controller nao cria dependencia errada nenhuma —
+/// o grafo depois do commit e identico ao de antes —, entao nenhuma analise de
+/// arquitetura acusa. Quem acusa e este arquivo, e ele so consegue existir
+/// porque a regra esta num lugar chamavel sem subir a aplicacao.
+/// </summary>
+public class DealTeste
+{
+    private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static Deal NovoDeal() => new(Guid.NewGuid(), Guid.NewGuid(), Agora);
+
+    [Fact]
+    public void Deal_nasce_em_Novo_e_com_custo_de_ia_zerado()
+    {
+        var deal = NovoDeal();
+
+        Assert.Equal(Estagio.Novo, deal.Estagio);
+        Assert.Equal(0m, deal.CustoIaAcumulado);
+        Assert.Null(deal.FechadoEm);
+    }
+
+    [Fact]
+    public void O_funil_anda_de_um_em_um()
+    {
+        var deal = NovoDeal();
+
+        Assert.Null(deal.MoverPara(Estagio.Qualificacao, Agora));
+        Assert.Null(deal.MoverPara(Estagio.Proposta, Agora));
+        Assert.Equal(Estagio.Proposta, deal.Estagio);
+    }
+
+    [Fact]
+    public void Pular_estagio_e_recusado_com_motivo()
+    {
+        var deal = NovoDeal();
+
+        var motivo = deal.MoverPara(Estagio.Negociacao, Agora);
+
+        Assert.NotNull(motivo);
+        Assert.Contains("pular", motivo, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Estagio.Novo, deal.Estagio);
+    }
+
+    [Fact]
+    public void Fechar_e_possivel_de_qualquer_estagio_aberto()
+    {
+        // Negocio morre a qualquer altura do funil, e obrigar a passar por todos
+        // os estagios antes de marcar Perdido faria o dado de funil mentir.
+        var deal = NovoDeal();
+
+        Assert.Null(deal.MoverPara(Estagio.Perdido, Agora));
+        Assert.Equal(Estagio.Perdido, deal.Estagio);
+        Assert.Equal(Agora, deal.FechadoEm);
+    }
+
+    [Fact]
+    public void Deal_fechado_nao_volta_ao_funil()
+    {
+        var deal = NovoDeal();
+        deal.MoverPara(Estagio.Ganho, Agora);
+
+        var motivo = deal.MoverPara(Estagio.Negociacao, Agora);
+
+        Assert.NotNull(motivo);
+        Assert.Equal(Estagio.Ganho, deal.Estagio);
+    }
+
+    [Fact]
+    public void Repetir_a_mesma_transicao_nao_e_erro()
+    {
+        // O vendedor clica duas vezes, o webhook reentrega. Tratar como erro
+        // encheria a tela de aviso para uma acao que nao mudou nada.
+        var deal = NovoDeal();
+        deal.MoverPara(Estagio.Qualificacao, Agora);
+
+        Assert.Null(deal.MoverPara(Estagio.Qualificacao, Agora));
+        Assert.Equal(Estagio.Qualificacao, deal.Estagio);
+    }
+
+    [Fact]
+    public void Custo_de_ia_acumula_por_invocacao()
+    {
+        var deal = NovoDeal();
+
+        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.15m, Agora));
+        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.25m, Agora));
+
+        Assert.Equal(0.40m, deal.CustoIaAcumulado);
+        Assert.Equal(2, deal.Invocacoes.Count);
+    }
+
+    [Fact]
+    public void Custo_negativo_nao_entra_e_nao_reduz_o_acumulado()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AiInvocation(Guid.NewGuid(), "fake", -1m, Agora));
+    }
+}


### PR DESCRIPTION
Fecha #48.

## Critério de aceite

- [x] Entidades sem atributo de persistência — `Copiloto.Dominio` segue sem `PackageReference`, e `DominioSemPacoteTeste` continua sendo quem prova
- [x] Regras de transição de estágio no domínio, não no controller
- [x] Testes de domínio sem banco — 21 passando, offline
- [x] `Deal` já nasce com `CustoIaAcumulado`

## O que ficou onde violar não compila

Regra escrita em documento depende de todo mundo lembrar. Duas delas viraram assinatura:

**`Sinal` exige `mensagemId` e `trechoCitado` no construtor.** Como campo opcional, bastaria um caminho de criação esquecer para o sinal aparecer na tela sem procedência — que é exatamente o "a IA tá ruim" que ninguém consegue verificar. O trecho vai junto do id porque o vendedor lê a frase na tela, sem abrir a conversa inteira para procurar.

**`BlocoSugerido` não tem construtor público:** sai por `Ancorado()` ou `Perguntar()`. Escassez, prova social, desconto e prazo exigem o dado do CRM que sustente; sem ele, o caminho é virar pergunta ao vendedor.

## Decisões que valem revisão

- **`MoverPara` devolve motivo, não lança.** Tentativa inválida é caso esperado — o vendedor arrasta o card de volta. Exceção para fluxo esperado obriga try/catch como if, e o motivo em texto é o que a tela mostra.
- **Repetir a mesma transição é no-op.** Webhook reentrega, dedo clica duas vezes.
- **Fechar vale de qualquer estágio aberto.** Negócio morre a qualquer altura do funil; obrigar a percorrer todos antes de marcar Perdido faria o dado de funil mentir.
- **`Playbook` vazio autoriza tudo.** Empresa que ainda não configurou nada não pode receber produto mudo.
- **`Conversa` ordena por envio, não por chegada.** WhatsApp entrega fora de ordem quando o celular estava sem sinal.

## Métricas

Build Release: 0 avisos, 0 erros · 21 testes · maior arquivo 91 linhas (gatilho da #74 é 300).
