### PR TITLE
Debounce de baloes: seis mensagens em quatro segundos sao uma fala

### DIFF
--- a/src/Copiloto.Dominio/Conversas/AgrupadorDeFalas.cs
+++ b/src/Copiloto.Dominio/Conversas/AgrupadorDeFalas.cs
@@ -1,0 +1,52 @@
+namespace Copiloto.Dominio.Conversas;
+
+/// <summary>
+/// Junta baloes seguidos do mesmo falante numa fala so (#19).
+///
+/// Reduz custo de IA em multiplo direto: quatro baloes viravam quatro analises.
+/// E melhora o contexto, porque "o bourbon" sozinho nao diz nada — junto de
+/// "vi o cafe de voces" e "qual o valor do kg?", diz tudo.
+/// </summary>
+public static class AgrupadorDeFalas
+{
+    /// <summary>
+    /// O silencio que fecha uma fala. Dez segundos porque a pausa entre baloes
+    /// de uma mesma ideia e de um a tres segundos — quem digita a proxima frase
+    /// nao some por dez. Configuravel porque conversa de suporte tem outro
+    /// ritmo que conversa de venda.
+    /// </summary>
+    public static readonly TimeSpan JanelaPadrao = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Quebra a conversa em falas. Baloes do mesmo autor separados por menos
+    /// que a janela ficam juntos; troca de falante quebra sempre, mesmo dentro
+    /// da janela — o vendedor respondendo no meio encerra a fala do cliente.
+    /// </summary>
+    public static IReadOnlyList<Fala> Agrupar(
+        IEnumerable<Mensagem> mensagens, TimeSpan? janela = null)
+    {
+        ArgumentNullException.ThrowIfNull(mensagens);
+        var limite = janela ?? JanelaPadrao;
+
+        var falas = new List<Fala>();
+        var atual = new List<Mensagem>();
+
+        foreach (var m in mensagens.OrderBy(x => x.EnviadaEm))
+        {
+            var quebrou = atual.Count > 0
+                && (atual[^1].Autor != m.Autor
+                    || m.EnviadaEm - atual[^1].EnviadaEm > limite);
+
+            if (quebrou)
+            {
+                falas.Add(new Fala(atual[0].Autor, atual));
+                atual = new List<Mensagem>();
+            }
+
+            atual.Add(m);
+        }
+
+        if (atual.Count > 0) falas.Add(new Fala(atual[0].Autor, atual));
+        return falas;
+    }
+}

--- a/src/Copiloto.Dominio/Conversas/Fala.cs
+++ b/src/Copiloto.Dominio/Conversas/Fala.cs
@@ -1,0 +1,44 @@
+namespace Copiloto.Dominio.Conversas;
+
+/// <summary>
+/// Varios baloes que sao UMA fala.
+///
+/// Ninguem escreve paragrafo no WhatsApp: manda "bom dia", "vi o cafe de
+/// voces", "o bourbon", "qual o valor do kg?" — quatro baloes, uma pergunta.
+/// Tratar cada um como fala separada gera quatro analises, quatro custos e um
+/// dossie que muda de opiniao a cada segundo.
+/// </summary>
+public class Fala
+{
+    private readonly List<Mensagem> _baloes;
+
+    public Fala(Autor autor, IEnumerable<Mensagem> baloes)
+    {
+        _baloes = baloes?.ToList() ?? throw new ArgumentNullException(nameof(baloes));
+        if (_baloes.Count == 0)
+            throw new ArgumentException("Fala sem balao nao e fala.", nameof(baloes));
+
+        Autor = autor;
+    }
+
+    public Autor Autor { get; }
+    public IReadOnlyList<Mensagem> Baloes => _baloes;
+
+    /// <summary>
+    /// O texto junto, na ordem. E o que vai para a analise — e o que faz "o
+    /// bourbon" deixar de ser uma frase solta sem sujeito.
+    /// </summary>
+    public string Texto => string.Join("\n", _baloes.Select(b => b.Texto));
+
+    /// <summary>
+    /// O instante da ULTIMA mensagem, e nao da primeira.
+    ///
+    /// A fala so esta completa quando o silencio confirma que acabou, entao e
+    /// o fim dela que marca quando ela aconteceu. Usar a primeira faria o
+    /// "sumiu ha 4 dias" contar a partir do "bom dia" em vez do "vou pensar".
+    /// </summary>
+    public DateTimeOffset Quando => _baloes[^1].EnviadaEm;
+
+    /// <summary>Os ids, para o sinal do dossie poder citar o balao exato.</summary>
+    public IReadOnlyList<Guid> IdsDosBaloes => _baloes.Select(b => b.Id).ToList();
+}

