### PR TITLE
Telefone normalizado e falante nos dois sentidos

### DIFF
--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -1,3 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <!--
+    A referencia anda num sentido so: Api -> Dominio. O contrario transformaria
+    o dominio em mais uma camada de aplicacao, e ha teste que reprova se um
+    ProjectReference aparecer no lado de la.
+
+    Mapeamento e persistencia moram AQUI, e nao no dominio, que e POCO puro por
+    decisao (#48) e nao tem pacote para compilar um [Table] nem um DbContext.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Copiloto.Dominio\Copiloto.Dominio.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Copiloto.Api/Ingestao/MensagemRecebida.cs
+++ b/src/Copiloto.Api/Ingestao/MensagemRecebida.cs
@@ -6,8 +6,17 @@ namespace Copiloto.Api.Ingestao;
 /// reconhecida. O provedor reentrega quando nao ve o 200 a tempo, e sem esse id
 /// a mesma fala vira duas — e duas chamadas de IA cobradas.
 /// </param>
+/// <param name="De">Quem enviou.</param>
+/// <param name="Para">Quem recebeu.</param>
+/// <remarks>
+/// Os dois numeros vem no payload, e o falante sai da COMPARACAO com o numero
+/// da empresa — nao de um campo "direcao" que o provedor preenche. Assim a
+/// mesma rotina resolve os dois sentidos, e a conversa que o vendedor iniciou
+/// nao entra no historico como se o cliente tivesse falado primeiro.
+/// </remarks>
 public record MensagemRecebida(
     string ProviderMessageId,
-    string Telefone,
+    string De,
+    string Para,
     string Texto,
     DateTimeOffset EnviadaEm);

--- a/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
+++ b/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
@@ -1,3 +1,6 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+
 namespace Copiloto.Api.Ingestao;
 
 /// <summary>
@@ -13,11 +16,14 @@ namespace Copiloto.Api.Ingestao;
 public class ProcessadorDeMensagens : BackgroundService
 {
     private readonly FilaDeMensagens _fila;
+    private readonly ResolvedorDeLead _resolvedor;
     private readonly ILogger<ProcessadorDeMensagens> _log;
 
-    public ProcessadorDeMensagens(FilaDeMensagens fila, ILogger<ProcessadorDeMensagens> log)
+    public ProcessadorDeMensagens(
+        FilaDeMensagens fila, ResolvedorDeLead resolvedor, ILogger<ProcessadorDeMensagens> log)
     {
         _fila = fila;
+        _resolvedor = resolvedor;
         _log = log;
     }
 
@@ -41,13 +47,28 @@ public class ProcessadorDeMensagens : BackgroundService
         }
     }
 
-    private Task Processar(MensagemRecebida mensagem)
+    private Task Processar(MensagemRecebida bruta)
     {
-        // O passo de IA entra aqui (#41 em diante). Por ora, o registro prova
-        // que a mensagem atravessou a fila sem passar pelo handler do webhook.
+        var doCliente = _resolvedor.TelefoneDoCliente(bruta);
+        if (doCliente is null)
+        {
+            // Numero irreconhecivel nao derruba o worker nem some: fica no log
+            // com o id do provedor, que e por onde alguem consegue ir atras.
+            _log.LogWarning(
+                "Mensagem {Id} descartada: nem De ({De}) nem Para ({Para}) e telefone valido",
+                bruta.ProviderMessageId, bruta.De, bruta.Para);
+            return Task.CompletedTask;
+        }
+
+        var lead = _resolvedor.Resolver(doCliente, bruta.EnviadaEm);
+        var remetente = Telefone.Normalizar(bruta.De)!;
+        var autor = _resolvedor.QuemFalou(remetente);
+
+        // O passo de IA entra aqui (#41 em diante). Ate la, o registro prova que
+        // a mensagem atravessou a fila sem passar pelo handler do webhook.
         _log.LogInformation(
-            "Mensagem {Id} de {Telefone} processada fora do webhook",
-            mensagem.ProviderMessageId, mensagem.Telefone);
+            "Mensagem {Id} de {Autor} no lead {Lead} processada fora do webhook",
+            bruta.ProviderMessageId, autor, lead.Id);
         return Task.CompletedTask;
     }
 

