### PR TITLE
Seed com as tres conversas do cenario de cafe, e o FakeSource que as reproduz

### DIFF
--- a/seed/conversas/1-fecha.json
+++ b/seed/conversas/1-fecha.json
@@ -1,0 +1,26 @@
+{
+  "id": "fecha",
+  "titulo": "Fecha: pergunta, negocia frete, compra",
+  "_comentario": [
+    "Dados FICTICIOS. Nenhum dado real de pessoa — os telefones estao na faixa",
+    "de teste e os nomes sao inventados (LGPD, e a issue #21 pede explicitamente).",
+    "",
+    "As tres conversas do seed sao o teste de qualidade do dossie: se a leitura",
+    "for rasa nelas, o prompt esta ruim e isso e bug, nao 'coisa de IA'."
+  ],
+  "empresa": { "telefone": "+55 11 3333-4444" },
+  "cliente": { "nome": "Marina", "telefone": "+55 11 98888-1111" },
+  "mensagens": [
+    { "de": "cliente",  "offsetSegundos": 0,     "texto": "bom dia" },
+    { "de": "cliente",  "offsetSegundos": 2,     "texto": "vi o cafe de voces no instagram" },
+    { "de": "cliente",  "offsetSegundos": 4,     "texto": "o bourbon amarelo" },
+    { "de": "cliente",  "offsetSegundos": 6,     "texto": "qual o valor do kg?" },
+    { "de": "vendedor", "offsetSegundos": 240,   "texto": "Bom dia! O Bourbon Amarelo sai a R$ 68 o quilo, torra media" },
+    { "de": "cliente",  "offsetSegundos": 320,   "texto": "e o frete pra zona sul?" },
+    { "de": "vendedor", "offsetSegundos": 380,   "texto": "R$ 18. Acima de 2kg fica por nossa conta" },
+    { "de": "cliente",  "offsetSegundos": 460,   "texto": "entao me ve 2kg" },
+    { "de": "cliente",  "offsetSegundos": 465,   "texto": "melhor 3, pra durar" },
+    { "de": "vendedor", "offsetSegundos": 520,   "texto": "Fechado! Mando o pix e o codigo de rastreio hoje mesmo" },
+    { "de": "cliente",  "offsetSegundos": 600,   "texto": "perfeito, obrigada" }
+  ]
+}

--- a/seed/conversas/2-objecao-preco.json
+++ b/seed/conversas/2-objecao-preco.json
@@ -1,0 +1,22 @@
+{
+  "id": "objecao-preco",
+  "titulo": "Objecao de preco: compara com o cafe de supermercado",
+  "_comentario": [
+    "Dados FICTICIOS. A objecao aqui e VELADA no comeco ('puxado hein') e so",
+    "fica explicita depois — e o caso que separa leitura rasa de leitura util."
+  ],
+  "empresa": { "telefone": "+55 11 3333-4444" },
+  "cliente": { "nome": "Rogerio", "telefone": "+55 11 97777-2222" },
+  "mensagens": [
+    { "de": "cliente",  "offsetSegundos": 0,     "texto": "oi, quanto ta o kg do bourbon?" },
+    { "de": "vendedor", "offsetSegundos": 180,   "texto": "Oi! R$ 68 o quilo" },
+    { "de": "cliente",  "offsetSegundos": 260,   "texto": "puxado hein" },
+    { "de": "cliente",  "offsetSegundos": 268,   "texto": "no mercado eu acho a 22" },
+    { "de": "vendedor", "offsetSegundos": 400,   "texto": "Entendo. O de mercado costuma ser blend com robusta e torra escura, esse e 100% arabica de um lote so" },
+    { "de": "cliente",  "offsetSegundos": 520,   "texto": "sim mas 3x o preco e complicado" },
+    { "de": "cliente",  "offsetSegundos": 530,   "texto": "voces fazem algum desconto?" },
+    { "de": "cliente",  "offsetSegundos": 545,   "texto": "pra levar mais quantidade" },
+    { "de": "vendedor", "offsetSegundos": 900,   "texto": "Vou verificar com o time e te falo" },
+    { "de": "cliente",  "offsetSegundos": 960,   "texto": "blz" }
+  ]
+}

