### PR TITLE
Fila em memoria: o webhook responde na hora e a IA roda fora do handler

### DIFF
--- a/src/Copiloto.Api/Ingestao/FilaDeMensagens.cs
+++ b/src/Copiloto.Api/Ingestao/FilaDeMensagens.cs
@@ -1,0 +1,70 @@
+using System.Threading.Channels;
+
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// A fila entre o webhook e o processamento (#40).
+///
+/// `Channel<T>` em memoria, e nao RabbitMQ: o volume nao justifica (YAGNI). A
+/// troca fica barata porque quem publica so enxerga `Publicar` e quem consome
+/// so enxerga `Ler` — o dia em que doer, o corpo muda e as duas pontas nao.
+///
+/// PERDE MENSAGEM SE O PROCESSO CAIR, e isso e' aceito enquanto a fila e' de
+/// memoria. A durabilidade e a #69, e ate' la' o webhook responder 200 e' uma
+/// promessa de que a mensagem foi RECEBIDA, nao de que sera processada.
+/// </summary>
+public class FilaDeMensagens
+{
+    /// <summary>
+    /// Teto de itens esperando. Existe porque fila sem limite nao para de
+    /// crescer: se o consumo ficar mais lento que a chegada — provedor de IA
+    /// devagar, pico de conversas —, a memoria sobe ate' o processo morrer, e
+    /// ai a perda e' de TUDO que estava na fila, nao de uma mensagem.
+    /// </summary>
+    public const int Capacidade = 1_000;
+
+    private readonly Channel<MensagemRecebida> _canal =
+        Channel.CreateBounded<MensagemRecebida>(new BoundedChannelOptions(Capacidade)
+        {
+            // Contrapressao: o produtor ESPERA em vez de a fila descartar. O
+            // webhook prefere demorar a responder do que perder a fala do
+            // cliente em silencio — e a espera aparece como latencia, que e'
+            // mensuravel, enquanto o descarte nao apareceria em lugar nenhum.
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    public int Aguardando => _canal.Reader.Count;
+
+    /// <summary>
+    /// Enfileira. Devolve false quando a fila esta cheia e a espera estourou o
+    /// tempo — o chamador decide o que dizer ao provedor.
+    /// </summary>
+    public async Task<bool> Publicar(MensagemRecebida mensagem, CancellationToken ct)
+    {
+        try
+        {
+            await _canal.Writer.WriteAsync(mensagem, ct);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch (ChannelClosedException)
+        {
+            // Desligamento em andamento: nao aceita trabalho novo.
+            return false;
+        }
+    }
+
+    public IAsyncEnumerable<MensagemRecebida> Ler(CancellationToken ct) =>
+        _canal.Reader.ReadAllAsync(ct);
+
+    /// <summary>
+    /// Fecha para escrita. O consumidor continua lendo o que ficou — e' o que
+    /// faz o desligamento DRENAR em vez de descartar.
+    /// </summary>
+    public void PararDeAceitar() => _canal.Writer.TryComplete();
+}

--- a/src/Copiloto.Api/Ingestao/MensagemRecebida.cs
+++ b/src/Copiloto.Api/Ingestao/MensagemRecebida.cs
@@ -1,0 +1,13 @@
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>O que o webhook do WhatsApp entrega, cru, antes de virar dominio.</summary>
+/// <param name="ProviderMessageId">
+/// O id do PROVEDOR, e nao um Guid nosso: e por ele que a reentrega e
+/// reconhecida. O provedor reentrega quando nao ve o 200 a tempo, e sem esse id
+/// a mesma fala vira duas — e duas chamadas de IA cobradas.
+/// </param>
+public record MensagemRecebida(
+    string ProviderMessageId,
+    string Telefone,
+    string Texto,
+    DateTimeOffset EnviadaEm);

--- a/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
+++ b/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
@@ -1,0 +1,62 @@
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// O worker que consome a fila fora do webhook (#40).
+///
+/// Processar IA dentro do handler e o erro classico: provedor lento vira
+/// timeout na origem, timeout vira reentrega, reentrega vira custo duplicado —
+/// e o custo duplicado e' de dinheiro, nao de CPU.
+///
+/// `MODEL_PROVIDER=fake` e' o padrao, entao isto roda offline e de graca ate' o
+/// provedor de verdade entrar.
+/// </summary>
+public class ProcessadorDeMensagens : BackgroundService
+{
+    private readonly FilaDeMensagens _fila;
+    private readonly ILogger<ProcessadorDeMensagens> _log;
+
+    public ProcessadorDeMensagens(FilaDeMensagens fila, ILogger<ProcessadorDeMensagens> log)
+    {
+        _fila = fila;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // O token NAO e' repassado ao Ler: no desligamento a fila para de
+        // aceitar e o laco termina sozinho ao esvaziar. Passar o token aqui
+        // abortaria no meio e descartaria o que ja estava dentro, que e' o
+        // oposto de drenar.
+        try
+        {
+            await foreach (var mensagem in _fila.Ler(CancellationToken.None))
+            {
+                await Processar(mensagem);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Desligamento estourou o prazo do host. O que sobrou se perde, e a
+            // durabilidade e' assunto da #69.
+        }
+    }
+
+    private Task Processar(MensagemRecebida mensagem)
+    {
+        // O passo de IA entra aqui (#41 em diante). Por ora, o registro prova
+        // que a mensagem atravessou a fila sem passar pelo handler do webhook.
+        _log.LogInformation(
+            "Mensagem {Id} de {Telefone} processada fora do webhook",
+            mensagem.ProviderMessageId, mensagem.Telefone);
+        return Task.CompletedTask;
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Ordem importa: fechar para escrita ANTES de esperar. Ao contrario, o
+        // laco ficaria esperando trabalho que nunca chega e o desligamento
+        // dependeria do timeout do host.
+        _fila.PararDeAceitar();
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,6 +1,32 @@
+using Copiloto.Api.Ingestao;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<FilaDeMensagens>();
+builder.Services.AddHostedService<ProcessadorDeMensagens>();
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.MapGet("/saude", () => Results.Ok(new { ok = true }));
+
+// O webhook responde na hora e nao processa nada (#40). O 202 e' deliberado: 200
+// diria "processado", e o que aconteceu foi "recebido e enfileirado".
+app.MapPost("/webhook/whatsapp", async (
+    MensagemRecebida mensagem, FilaDeMensagens fila, CancellationToken ct) =>
+{
+    if (string.IsNullOrWhiteSpace(mensagem.ProviderMessageId))
+        return Results.BadRequest(new { erro = "sem ProviderMessageId: a reentrega nao teria como ser reconhecida" });
+
+    var enfileirou = await fila.Publicar(mensagem, ct);
+
+    // 503 e nao 500: o provedor deve REENTREGAR. Dizer 200 com a fila cheia
+    // perderia a fala do cliente em silencio, que e' o pior desfecho possivel.
+    return enfileirou
+        ? Results.Accepted()
+        : Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+});
 
 app.Run();
+
+/// <summary>Torna a classe gerada visivel para o WebApplicationFactory da suite.</summary>
+public partial class Program;

--- a/testes/Copiloto.Testes/FilaDeMensagensTeste.cs
+++ b/testes/Copiloto.Testes/FilaDeMensagensTeste.cs
@@ -1,0 +1,107 @@
+using Copiloto.Api.Ingestao;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A fila entre o webhook e o processamento (#40).
+///
+/// Processar IA dentro do handler e o erro classico: provedor lento vira timeout
+/// na origem, timeout vira reentrega, reentrega vira custo DUPLICADO — e o custo
+/// aqui e de dinheiro, nao de CPU.
+/// </summary>
+public class FilaDeMensagensTeste
+{
+    private static MensagemRecebida Fala(string id = "wamid.1") =>
+        new(id, "+5511999999999", "qual o valor do kg?", DateTimeOffset.UtcNow);
+
+    [Fact]
+    public async Task Publicar_entrega_para_quem_le()
+    {
+        var fila = new FilaDeMensagens();
+
+        Assert.True(await fila.Publicar(Fala(), CancellationToken.None));
+
+        await foreach (var m in fila.Ler(CancellationToken.None))
+        {
+            Assert.Equal("wamid.1", m.ProviderMessageId);
+            break;
+        }
+    }
+
+    [Fact]
+    public async Task A_fila_tem_limite()
+    {
+        // Fila sem teto nao para de crescer: consumo mais lento que a chegada faz
+        // a memoria subir ate o processo morrer, e ai a perda e de TUDO.
+        var fila = new FilaDeMensagens();
+
+        for (var i = 0; i < FilaDeMensagens.Capacidade; i++)
+            await fila.Publicar(Fala($"wamid.{i}"), CancellationToken.None);
+
+        Assert.Equal(FilaDeMensagens.Capacidade, fila.Aguardando);
+    }
+
+    [Fact]
+    public async Task Fila_cheia_aplica_contrapressao_em_vez_de_descartar()
+    {
+        // O produtor ESPERA. Descartar em silencio perderia a fala do cliente
+        // sem aparecer em lugar nenhum; a espera aparece como latencia.
+        var fila = new FilaDeMensagens();
+        for (var i = 0; i < FilaDeMensagens.Capacidade; i++)
+            await fila.Publicar(Fala($"wamid.{i}"), CancellationToken.None);
+
+        using var prazo = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
+        var publicou = await fila.Publicar(Fala("estoura"), prazo.Token);
+
+        Assert.False(publicou);
+        Assert.Equal(FilaDeMensagens.Capacidade, fila.Aguardando);
+    }
+
+    [Fact]
+    public async Task Desligamento_drena_o_que_ja_estava_na_fila()
+    {
+        // O criterio de aceite: parar de aceitar nao pode descartar o que entrou.
+        var fila = new FilaDeMensagens();
+        await fila.Publicar(Fala("a"), CancellationToken.None);
+        await fila.Publicar(Fala("b"), CancellationToken.None);
+
+        fila.PararDeAceitar();
+
+        var lidas = new List<string>();
+        await foreach (var m in fila.Ler(CancellationToken.None))
+            lidas.Add(m.ProviderMessageId);
+
+        Assert.Equal(new[] { "a", "b" }, lidas);
+    }
+
+    [Fact]
+    public async Task Depois_de_parar_nao_aceita_trabalho_novo()
+    {
+        var fila = new FilaDeMensagens();
+        fila.PararDeAceitar();
+
+        Assert.False(await fila.Publicar(Fala(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task A_leitura_termina_sozinha_quando_a_fila_fecha_e_esvazia()
+    {
+        // Sem isto, o desligamento dependeria do timeout do host: o laco ficaria
+        // esperando trabalho que nunca chega.
+        var fila = new FilaDeMensagens();
+        await fila.Publicar(Fala(), CancellationToken.None);
+        fila.PararDeAceitar();
+
+        var consumo = Task.Run(async () =>
+        {
+            var n = 0;
+            await foreach (var _ in fila.Ler(CancellationToken.None)) n++;
+            return n;
+        });
+
+        var terminou = await Task.WhenAny(consumo, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.Same(consumo, terminou);
+        Assert.Equal(1, await consumo);
+    }
+}


### PR DESCRIPTION
Closes #40.

## Critério de aceite

- [x] **Webhook responde em menos de 100ms** — medido com a API de pé, 10 chamadas: **202 em ~1ms** (a primeira 19,8ms, JIT)
- [x] **Processamento de IA nunca dentro do handler** — as 10 apareceram no log do `BackgroundService`, fora dele
- [x] **Fila com limite; ao encher, contrapressão e registro** — teto de 1.000 com `BoundedChannelFullMode.Wait`, e 503 quando a espera estoura
- [x] **Desligamento gracioso drena a fila** — testado

## Decisões que valem revisão

**202 e não 200.** 200 diria "processado"; o que aconteceu foi "recebido e enfileirado". A distinção importa porque a fila é de memória — o 202 promete recebimento, não conclusão.

**Contrapressão, não descarte.** Descartar em silêncio perderia a fala do cliente sem aparecer em lugar nenhum; a espera aparece como latência, que é mensurável.

**503 quando não enfileira**, para o provedor reentregar. Responder 200 com a fila cheia perderia a mensagem calado.

**`ProviderMessageId` obrigatório (400 sem ele).** É o id do provedor, não um Guid nosso: é por ele que a reentrega é reconhecida. Sem ele, a mesma fala vira duas — e duas chamadas de IA cobradas.

**O laço de leitura não recebe o `stoppingToken`.** Passar o token abortaria no meio e descartaria o que já estava na fila, que é o oposto de drenar. E `StopAsync` fecha para escrita *antes* de esperar: ao contrário, o laço ficaria parado esperando trabalho que nunca chega.

## Limite assumido

A fila é de memória (YAGNI, como a issue pede) e **perde se o processo cair**. Está escrito na classe: a durabilidade é a #69, e até lá o 202 promete recebimento, não processamento.

## Métricas

27 testes em Release, 0 avisos, nenhum pacote novo.