--- a/src/Copiloto.Api/Ingestao/ResolvedorDeLead.cs
+++ b/src/Copiloto.Api/Ingestao/ResolvedorDeLead.cs
@@ -1,0 +1,65 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// Transforma o payload bruto em Lead + falante (#22).
+///
+/// A resolucao e por telefone NORMALIZADO, nunca pela string que chegou: o
+/// mesmo cliente manda mensagem do celular novo e do numero antigo de oito
+/// digitos, e comparar texto cru faz virar dois leads com o historico partido
+/// no meio.
+/// </summary>
+public class ResolvedorDeLead
+{
+    private readonly Telefone _numeroDaEmpresa;
+    private readonly Dictionary<string, Lead> _porTelefone = new();
+
+    public ResolvedorDeLead(string numeroDaEmpresa)
+    {
+        _numeroDaEmpresa = Telefone.Normalizar(numeroDaEmpresa)
+            ?? throw new ArgumentException(
+                "O numero da empresa precisa ser um telefone brasileiro valido: e "
+                + "ele que decide quem falou em cada mensagem.", nameof(numeroDaEmpresa));
+    }
+
+    /// <summary>
+    /// Quem falou. Sai da comparacao com o numero da empresa, e nao de um campo
+    /// do provedor — a mesma rotina serve para mensagem que entra e que sai.
+    /// </summary>
+    public Autor QuemFalou(Telefone remetente) =>
+        remetente.Equals(_numeroDaEmpresa) ? Autor.Vendedor : Autor.Cliente;
+
+    /// <summary>
+    /// O telefone do CLIENTE na troca, seja ele quem enviou ou quem recebeu.
+    /// E' ele que identifica a conversa nos dois sentidos.
+    /// </summary>
+    public Telefone? TelefoneDoCliente(MensagemRecebida bruta)
+    {
+        var de = Telefone.Normalizar(bruta.De);
+        var para = Telefone.Normalizar(bruta.Para);
+        if (de is null || para is null) return null;
+
+        return QuemFalou(de) == Autor.Cliente ? de : para;
+    }
+
+    /// <summary>
+    /// O Lead daquele telefone, criando na hora se for a primeira vez.
+    ///
+    /// Telefone desconhecido cria Lead: no WhatsApp nao existe cadastro previo,
+    /// e um Lead que so passa a existir depois de alguem preencher formulario e
+    /// um Lead que nunca existe.
+    /// </summary>
+    public Lead Resolver(Telefone telefone, DateTimeOffset quando)
+    {
+        if (_porTelefone.TryGetValue(telefone.E164, out var existente))
+            return existente;
+
+        var novo = new Lead(Guid.NewGuid(), telefone.E164, quando);
+        _porTelefone[telefone.E164] = novo;
+        return novo;
+    }
+
+    public int LeadsConhecidos => _porTelefone.Count;
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -3,6 +3,11 @@ using Copiloto.Api.Ingestao;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<FilaDeMensagens>();
+
+// O numero da empresa e o que decide quem falou em cada mensagem, entao ele e
+// configuracao e nao constante: cada instalacao tem o seu.
+builder.Services.AddSingleton(_ => new ResolvedorDeLead(
+    builder.Configuration["WHATSAPP_NUMERO_EMPRESA"] ?? "+55 11 3333-4444"));
 builder.Services.AddHostedService<ProcessadorDeMensagens>();
 
 var app = builder.Build();
@@ -16,6 +21,8 @@ app.MapPost("/webhook/whatsapp", async (
 {
     if (string.IsNullOrWhiteSpace(mensagem.ProviderMessageId))
         return Results.BadRequest(new { erro = "sem ProviderMessageId: a reentrega nao teria como ser reconhecida" });
+    if (string.IsNullOrWhiteSpace(mensagem.De) || string.IsNullOrWhiteSpace(mensagem.Para))
+        return Results.BadRequest(new { erro = "sem De/Para: nao ha como dizer quem falou" });
 
     var enfileirou = await fila.Publicar(mensagem, ct);
 

--- a/src/Copiloto.Dominio/Vendas/Telefone.cs
+++ b/src/Copiloto.Dominio/Vendas/Telefone.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>
+/// Telefone brasileiro na forma canonica `+55DDNNNNNNNNN`.
+///
+/// Normalizacao de numero brasileiro e fonte classica de bug, e o estrago e
+/// especifico: o mesmo cliente vira DOIS leads e o historico se parte no meio —
+/// o vendedor abre a conversa e nao ve o que foi combinado semana passada.
+///
+/// O caso que causa isso e o NONO DIGITO. Celular ganhou o 9 na frente em 2016,
+/// e ate hoje chega numero dos dois jeitos: agenda velha, cadastro antigo,
+/// etiqueta de loja. `11 8765-4321` e `11 98765-4321` sao a mesma pessoa, e
+/// comparar string crua diz que nao sao.
+///
+/// A regra do nono digito vale para CELULAR, e celular no Brasil comeca com
+/// 6, 7, 8 ou 9. Fixo comeca com 2, 3, 4 ou 5 e continua com oito digitos —
+/// enfiar um 9 nele criaria um numero que nao existe.
+/// </summary>
+public sealed class Telefone : IEquatable<Telefone>
+{
+    private const string Ddi = "55";
+
+    private Telefone(string e164) => E164 = e164;
+
+    /// <summary>A forma canonica: `+55` + DDD + assinante.</summary>
+    public string E164 { get; }
+
+    public string Ddd => E164.Substring(3, 2);
+    public string Assinante => E164[5..];
+    public bool EhCelular => Assinante.Length == 9;
+
+    /// <summary>
+    /// Normaliza. Devolve null quando o que chegou nao e telefone brasileiro
+    /// reconhecivel — e nao um Telefone com dado torto, que so adiaria o erro.
+    /// </summary>
+    public static Telefone? Normalizar(string? bruto)
+    {
+        if (string.IsNullOrWhiteSpace(bruto)) return null;
+
+        var digitos = Regex.Replace(bruto, @"\D", "");
+
+        // DDI opcional. `550` nao e DDI seguido de DDD: nao existe DDD com zero
+        // na frente, entao ali o 55 e o proprio DDD (Rio Grande do Sul).
+        if (digitos.Length is 12 or 13 && digitos.StartsWith(Ddi) && digitos[2] != '0')
+            digitos = digitos[2..];
+
+        if (digitos.Length is not (10 or 11)) return null;
+
+        var ddd = digitos[..2];
+        var assinante = digitos[2..];
+
+        // DDD brasileiro vai de 11 a 99, e nenhum comeca com 0 ou 1 no segundo
+        // digito abaixo de 11.
+        if (int.Parse(ddd) < 11) return null;
+
+        if (assinante.Length == 8)
+        {
+            // Celular antigo (comeca com 6-9) ganha o nono digito. Fixo nao.
+            if (assinante[0] >= '6') assinante = "9" + assinante;
+            else if (assinante[0] < '2') return null;
+        }
+        else if (assinante[0] != '9')
+        {
+            // Nove digitos que nao comeca com 9 nao e celular valido.
+            return null;
+        }
+
+        return new Telefone($"+{Ddi}{ddd}{assinante}");
+    }
+
+    public bool Equals(Telefone? outro) => outro is not null && E164 == outro.E164;
+    public override bool Equals(object? obj) => Equals(obj as Telefone);
+    public override int GetHashCode() => E164.GetHashCode();
+    public override string ToString() => E164;
+}

--- a/testes/Copiloto.Testes/FilaDeMensagensTeste.cs
+++ b/testes/Copiloto.Testes/FilaDeMensagensTeste.cs
@@ -12,7 +12,8 @@ namespace Copiloto.Testes;
 public class FilaDeMensagensTeste
 {
     private static MensagemRecebida Fala(string id = "wamid.1") =>
-        new(id, "+5511999999999", "qual o valor do kg?", DateTimeOffset.UtcNow);
+        new(id, "+5511987654321", "+5511333334444", "qual o valor do kg?",
+            DateTimeOffset.UtcNow);
 
     [Fact]
     public async Task Publicar_entrega_para_quem_le()

--- a/testes/Copiloto.Testes/ResolvedorDeLeadTeste.cs
+++ b/testes/Copiloto.Testes/ResolvedorDeLeadTeste.cs
@@ -1,0 +1,93 @@
+using Copiloto.Api.Ingestao;
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Resolucao de Lead por telefone e identificacao do falante (#22).
+/// </summary>
+public class ResolvedorDeLeadTeste
+{
+    private const string Empresa = "+55 11 3333-4444";
+    private const string Cliente = "+55 11 98765-4321";
+    private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static ResolvedorDeLead Novo() => new(Empresa);
+
+    private static MensagemRecebida Fala(string de, string para) =>
+        new("wamid.1", de, para, "qual o valor?", Agora);
+
+    [Fact]
+    public void Mensagem_que_chega_e_do_cliente()
+    {
+        var r = Novo();
+        Assert.Equal(Autor.Cliente, r.QuemFalou(Telefone.Normalizar(Cliente)!));
+    }
+
+    [Fact]
+    public void Mensagem_que_sai_e_do_vendedor()
+    {
+        // O outro sentido, e ele importa: sem isto a conversa que o vendedor
+        // iniciou entraria no historico como se o cliente tivesse falado primeiro.
+        var r = Novo();
+        Assert.Equal(Autor.Vendedor, r.QuemFalou(Telefone.Normalizar(Empresa)!));
+    }
+
+    [Fact]
+    public void O_cliente_e_o_mesmo_nos_dois_sentidos()
+    {
+        var r = Novo();
+
+        var entrando = r.TelefoneDoCliente(Fala(Cliente, Empresa));
+        var saindo = r.TelefoneDoCliente(Fala(Empresa, Cliente));
+
+        Assert.Equal(entrando, saindo);
+        Assert.Equal("+5511987654321", entrando!.E164);
+    }
+
+    [Fact]
+    public void Telefone_desconhecido_cria_o_Lead()
+    {
+        // No WhatsApp nao existe cadastro previo: um Lead que so passa a existir
+        // depois de alguem preencher formulario e um Lead que nunca existe.
+        var r = Novo();
+
+        var lead = r.Resolver(Telefone.Normalizar(Cliente)!, Agora);
+
+        Assert.Equal(1, r.LeadsConhecidos);
+        Assert.Equal("+5511987654321", lead.Telefone);
+    }
+
+    [Fact]
+    public void O_mesmo_numero_em_formatos_diferentes_e_UM_lead_so()
+    {
+        // O bug que a issue existe para evitar: o historico partido no meio.
+        var r = Novo();
+
+        var a = r.Resolver(Telefone.Normalizar("(11) 98765-4321")!, Agora);
+        var b = r.Resolver(Telefone.Normalizar("5511987654321")!, Agora);
+        var c = r.Resolver(Telefone.Normalizar("11 8765-4321")!, Agora);   // sem o nono digito
+
+        Assert.Equal(1, r.LeadsConhecidos);
+        Assert.Equal(a.Id, b.Id);
+        Assert.Equal(a.Id, c.Id);
+    }
+
+    [Fact]
+    public void Numero_irreconhecivel_devolve_null_em_vez_de_criar_lead_torto()
+    {
+        var r = Novo();
+
+        Assert.Null(r.TelefoneDoCliente(Fala("123", Empresa)));
+        Assert.Equal(0, r.LeadsConhecidos);
+    }
+
+    [Fact]
+    public void Empresa_com_numero_invalido_nao_sobe()
+    {
+        // Falhar na construcao e melhor que classificar todo mundo como cliente:
+        // o erro apareceria como "o vendedor nunca fala", tres camadas adiante.
+        Assert.Throws<ArgumentException>(() => new ResolvedorDeLead("nao e telefone"));
+    }
+}

--- a/testes/Copiloto.Testes/TelefoneTeste.cs
+++ b/testes/Copiloto.Testes/TelefoneTeste.cs
@@ -1,0 +1,88 @@
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A normalizacao de telefone brasileiro (#22).
+///
+/// O estrago que ela evita e especifico: o mesmo cliente vira DOIS leads e o
+/// historico se parte no meio — o vendedor abre a conversa e nao ve o que foi
+/// combinado semana passada.
+/// </summary>
+public class TelefoneTeste
+{
+    [Theory]
+    [InlineData("+55 11 98765-4321")]
+    [InlineData("5511987654321")]
+    [InlineData("11987654321")]
+    [InlineData("(11) 98765-4321")]
+    [InlineData("11 9 8765 4321")]
+    [InlineData("  +55(11)98765.4321  ")]
+    public void Formatos_diferentes_do_mesmo_numero_convergem(string bruto)
+    {
+        Assert.Equal("+5511987654321", Telefone.Normalizar(bruto)!.E164);
+    }
+
+    [Fact]
+    public void Celular_sem_o_nono_digito_e_o_mesmo_cliente()
+    {
+        // O caso que parte o historico: agenda velha e cadastro antigo ainda
+        // entregam o numero de oito digitos.
+        var antigo = Telefone.Normalizar("11 8765-4321");
+        var novo = Telefone.Normalizar("11 98765-4321");
+
+        Assert.Equal(novo, antigo);
+        Assert.Equal("+5511987654321", antigo!.E164);
+    }
+
+    [Theory]
+    [InlineData("11 3123-4567")]   // fixo Sao Paulo
+    [InlineData("21 2222-3333")]   // fixo Rio
+    public void Fixo_nao_ganha_nono_digito(string bruto)
+    {
+        // Enfiar um 9 num fixo criaria um numero que nao existe.
+        var t = Telefone.Normalizar(bruto)!;
+
+        Assert.False(t.EhCelular);
+        Assert.Equal(8, t.Assinante.Length);
+    }
+
+    [Fact]
+    public void DDD_55_nao_e_confundido_com_o_DDI()
+    {
+        // Rio Grande do Sul tem DDD 55. `5555XXXXXXXX` e DDI+DDD; `55XXXXXXXXX`
+        // sozinho e o DDD gaucho.
+        var comDdi = Telefone.Normalizar("55 55 99999-8888")!;
+        var semDdi = Telefone.Normalizar("55 99999-8888")!;
+
+        Assert.Equal("55", comDdi.Ddd);
+        Assert.Equal("55", semDdi.Ddd);
+        Assert.Equal(comDdi, semDdi);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("123")]
+    [InlineData("11 1234-5678")]      // assinante comecando com 1
+    [InlineData("09 98765-4321")]     // DDD invalido
+    [InlineData("11 12345-6789")]     // nove digitos sem comecar com 9
+    public void O_que_nao_e_telefone_brasileiro_devolve_null(string? bruto)
+    {
+        // Null e nao um Telefone com dado torto: devolver o torto so adiaria o
+        // erro para uma camada onde ninguem sabe mais de onde ele veio.
+        Assert.Null(Telefone.Normalizar(bruto));
+    }
+
+    [Fact]
+    public void Telefones_iguais_sao_iguais_como_valor()
+    {
+        // E o que permite resolver o Lead por telefone sem comparar string crua.
+        var a = Telefone.Normalizar("(11) 98765-4321")!;
+        var b = Telefone.Normalizar("5511987654321")!;
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+}


### PR DESCRIPTION
Closes #22.

## Critério de aceite

- [x] **Telefone normalizado antes de casar com Lead** — `Telefone` é value object, canônico em `+55DDNNNNNNNNN`
- [x] **Telefone desconhecido cria Lead** — `ResolvedorDeLead.Resolver` cria na hora; no WhatsApp não existe cadastro prévio
- [x] **Falante identificado nos dois sentidos** — sai da comparação com o número da empresa, não de um campo do provedor
- [x] **Testes cobrindo variações de formato brasileiro** — 6 formatos do mesmo número convergindo, mais os casos de borda

## O caso que a issue existe para evitar

O **nono dígito**. Celular ganhou o 9 na frente em 2016, e até hoje chega dos dois jeitos — agenda velha, cadastro antigo, etiqueta de loja. `11 8765-4321` e `11 98765-4321` são a mesma pessoa, e comparar string crua diz que não são: vira dois leads, e o vendedor abre a conversa sem ver o que foi combinado semana passada.

A regra vale só para **celular** (começa com 6-9). Fixo começa com 2-5 e fica com oito dígitos — enfiar um 9 nele criaria número que não existe. Teste dos dois lados.

## Armadilha tratada: DDD 55 × DDI 55

Rio Grande do Sul tem DDD 55. `5555XXXXXXXX` é DDI+DDD; `55XXXXXXXXX` sozinho é o DDD gaúcho. A diferença é que não existe DDD começando com zero. Sem essa checagem, **todo número do RS perderia o próprio DDD**.

## Decisões

- **O que não é telefone brasileiro devolve `null`**, não um `Telefone` com dado torto — o torto adiaria o erro para uma camada onde ninguém sabe de onde ele veio.
- **O falante vem da comparação com o número da empresa.** Um campo "direção" do provedor resolveria só um sentido; assim a conversa que o vendedor iniciou não entra no histórico como se o cliente tivesse falado primeiro.
- **`ResolvedorDeLead` recusa subir com número de empresa inválido.** Falhar na construção é melhor que classificar todo mundo como cliente — esse erro apareceria como "o vendedor nunca fala", três camadas adiante.

## Nota

A `Copiloto.Api` passou a referenciar o `Copiloto.Dominio` (o csproj estava vazio). A referência anda num sentido só, e o teste que reprova o contrário já existia esperando.

52 testes em Release, 0 avisos, nenhum pacote novo.