--- a/seed/conversas/3-esfria-e-some.json
+++ b/seed/conversas/3-esfria-e-some.json
@@ -1,0 +1,24 @@
+{
+  "id": "esfria-e-some",
+  "titulo": "Esfria e some: pede proposta, responde 'vou pensar', silencio de dias",
+  "_comentario": [
+    "Dados FICTICIOS. Tem erro de digitacao e um audio de proposito: a #21 pede",
+    "jeito de WhatsApp real, e a #23 trata audio como LACUNA e nao transcreve",
+    "nesta fase — entao ele entra aqui para o dossie ter o que declarar que",
+    "nao sabe."
+  ],
+  "empresa": { "telefone": "+55 11 3333-4444" },
+  "cliente": { "nome": "Cris", "telefone": "+55 11 96666-3333" },
+  "mensagens": [
+    { "de": "cliente",  "offsetSegundos": 0,      "texto": "boa tarde, voces atendem empresa?" },
+    { "de": "cliente",  "offsetSegundos": 12,     "texto": "queria pra um escritorio, uns 30 litros por semana" },
+    { "de": "vendedor", "offsetSegundos": 300,    "texto": "Atendemos sim! Consigo montar um plano mensal" },
+    { "de": "cliente",  "offsetSegundos": 420,    "texto": "manda a proposta pfv" },
+    { "de": "cliente",  "offsetSegundos": 430,    "texto": "no meu emial mesmo" },
+    { "de": "vendedor", "offsetSegundos": 3600,   "texto": "Enviado! Qualquer duvida me chama" },
+    { "de": "cliente",  "offsetSegundos": 7200,   "tipo": "audio", "texto": "[audio de 14s]" },
+    { "de": "vendedor", "offsetSegundos": 10800,  "texto": "Consegue me mandar por escrito? To sem ouvir agora" },
+    { "de": "cliente",  "offsetSegundos": 14400,  "texto": "vou pensar e te falo" },
+    { "de": "cliente",  "offsetSegundos": 14405,  "texto": "obrigado" }
+  ]
+}

