### PR TITLE
Vinculo custo-negocio: a invocacao carrega o deal e o Deal recusa custo alheio

### DIFF
--- a/src/Copiloto.Dominio/Ia/AiInvocation.cs
+++ b/src/Copiloto.Dominio/Ia/AiInvocation.cs
@@ -11,8 +11,14 @@ namespace Copiloto.Dominio.Ia;
 /// </summary>
 public class AiInvocation
 {
+    /// <param name="dealId">
+    /// O negocio em que a invocacao aconteceu. Nulo so quando nao ha negocio no
+    /// contexto — uma chamada de diagnostico, um teste de provedor. Havendo
+    /// Deal, ele e obrigatorio, e quem cobra isso e o proprio Deal ao registrar.
+    /// </param>
     public AiInvocation(
-        Guid id, string modelo, decimal custoEmReais, DateTimeOffset quando)
+        Guid id, string modelo, decimal custoEmReais, DateTimeOffset quando,
+        Guid? dealId = null)
     {
         if (id == Guid.Empty) throw new ArgumentException("Invocacao sem id.", nameof(id));
         if (string.IsNullOrWhiteSpace(modelo))
@@ -23,13 +29,29 @@ public class AiInvocation
             throw new ArgumentOutOfRangeException(nameof(custoEmReais),
                 "Custo negativo nao existe, e somado ao acumulado ele o faria DIMINUIR.");
 
+        if (dealId == Guid.Empty)
+            throw new ArgumentException(
+                "Guid.Empty nao e 'sem negocio': use null. Empty passaria por "
+                + "preenchido e o custo seria somado a um Deal que nao existe.",
+                nameof(dealId));
+
         Id = id;
+        DealId = dealId;
         Modelo = modelo.Trim();
         CustoEmReais = custoEmReais;
         Quando = quando;
     }
 
     public Guid Id { get; }
+
+    /// <summary>
+    /// O vinculo custo-negocio. E barato agora e caro depois: enxertar rastreio
+    /// num modelo ja povoado exige backfill e adivinhacao, e a resposta ficaria
+    /// sendo estimativa para sempre — justamente na conta que decide se o
+    /// produto se paga.
+    /// </summary>
+    public Guid? DealId { get; }
+
     public string Modelo { get; }
     public decimal CustoEmReais { get; }
     public DateTimeOffset Quando { get; }

--- a/src/Copiloto.Dominio/Vendas/Deal.cs
+++ b/src/Copiloto.Dominio/Vendas/Deal.cs
@@ -85,6 +85,15 @@ public class Deal
     public void RegistrarInvocacao(AiInvocation invocacao)
     {
         ArgumentNullException.ThrowIfNull(invocacao);
+
+        // O Deal recusa custo que nao e dele. Sem esta checagem, "quanto custou
+        // fechar este negocio?" responderia com a soma de outro — e o erro nao
+        // apareceria em lugar nenhum, porque o numero continua parecendo certo.
+        if (invocacao.DealId != Id)
+            throw new ArgumentException(
+                $"A invocacao aponta para o deal {invocacao.DealId?.ToString() ?? "nenhum"} "
+                + $"e esta sendo registrada em {Id}.", nameof(invocacao));
+
         _invocacoes.Add(invocacao);
         CustoIaAcumulado += invocacao.CustoEmReais;
     }

--- a/testes/Copiloto.Testes/DealTeste.cs
+++ b/testes/Copiloto.Testes/DealTeste.cs
@@ -90,11 +90,61 @@ public class DealTeste
     {
         var deal = NovoDeal();
 
-        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.15m, Agora));
-        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.25m, Agora));
+        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.15m, Agora, deal.Id));
+        deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", 0.25m, Agora, deal.Id));
 
         Assert.Equal(0.40m, deal.CustoIaAcumulado);
         Assert.Equal(2, deal.Invocacoes.Count);