--- a/testes/Copiloto.Testes/AgrupadorDeFalasTeste.cs
+++ b/testes/Copiloto.Testes/AgrupadorDeFalasTeste.cs
@@ -1,0 +1,141 @@
+using Copiloto.Dominio.Conversas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Baloes seguidos sao UMA fala (#19).
+///
+/// Ninguem escreve paragrafo no WhatsApp. Tratar cada balao como fala separada
+/// gera N analises, N custos e um dossie que muda de opiniao a cada segundo.
+/// </summary>
+public class AgrupadorDeFalasTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static Mensagem Balao(Autor autor, string texto, int segundos) =>
+        new(Guid.NewGuid(), autor, texto, T0.AddSeconds(segundos));
+
+    [Fact]
+    public void Seis_baloes_em_quatro_segundos_viram_uma_fala()
+    {
+        // O criterio de aceite, com o cenario do café da issue.
+        var baloes = new[]
+        {
+            Balao(Autor.Cliente, "bom dia", 0),
+            Balao(Autor.Cliente, "vi o cafe de voces", 1),
+            Balao(Autor.Cliente, "o bourbon", 2),
+            Balao(Autor.Cliente, "qual o valor do kg?", 3),
+            Balao(Autor.Cliente, "e o frete", 3),
+            Balao(Autor.Cliente, "pra SP", 4),
+        };
+
+        var falas = AgrupadorDeFalas.Agrupar(baloes);
+
+        Assert.Single(falas);
+        Assert.Equal(6, falas[0].Baloes.Count);
+    }
+
+    [Fact]
+    public void O_texto_da_fala_junta_os_baloes_na_ordem()
+    {
+        // "o bourbon" sozinho nao diz nada; junto, diz tudo.
+        var falas = AgrupadorDeFalas.Agrupar(new[]
+        {
+            Balao(Autor.Cliente, "vi o cafe de voces", 0),
+            Balao(Autor.Cliente, "o bourbon", 1),
+        });
+
+        Assert.Equal("vi o cafe de voces\no bourbon", falas[0].Texto);
+    }
+
+    [Fact]
+    public void O_instante_da_fala_e_o_do_ultimo_balao()
+    {
+        // A fala so esta completa quando o silencio confirma que acabou. Usar a
+        // primeira faria o "sumiu ha 4 dias" contar a partir do "bom dia".
+        var falas = AgrupadorDeFalas.Agrupar(new[]
+        {
+            Balao(Autor.Cliente, "bom dia", 0),
+            Balao(Autor.Cliente, "vou pensar", 5),
+        });
+
+        Assert.Equal(T0.AddSeconds(5), falas[0].Quando);
+    }
+
+    [Fact]
+    public void Silencio_maior_que_a_janela_abre_outra_fala()
+    {
+        var falas = AgrupadorDeFalas.Agrupar(new[]
+        {
+            Balao(Autor.Cliente, "qual o valor?", 0),
+            Balao(Autor.Cliente, "vou pensar", 60),
+        });
+
+        Assert.Equal(2, falas.Count);
+    }
+
+    [Fact]
+    public void Troca_de_falante_quebra_mesmo_dentro_da_janela()
+    {
+        // O vendedor respondendo no meio encerra a fala do cliente, ainda que a
+        // resposta venha em um segundo.
+        var falas = AgrupadorDeFalas.Agrupar(new[]
+        {
+            Balao(Autor.Cliente, "qual o valor?", 0),
+            Balao(Autor.Vendedor, "bom dia! o Bourbon sai a", 1),
+            Balao(Autor.Cliente, "puxado hein", 2),
+        });
+
+        Assert.Equal(3, falas.Count);
+        Assert.Equal(Autor.Cliente, falas[0].Autor);
+        Assert.Equal(Autor.Vendedor, falas[1].Autor);
+        Assert.Equal(Autor.Cliente, falas[2].Autor);
+    }
+
+    [Fact]
+    public void A_janela_e_configuravel()
+    {
+        // Conversa de suporte tem outro ritmo que conversa de venda.
+        var baloes = new[]
+        {
+            Balao(Autor.Cliente, "a", 0),
+            Balao(Autor.Cliente, "b", 30),
+        };
+
+        Assert.Equal(2, AgrupadorDeFalas.Agrupar(baloes).Count);
+        Assert.Single(AgrupadorDeFalas.Agrupar(baloes, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void Baloes_fora_de_ordem_sao_ordenados_antes_de_agrupar()
+    {
+        // Celular sem sinal entrega fora de ordem, e agrupar na ordem errada
+        // juntaria baloes que estao a minutos de distancia.
+        var falas = AgrupadorDeFalas.Agrupar(new[]
+        {
+            Balao(Autor.Cliente, "segundo", 1),
+            Balao(Autor.Cliente, "primeiro", 0),
+        });
+
+        Assert.Single(falas);
+        Assert.Equal("primeiro\nsegundo", falas[0].Texto);
+    }
+
+    [Fact]
+    public void Conversa_vazia_nao_produz_fala()
+    {
+        Assert.Empty(AgrupadorDeFalas.Agrupar(Array.Empty<Mensagem>()));
+    }
+
+    [Fact]
+    public void A_fala_guarda_os_ids_para_o_sinal_poder_citar_o_balao_exato()
+    {
+        // O dossie cita a FALA que originou o sinal, e a fala tem varios baloes:
+        // sem os ids, a citacao apontaria para o bloco inteiro em vez da frase.
+        var baloes = new[] { Balao(Autor.Cliente, "a", 0), Balao(Autor.Cliente, "b", 1) };
+
+        var fala = AgrupadorDeFalas.Agrupar(baloes)[0];
+
+        Assert.Equal(baloes.Select(b => b.Id), fala.IdsDosBaloes);
+    }
+}


### PR DESCRIPTION
Closes #19.

## Critério de aceite

- [x] **Janela configurável** — padrão de 10s de silêncio
- [x] **Mensagens do mesmo falante dentro da janela viram uma fala**
- [x] **Timestamp da fala é o da última mensagem**
- [x] **6 mensagens em 4s produzem 1 fala** — teste com o cenário do café da própria issue

## Decisões

**Troca de falante quebra sempre**, mesmo dentro da janela: o vendedor respondendo encerra a fala do cliente, ainda que responda em um segundo.

**O instante é o do último balão.** A fala só está completa quando o silêncio confirma que acabou. Usar o primeiro faria o "sumiu há 4 dias" contar a partir do "bom dia" em vez do "vou pensar" — e o esfriamento é justamente o sinal que a tela mostra.

**Balões são ordenados por envio antes de agrupar.** Celular sem sinal entrega fora de ordem, e agrupar na ordem de chegada juntaria balões que estão a minutos de distância.

**A `Fala` guarda os ids dos balões**, porque o sinal do dossiê precisa citar a frase exata e não o bloco inteiro — a citação existe para o vendedor conferir com os próprios olhos.

## Por que o ganho é em múltiplo direto

Quatro balões viravam quatro análises e quatro custos. Além do dinheiro, o contexto melhora: "o bourbon" sozinho não diz nada; junto de "vi o café de vocês" e "qual o valor do kg?", diz tudo.

61 testes em Release, 0 avisos.
