### PR TITLE
PII Shield, e um gate que reprova o build quando dado pessoal escapa

### DIFF
--- a/src/Copiloto.Api/Seguranca/DetectorDePii.cs
+++ b/src/Copiloto.Api/Seguranca/DetectorDePii.cs
@@ -1,0 +1,62 @@
+using System.Text.RegularExpressions;
+
+namespace Copiloto.Api.Seguranca;
+
+/// <summary>
+/// Procura dado pessoal no que JA passou pelo escudo. Independente dele.
+///
+/// A primeira versao reusava os padroes do `EscudoDePii`, com o argumento de
+/// que dois detectores poderiam divergir. O argumento estava errado, e o teste
+/// que sabota o escudo provou: desligando o padrao de telefone do escudo, o
+/// gate continuou VERDE — porque o detector deixou de procurar exatamente o que
+/// o escudo deixou de mascarar.
+///
+/// Compartilhar os padroes torna o gate cego a falha mais provavel, que e a de
+/// COBERTURA: alguem escreve um regex que nao pega um formato, e nada acusa.
+/// Um gate de seguranca que so encontra o que o proprio codigo ja sabe procurar
+/// nao e gate, e eco.
+///
+/// Por isso aqui os padroes sao proprios e deliberadamente MAIS AMPLOS. Falso
+/// positivo custa uma investigacao; falso negativo custa dado pessoal do
+/// cliente na rede de terceiro.
+/// </summary>
+public static class DetectorDePii
+{
+    private static readonly (string Tipo, Regex Padrao)[] Suspeitas =
+    [
+        // Qualquer coisa com arroba entre caracteres nao-brancos.
+        ("possivel e-mail", new Regex(@"\S+@\S+", RegexOptions.Compiled)),
+
+        // Sequencias longas de digitos, aceitando pontuacao no meio. Nao tenta
+        // dizer se e CPF, telefone ou CEP: na saida, digito agrupado e suspeito
+        // ate prova em contrario.
+        ("sequencia numerica longa",
+            new Regex(@"(?<![\w\[])(?:\d[\s.\-()]?){8,}\d(?![\w\]])", RegexOptions.Compiled)),
+
+        // Logradouro seguido de qualquer coisa: mais amplo que o do escudo, que
+        // exige numero.
+        ("possivel endereco",
+            new Regex(@"\b(?:rua|av\.?|avenida|travessa|alameda|pra[cç]a|rodovia|estrada)\s+\w",
+                      RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+    ];
+
+    /// <summary>
+    /// O que ainda parece dado pessoal. Vazio e o esperado depois do escudo.
+    ///
+    /// Marcadores (`[TEL_1]`) sao ignorados de proposito: eles sao o RESULTADO
+    /// do escudo, e acusa-los faria o gate reprovar o proprio conserto.
+    /// </summary>
+    public static IReadOnlyList<string> Suspeito(string? texto)
+    {
+        if (string.IsNullOrEmpty(texto)) return [];
+
+        var semMarcadores = Regex.Replace(texto, @"\[[A-Z]+_\d+\]", " ");
+
+        var achados = new List<string>();
+        foreach (var (tipo, padrao) in Suspeitas)
+            foreach (Match m in padrao.Matches(semMarcadores))
+                achados.Add($"{tipo}: {m.Value.Trim()}");
+
+        return achados;
+    }
+}

--- a/src/Copiloto.Api/Seguranca/EscudoDePii.cs
+++ b/src/Copiloto.Api/Seguranca/EscudoDePii.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+
+namespace Copiloto.Api.Seguranca;
+
+/// <summary>
+/// Troca dado pessoal por marcador antes de a carga sair da rede, e remonta na
+/// volta (#43).
+///
+/// Conversa com cliente e dado pessoal, e mandar para modelo de terceiro e
+/// TRANSFERENCIA de dado pessoal sob a LGPD. O marcador nao elimina a
+/// transferencia; reduz o que atravessa.
+///
+/// E PSEUDONIMIZACAO, NAO ANONIMIZACAO (#83). O mapa que remonta fica do nosso
+/// lado, entao o texto continua sendo dado pessoal sob a LGPD — anonimo seria o
+/// que nao da para reverter nem com informacao adicional, e aqui da, por
+/// construcao. Chamar de anonimizacao seria a base legal errada.
+/// </summary>
+public class EscudoDePii
+{
+    // A ORDEM importa e nao e alfabetica: o que e mais especifico vai primeiro.
+    // E-mail antes de tudo porque contem ponto e digito e seria retalhado pelos
+    // outros; CPF antes de telefone porque os dois tem onze digitos.
+    private static readonly (string Tipo, Regex Padrao)[] Padroes =
+    [
+        ("EMAIL", new Regex(@"\b[\w.+-]+@[\w-]+\.[\w.-]+\b", RegexOptions.Compiled)),
+        ("CPF",   new Regex(@"\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b", RegexOptions.Compiled)),
+        ("CEP",   new Regex(@"\b\d{5}-\d{3}\b", RegexOptions.Compiled)),
+        ("TEL",   new Regex(@"(?:\+55\s?)?\(?\b\d{2}\)?[\s.-]?9?\d{4}[\s.-]?\d{4}\b",
+                            RegexOptions.Compiled)),
+        // Endereco: logradouro + numero. Nao pega tudo, e a issue nao pede que
+        // pegue — pega a forma que aparece em conversa de venda ("manda pra Rua
+        // X, 123").
+        ("END",   new Regex(@"\b(?:rua|av\.?|avenida|travessa|alameda|praca|rodovia)\s+[^,\n]{2,60},\s*\d+\w*",
+                            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+    ];
+
+    /// <summary>
+    /// Mascara o texto. Devolve o texto com marcadores e o mapa para remontar.
+    ///
+    /// O mesmo valor recebe SEMPRE o mesmo marcador dentro de uma carga: o
+    /// cliente que repete o telefone em tres falas precisa aparecer como uma
+    /// pessoa so, senao o modelo le tres pessoas e o dossie inventa relacao
+    /// entre elas.
+    /// </summary>
+    public static (string Texto, IReadOnlyDictionary<string, string> Mapa) Mascarar(string? texto)
+    {
+        if (string.IsNullOrEmpty(texto))
+            return (texto ?? "", new Dictionary<string, string>());
+
+        var mapa = new Dictionary<string, string>();
+        var jaVisto = new Dictionary<string, string>();
+        var contador = new Dictionary<string, int>();
+        var saida = texto;
+
+        foreach (var (tipo, padrao) in Padroes)
+        {
+            saida = padrao.Replace(saida, m =>
+            {
+                var achado = m.Value;
+
+                // CPF e celular tem onze digitos. So o digito verificador
+                // desempata, e errar aqui vaza o CPF ou apaga o telefone.
+                if (tipo == "CPF" && !EhCpfValido(achado)) return achado;
+
+                if (jaVisto.TryGetValue(achado, out var marcadorAntigo))
+                    return marcadorAntigo;
+
+                contador[tipo] = contador.GetValueOrDefault(tipo) + 1;
+                var marcador = $"[{tipo}_{contador[tipo]}]";
+
+                jaVisto[achado] = marcador;
+                mapa[marcador] = achado;
+                return marcador;
+            });
+        }
+
+        return (saida, mapa);
+    }
+
+    /// <summary>
+    /// Remonta o texto que voltou do modelo.
+    ///
+    /// Marcador que o modelo inventou e que nao esta no mapa fica como esta: o
+    /// certo e o texto sair com `[TEL_9]` visivel, que denuncia o problema, e
+    /// nao com um telefone de outra pessoa no lugar.
+    /// </summary>
+    public static string Remontar(string? texto, IReadOnlyDictionary<string, string> mapa)
+    {
+        if (string.IsNullOrEmpty(texto)) return texto ?? "";
+
+        foreach (var (marcador, valor) in mapa)
+            texto = texto.Replace(marcador, valor);
+
+        return texto;
+    }
+
+    /// <summary>Digito verificador. E o que separa CPF de celular.</summary>
+    private static bool EhCpfValido(string bruto)
+    {
+        var d = Regex.Replace(bruto, @"\D", "");
+        if (d.Length != 11 || d.Distinct().Count() == 1) return false;
+
+        for (var casa = 9; casa < 11; casa++)
+        {
+            var soma = 0;
+            for (var i = 0; i < casa; i++)
+                soma += (d[i] - '0') * (casa + 1 - i);
+
+            var resto = soma * 10 % 11 % 10;
+            if (resto != d[casa] - '0') return false;
+        }
+        return true;
+    }
+}

--- a/testes/Copiloto.Testes/EscudoDePiiTeste.cs
+++ b/testes/Copiloto.Testes/EscudoDePiiTeste.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using Copiloto.Api.Ingestao;
+using Copiloto.Api.Seguranca;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O PII Shield (#43), e o teste que FALHA O BUILD se dado pessoal vazar.
+///
+/// Conversa com cliente e dado pessoal, e mandar para modelo de terceiro e
+/// transferencia sob a LGPD. O teste que quebra o build e o que transforma a
+/// intencao em garantia.
+/// </summary>
+public class EscudoDePiiTeste
+{
+    [Fact]
+    public void Mascara_email_no_meio_da_frase()
+    {
+        // "Cobre PII no meio de frase, nao so em campo estruturado": em conversa
+        // de WhatsApp nao existe campo, existe frase.
+        var (texto, mapa) = EscudoDePii.Mascarar("manda pro meu email joao.silva@empresa.com.br pfv");
+
+        Assert.DoesNotContain("joao.silva@empresa.com.br", texto);
+        Assert.Contains("[EMAIL_1]", texto);
+        Assert.Equal("joao.silva@empresa.com.br", mapa["[EMAIL_1]"]);
+    }
+
+    [Theory]
+    [InlineData("meu cpf e 529.982.247-25")]
+    [InlineData("cpf 52998224725 pode faturar")]
+    public void Mascara_CPF_formatado_e_sem_formatacao(string frase)
+    {
+        var (texto, _) = EscudoDePii.Mascarar(frase);
+
+        Assert.Contains("[CPF_1]", texto);
+        Assert.DoesNotContain("52998224725", texto.Replace(".", "").Replace("-", ""));
+    }
+
+    [Fact]
+    public void Numero_de_onze_digitos_que_nao_e_CPF_valido_nao_vira_CPF()
+    {
+        // CPF e celular tem onze digitos, e so o digito verificador desempata.
+        // Errar aqui vaza o CPF ou apaga o telefone.
+        var (texto, _) = EscudoDePii.Mascarar("meu zap e 11987654321");
+
+        Assert.DoesNotContain("[CPF_", texto);
+        Assert.Contains("[TEL_1]", texto);
+    }
+
+    [Theory]
+    [InlineData("liga no (11) 98765-4321")]
+    [InlineData("meu numero: +55 11 98765-4321")]
+    [InlineData("chama no 11987654321")]
+    public void Mascara_telefone_em_varios_formatos(string frase)
+    {
+        var (texto, _) = EscudoDePii.Mascarar(frase);
+        Assert.Contains("[TEL_1]", texto);
+    }
+
+    [Fact]
+    public void Mascara_CEP_e_endereco()
+    {
+        var (texto, _) = EscudoDePii.Mascarar("entrega na Rua das Flores, 123 - CEP 01310-100");
+
+        Assert.Contains("[END_1]", texto);
+        Assert.Contains("[CEP_1]", texto);
+        Assert.DoesNotContain("Flores", texto);
+    }
+
+    [Fact]
+    public void O_mesmo_valor_repetido_recebe_o_mesmo_marcador()
+    {
+        // O cliente que repete o telefone em tres falas precisa aparecer como
+        // UMA pessoa: com marcadores diferentes, o modelo le tres pessoas e o
+        // dossie inventa relacao entre elas.
+        var (texto, mapa) = EscudoDePii.Mascarar(
+            "liga no 11987654321, se nao atender tenta 11987654321 de novo");
+
+        Assert.Equal(2, System.Text.RegularExpressions.Regex.Matches(texto, @"\[TEL_1\]").Count);
+        Assert.Single(mapa);
+    }
+
+    [Fact]
+    public void Remontar_devolve_o_texto_original()
+    {
+        var original = "manda pro joao@empresa.com ou liga no (11) 98765-4321";
+        var (mascarado, mapa) = EscudoDePii.Mascarar(original);
+
+        Assert.Equal(original, EscudoDePii.Remontar(mascarado, mapa));
+    }
+
+    [Fact]
+    public void Marcador_inventado_pelo_modelo_nao_vira_dado_de_outra_pessoa()
+    {
+        // O certo e sair com `[TEL_9]` visivel, que denuncia o problema, e nao
+        // com o telefone de outro cliente no lugar.
+        var (_, mapa) = EscudoDePii.Mascarar("liga no 11987654321");
+
+        var resposta = EscudoDePii.Remontar("confirmar com [TEL_9]", mapa);
+
+        Assert.Contains("[TEL_9]", resposta);
+    }
+
+    // ---------------------------------------------------------------------
+    // O teste que FALHA O BUILD. E o criterio de aceite da issue.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Nada_do_seed_sai_com_dado_pessoal_apos_o_escudo()
+    {
+        // Roda sobre as conversas REAIS do seed, e nao sobre exemplo inventado
+        // no proprio teste: exemplo escrito para passar passa sempre.
+        var raiz = typeof(EscudoDePiiTeste).Assembly
+            .GetCustomAttributes<System.Reflection.AssemblyMetadataAttribute>()
+            .First(a => a.Key == "RaizDoRepositorio").Value!;
+        var fonte = FakeSource.DaPasta(Path.Combine(raiz, "seed", "conversas"));
+
+        var vazamentos = new List<string>();
+        foreach (var conversa in fonte.Conversas)
+        {
+            foreach (var m in fonte.Reproduzir(conversa.Id, DateTimeOffset.UtcNow))
+            {
+                // O que sairia para o modelo: o texto da fala E os telefones da
+                // troca, que sao PII tanto quanto o corpo da mensagem.
+                var carga = $"{m.De} {m.Para} {m.Texto}";
+                var (mascarado, _) = EscudoDePii.Mascarar(carga);
+
+                vazamentos.AddRange(DetectorDePii.Suspeito(mascarado)
+                    .Select(v => $"{conversa.Id}/{m.ProviderMessageId}: {v}"));
+            }
+        }
+
+        Assert.True(vazamentos.Count == 0,
+            "PII saiu da rede sem mascara — isto e transferencia de dado pessoal "
+            + "sob a LGPD, e por isso reprova o build:\n  "
+            + string.Join("\n  ", vazamentos));
+    }
+
+    [Fact]
+    public void O_detector_enxerga_PII_de_verdade()
+    {
+        // Sem isto, um erro no regex faria o teste acima passar sempre — verde
+        // por nao ter olhado, que e o pior tipo de verde num gate de seguranca.
+        var sujo = "joao@empresa.com, 11987654321, 529.982.247-25, 01310-100";
+
+        var achados = DetectorDePii.Suspeito(sujo);
+
+        Assert.Contains(achados, a => a.Contains("e-mail"));
+        Assert.Contains(achados, a => a.Contains("sequencia numerica"));
+    }
+
+    [Fact]
+    public void O_detector_e_independente_do_escudo()
+    {
+        // A razao de existir do `DetectorDePii`, e ela foi paga: enquanto o
+        // gate reusava os padroes do escudo, desligar um padrao la deixava o
+        // gate VERDE — ele parava de procurar exatamente o que o escudo parava
+        // de mascarar. Gate que so acha o que o proprio codigo ja sabe procurar
+        // nao e gate, e eco.
+        //
+        // Aqui a prova: um telefone escrito num formato que o ESCUDO nao pega
+        // continua sendo acusado pelo DETECTOR.
+        const string formatoExotico = "meu contato e 11 9 8 7 6 5 4 3 2 1";
+
+        var (mascarado, _) = EscudoDePii.Mascarar(formatoExotico);
+
+        Assert.NotEmpty(DetectorDePii.Suspeito(mascarado));
+    }
+
+    [Fact]
+    public void O_marcador_do_proprio_escudo_nao_e_acusado()
+    {
+        // Senao o gate reprovaria o conserto.
+        Assert.Empty(DetectorDePii.Suspeito("confirmar [TEL_1] e [EMAIL_2] com o cliente"));
+    }
+}


### PR DESCRIPTION
Closes #43.

## Critério de aceite

- [x] Mascara CPF, telefone, e-mail, CEP e endereço
- [x] Remontagem correta na resposta
- [x] **Teste que falha o build se PII sair sem máscara**
- [x] Cobre PII no meio de frase — em conversa de WhatsApp não existe campo, existe frase

## O gate estava errado, e a sabotagem provou

A primeira versão do gate reusava os padrões do próprio escudo, com o argumento de que dois detectores poderiam divergir. **O argumento não se sustenta.**

Testei sabotando o escudo — desliguei o padrão de telefone — e o gate continuou **verde**. Porque ele parou de procurar exatamente o que o escudo parou de mascarar.

Compartilhar os padrões torna o gate cego à falha **mais provável**, que é a de cobertura: alguém escreve um regex que não pega um formato, e nada acusa. Um gate de segurança que só encontra o que o próprio código já sabe procurar não é gate, é eco.

`DetectorDePii` agora tem padrões próprios e deliberadamente **mais amplos** — falso positivo custa uma investigação, falso negativo custa dado do cliente na rede de terceiro. Refeita a sabotagem, o gate reprova e nomeia os telefones que vazariam.

## Outras decisões

**CPF e celular têm os mesmos 11 dígitos**, e só o dígito verificador desempata. Sem ele, ou o CPF vaza classificado como telefone, ou o telefone é apagado como se fosse CPF. Teste dos dois lados.

**O mesmo valor repetido recebe o mesmo marcador.** O cliente que manda o telefone em três falas precisa chegar ao modelo como uma pessoa — senão ele lê três, e o dossiê inventa relação entre elas.

**Marcador que o modelo inventou fica visível.** Melhor `[TEL_9]` na tela, que denuncia o problema, do que o telefone de outro cliente no lugar.

**É pseudonimização, não anonimização** (#83). O mapa fica do nosso lado, então o texto continua sendo dado pessoal — anônimo seria o que não dá para reverter nem com informação adicional, e aqui dá por construção. Chamar de anonimização seria escolher a base legal errada.

## Nota sobre o teste

Ele roda sobre as conversas **reais do seed**, não sobre exemplo inventado no próprio teste — exemplo escrito para passar passa sempre.

99 testes em Release, 0 avisos.