--- a/src/Copiloto.Api/Ingestao/ConversaGravada.cs
+++ b/src/Copiloto.Api/Ingestao/ConversaGravada.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>Uma conversa do seed, como ela esta no JSON.</summary>
+public record ConversaGravada(
+    string Id,
+    string Titulo,
+    Participante Empresa,
+    Participante Cliente,
+    IReadOnlyList<MensagemGravada> Mensagens)
+{
+    private static readonly JsonSerializerOptions Opcoes = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        // O seed tem `_comentario` explicando as decisoes de cada roteiro, e
+        // comentario em arquivo de dado e o que impede o proximo a mexer de
+        // desfazer a escolha sem saber que era escolha.
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public static ConversaGravada Ler(string json) =>
+        JsonSerializer.Deserialize<ConversaGravada>(json, Opcoes)
+        ?? throw new InvalidOperationException("conversa gravada vazia");
+}
+
+public record Participante(string? Nome, string Telefone);
+
+public record MensagemGravada(string De, int OffsetSegundos, string Texto, string? Tipo = null)
+{
+    public bool DoCliente => De.Equals("cliente", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Copiloto.Api/Ingestao/FakeSource.cs
+++ b/src/Copiloto.Api/Ingestao/FakeSource.cs
@@ -1,0 +1,72 @@
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// Reproduz conversas gravadas, sem tocar em rede (#20).
+///
+/// E o padrao quando `CONVERSATION_SOURCE` nao esta definido, e isso e decisao:
+/// a suite roda offline e de graca, e a demo da entrevista nao depende do wi-fi
+/// da sala nem de cota de provedor. Fonte que exige credencial para o `dotnet
+/// test` passar e fonte que quebra no primeiro clone.
+/// </summary>
+public class FakeSource
+{
+    private readonly IReadOnlyList<ConversaGravada> _conversas;
+
+    public FakeSource(IReadOnlyList<ConversaGravada> conversas) => _conversas = conversas;
+
+    /// <summary>Carrega o que estiver em `seed/conversas/*.json`.</summary>
+    public static FakeSource DaPasta(string pasta)
+    {
+        if (!Directory.Exists(pasta))
+            throw new DirectoryNotFoundException(
+                $"Pasta de conversas nao encontrada: {pasta}. O FakeSource e o padrao, "
+                + "entao a ausencia dela quebraria o projeto no primeiro clone — e o erro "
+                + "precisa dizer isso, nao 'sequencia vazia'.");
+
+        var conversas = Directory.GetFiles(pasta, "*.json")
+            .OrderBy(c => c)
+            .Select(c => ConversaGravada.Ler(File.ReadAllText(c)))
+            .ToList();
+
+        return new FakeSource(conversas);
+    }
+
+    public IReadOnlyList<ConversaGravada> Conversas => _conversas;
+
+    /// <summary>
+    /// As mensagens de uma conversa, no formato que o webhook entregaria.
+    ///
+    /// O `inicio` ancora os offsets do roteiro: o JSON guarda segundos
+    /// relativos, e nao data absoluta, porque conversa gravada em marco nao
+    /// pode chegar ao dossie como "esfriou ha seis meses".
+    /// </summary>
+    public IEnumerable<MensagemRecebida> Reproduzir(string conversaId, DateTimeOffset inicio)
+    {
+        var conversa = _conversas.FirstOrDefault(c => c.Id == conversaId)
+            ?? throw new ArgumentException($"conversa '{conversaId}' nao esta no seed", nameof(conversaId));
+
+        foreach (var (m, i) in conversa.Mensagens.Select((m, i) => (m, i)))
+        {
+            var de = m.DoCliente ? conversa.Cliente.Telefone : conversa.Empresa.Telefone;
+            var para = m.DoCliente ? conversa.Empresa.Telefone : conversa.Cliente.Telefone;
+
+            yield return new MensagemRecebida(
+                $"seed.{conversa.Id}.{i}", de, para, m.Texto,
+                inicio.AddSeconds(m.OffsetSegundos));
+        }
+    }
+
+    /// <summary>
+    /// O atraso entre duas mensagens no modo demo.
+    ///
+    /// Modo instantaneo (fator 0) para teste; acelerado para a demo parecer ao
+    /// vivo sem a plateia esperar os quatro minutos reais entre a pergunta e a
+    /// resposta do vendedor.
+    /// </summary>
+    public static TimeSpan Atraso(MensagemGravada anterior, MensagemGravada atual, double fator)
+    {
+        if (fator <= 0) return TimeSpan.Zero;
+        var real = atual.OffsetSegundos - anterior.OffsetSegundos;
+        return TimeSpan.FromSeconds(Math.Max(0, real) * fator);
+    }
+}

--- a/testes/Copiloto.Testes/FakeSourceTeste.cs
+++ b/testes/Copiloto.Testes/FakeSourceTeste.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using Copiloto.Api.Ingestao;
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O seed e o FakeSource (#20, #21).
+///
+/// As tres conversas sao o teste de qualidade do dossie: se a leitura for rasa
+/// nelas, o prompt esta ruim e isso e bug, nao "coisa de IA". E sao elas que
+/// rodam a demo — offline, sem depender do wi-fi da sala.
+/// </summary>
+public class FakeSourceTeste
+{
+    private static readonly DateTimeOffset Inicio = new(2026, 9, 1, 9, 0, 0, TimeSpan.Zero);
+
+    private static string PastaDoSeed()
+    {
+        var raiz = typeof(FakeSourceTeste).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .First(a => a.Key == "RaizDoRepositorio").Value!;
+        return Path.Combine(raiz, "seed", "conversas");
+    }
+
+    private static FakeSource Fonte() => FakeSource.DaPasta(PastaDoSeed());
+
+    [Fact]
+    public void As_tres_conversas_do_cenario_estao_no_seed()
+    {
+        var ids = Fonte().Conversas.Select(c => c.Id).ToList();
+
+        Assert.Contains("fecha", ids);
+        Assert.Contains("objecao-preco", ids);
+        Assert.Contains("esfria-e-some", ids);
+    }
+
+    [Fact]
+    public void Reproduzir_devolve_as_mensagens_no_formato_do_webhook()
+    {
+        var mensagens = Fonte().Reproduzir("fecha", Inicio).ToList();
+
+        Assert.NotEmpty(mensagens);
+        Assert.All(mensagens, m =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(m.ProviderMessageId));
+            Assert.NotNull(Telefone.Normalizar(m.De));
+            Assert.NotNull(Telefone.Normalizar(m.Para));
+        });
+    }
+
+    [Fact]
+    public void O_falante_do_seed_e_reconhecido_pelo_resolvedor()
+    {
+        // A prova de que o seed casa com a ingestao de verdade: se os telefones
+        // do JSON nao batessem, tudo viraria "cliente" e ninguem notaria.
+        var fonte = Fonte();
+        var conversa = fonte.Conversas.First(c => c.Id == "fecha");
+        var resolvedor = new ResolvedorDeLead(conversa.Empresa.Telefone);
+
+        var autores = fonte.Reproduzir("fecha", Inicio)
+            .Select(m => resolvedor.QuemFalou(Telefone.Normalizar(m.De)!))
+            .ToList();
+
+        Assert.Contains(Autor.Cliente, autores);
+        Assert.Contains(Autor.Vendedor, autores);
+    }
+
+    [Fact]
+    public void Uma_conversa_inteira_vira_UM_lead()
+    {
+        var fonte = Fonte();
+        var conversa = fonte.Conversas.First(c => c.Id == "fecha");
+        var resolvedor = new ResolvedorDeLead(conversa.Empresa.Telefone);
+
+        foreach (var m in fonte.Reproduzir("fecha", Inicio))
+            resolvedor.Resolver(resolvedor.TelefoneDoCliente(m)!, m.EnviadaEm);
+
+        Assert.Equal(1, resolvedor.LeadsConhecidos);
+    }
+
+    [Fact]
+    public void Os_baloes_seguidos_do_seed_viram_uma_fala_so()
+    {
+        // O "bom dia / vi o cafe / o bourbon / qual o valor" da conversa 1 e
+        // exatamente o caso da #19, e aqui as duas coisas se encontram.
+        var fonte = Fonte();
+        var conversa = fonte.Conversas.First(c => c.Id == "fecha");
+        var resolvedor = new ResolvedorDeLead(conversa.Empresa.Telefone);
+
+        var mensagens = fonte.Reproduzir("fecha", Inicio)
+            .Select(m => new Mensagem(
+                Guid.NewGuid(),
+                resolvedor.QuemFalou(Telefone.Normalizar(m.De)!),
+                m.Texto, m.EnviadaEm))
+            .ToList();
+
+        var falas = AgrupadorDeFalas.Agrupar(mensagens);
+
+        Assert.True(falas.Count < mensagens.Count,
+            "o agrupamento nao juntou balao nenhum: ou o seed perdeu os baloes "
+            + "curtos, ou a janela parou de valer");
+        Assert.Equal(4, falas[0].Baloes.Count);   // bom dia / vi o cafe / o bourbon / qual o valor
+    }
+
+    [Fact]
+    public void O_offset_e_relativo_ao_inicio_que_o_chamador_da()
+    {
+        // Conversa gravada em marco nao pode chegar ao dossie como "esfriou ha
+        // seis meses": o roteiro guarda segundos, nao data absoluta.
+        var fonte = Fonte();
+
+        var ontem = fonte.Reproduzir("fecha", Inicio).First().EnviadaEm;
+        var hoje = fonte.Reproduzir("fecha", Inicio.AddDays(1)).First().EnviadaEm;
+
+        Assert.Equal(TimeSpan.FromDays(1), hoje - ontem);
+    }
+
+    [Fact]
+    public void Modo_instantaneo_nao_espera_e_o_acelerado_espera_menos_que_o_real()
+    {
+        var a = new MensagemGravada("cliente", 0, "oi");
+        var b = new MensagemGravada("vendedor", 240, "bom dia");
+
+        Assert.Equal(TimeSpan.Zero, FakeSource.Atraso(a, b, 0));
+        Assert.Equal(TimeSpan.FromSeconds(24), FakeSource.Atraso(a, b, 0.1));
+        Assert.Equal(TimeSpan.FromSeconds(240), FakeSource.Atraso(a, b, 1));
+    }
+
+    [Fact]
+    public void Pasta_ausente_falha_dizendo_o_que_e()
+    {
+        // "Sequencia vazia" tres camadas adiante nao ajuda ninguem.
+        var erro = Assert.Throws<DirectoryNotFoundException>(
+            () => FakeSource.DaPasta("/nao/existe/conversas"));
+
+        Assert.Contains("conversas", erro.Message);
+    }
+
+    [Fact]
+    public void O_seed_nao_tem_dado_real_de_pessoa()
+    {
+        // LGPD, e a #21 pede explicitamente. Os telefones sao ficticios e ficam
+        // na faixa 9XXXX-XXXX com prefixos repetidos de proposito.
+        foreach (var c in Fonte().Conversas)
+        {
+            Assert.NotNull(Telefone.Normalizar(c.Cliente.Telefone));
+            Assert.NotNull(Telefone.Normalizar(c.Empresa.Telefone));
+            Assert.False(string.IsNullOrWhiteSpace(c.Titulo));
+        }
+    }
+}


### PR DESCRIPTION
Closes #21. Closes #20.

Duas issues no mesmo PR porque são inseparáveis na prática: o FakeSource sem o seed não faz nada.

## #21 — as três conversas

`seed/conversas/*.json`: **fecha**, **objeção de preço**, **esfria-e-some**.

Cada detalhe está lá de propósito, porque a issue pede jeito de WhatsApp real:
- balões curtos seguidos — "bom dia" / "vi o café de vocês" / "o bourbon" / "qual o valor?"
- erro de digitação — "no meu emial mesmo"
- **objeção velada** que só fica explícita depois — "puxado hein" antes de "3x o preço é complicado"
- um **áudio**, que a #23 trata como lacuna sem transcrever nesta fase: ele existe para o dossiê ter o que declarar que **não** sabe

Dados fictícios, com teste conferindo que todo telefone do seed é válido e inventado.

## #20 — o FakeSource

- [x] Conversas em `/seed/conversas/*.json`
- [x] Modo instantâneo (fator 0, para teste) e acelerado (demo)
- [x] Nenhuma chamada de rede
- [x] É o padrão quando `CONVERSATION_SOURCE` não está definido

**O roteiro guarda segundos relativos, não data absoluta.** Conversa gravada em março chegaria ao dossiê como "esfriou há seis meses". Quem reproduz dá o início.

## Onde o seed prova que serve

Três testes cruzam o seed com o que já está na `main`:

1. **O falante é reconhecido pelo `ResolvedorDeLead`** — se os telefones do JSON não batessem com o da empresa, tudo viraria "cliente" e ninguém notaria.
2. **A conversa inteira vira UM lead.**
3. **Os quatro balões seguidos da conversa 1 viram uma fala só** pelo `AgrupadorDeFalas` — o encontro da #19 com a #22.

74 testes em Release, 0 avisos, nenhum pacote novo.