+    }
+
+    [Fact]
+    public void O_somatorio_das_invocacoes_bate_com_o_acumulado()
+    {
+        // Criterio de aceite da #2, e a razao dele: o acumulado e um numero
+        // guardado, e numero guardado pode divergir da soma que o originou. O
+        // dia em que divergir, "quanto custou fechar este negocio?" passa a ter
+        // duas respostas e ninguem sabe qual e a certa.
+        var deal = NovoDeal();
+        decimal[] custos = [0.07m, 0.13m, 1.20m, 0.004m];
+
+        foreach (var c in custos)
+            deal.RegistrarInvocacao(new AiInvocation(Guid.NewGuid(), "fake", c, Agora, deal.Id));
+
+        Assert.Equal(deal.Invocacoes.Sum(i => i.CustoEmReais), deal.CustoIaAcumulado);
+        Assert.Equal(custos.Sum(), deal.CustoIaAcumulado);
+    }
+
+    [Fact]
+    public void O_Deal_recusa_custo_que_nao_e_dele()
+    {
+        // Sem isto, "quanto custou este negocio?" responderia com a soma de
+        // outro — e o erro nao apareceria, porque o numero continua com cara
+        // de certo.
+        var deal = NovoDeal();
+        var deOutro = new AiInvocation(Guid.NewGuid(), "fake", 9.99m, Agora, Guid.NewGuid());
+
+        Assert.Throws<ArgumentException>(() => deal.RegistrarInvocacao(deOutro));
+        Assert.Equal(0m, deal.CustoIaAcumulado);
+    }
+
+    [Fact]
+    public void Invocacao_sem_deal_nao_entra_num_deal()
+    {
+        // `DealId` nulo e legitimo (diagnostico, teste de provedor), mas nao
+        // pertence a negocio nenhum.
+        var deal = NovoDeal();
+        var solta = new AiInvocation(Guid.NewGuid(), "fake", 0.50m, Agora);
+
+        Assert.Throws<ArgumentException>(() => deal.RegistrarInvocacao(solta));
+    }
+
+    [Fact]
+    public void Guid_vazio_nao_passa_por_sem_negocio()
+    {
+        // Empty passaria por preenchido e o custo seria somado a um Deal que
+        // nao existe. Para "sem negocio" existe o null.
+        Assert.Throws<ArgumentException>(
+            () => new AiInvocation(Guid.NewGuid(), "fake", 0.10m, Agora, Guid.Empty));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #2.

## Critério de aceite

- [x] **`Deal` tem `custo_ia_acumulado`, atualizado a cada invocação** — veio no #97; aqui ganhou a validação de dono
- [x] **`AiInvocation` tem `deal_id` não nulo quando há negócio no contexto**
- [x] **Teste: somatório das invocações bate com `custo_ia_acumulado`**
- [ ] **Entra na primeira migration** — ver abaixo

## O que este PR acrescenta

`Deal.RegistrarInvocacao` **recusa custo que não é dele**. Sem isso, "quanto custou fechar este negócio?" responderia com a soma de outro — e o erro não apareceria em lugar nenhum, porque o número continua com cara de certo. É o defeito que só é descoberto conferindo na mão, que é justamente o que ter o número deveria evitar.

`DealId` é anulável porque existe invocação legítima sem negócio (diagnóstico, teste de provedor). Mas **`Guid.Empty` é recusado na entrada**: ele passaria por preenchido e o custo seria somado a um Deal que não existe. Para "sem negócio" existe o `null`.

O teste do somatório existe porque o acumulado é **número guardado**, e número guardado pode divergir da soma que o originou. No dia em que divergir, a pergunta passa a ter duas respostas e ninguém sabe qual vale.

## O critério que não dá para fechar agora

**"Entra na primeira migration, não numa posterior."** Não há EF no projeto ainda — o domínio é POCO puro e sem pacote por decisão (#48), e mapeamento mora na Api.

O que a issue protege já está garantido: **o campo nasce no modelo**, então a primeira migration que existir vai incluí-lo, sem backfill nem adivinhação. Que é exatamente o "barato agora, caro depois" que a issue levanta.

Deixo registrado aqui em vez de marcar como feito — se preferir, abro issue separada amarrando isso à criação do `DbContext`.

56 testes em Release, 0 avisos.
