### PR TITLE
Ficha do Cliente: o que o vendedor descobriu antes de falar

### DIFF
--- a/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
+++ b/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
@@ -1,4 +1,5 @@
 using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Fichas;
 using Copiloto.Dominio.Ia;
 using Copiloto.Dominio.Vendas;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +27,7 @@ public class CopilotoDbContext : DbContext
     public DbSet<AiInvocation> Invocacoes => Set<AiInvocation>();
     public DbSet<Conversa> Conversas => Set<Conversa>();
     public DbSet<Mensagem> Mensagens => Set<Mensagem>();
+    public DbSet<FichaCliente> Fichas => Set<FichaCliente>();
 
     protected override void OnModelCreating(ModelBuilder b) =>
         b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/FichaClienteMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/FichaClienteMap.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using Copiloto.Dominio.Fichas;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Copiloto.Api.Persistencia.Mapeamentos;
+
+public class FichaClienteMap : IEntityTypeConfiguration<FichaCliente>
+{
+    private static readonly JsonSerializerOptions Json = new();
+
+    public void Configure(EntityTypeBuilder<FichaCliente> e)
+    {
+        e.ToTable("fichas_cliente");
+        e.HasKey(f => f.Id);
+        e.Property(f => f.LeadId).IsRequired();
+        e.Property(f => f.CriadaEm).IsRequired();
+        e.Property(f => f.AtualizadaEm).IsRequired();
+
+        // Uma ficha por lead: a ficha E o que se sabe daquele cliente, e duas
+        // seriam duas versoes da verdade sem criterio de desempate.
+        e.HasIndex(f => f.LeadId).IsUnique().HasDatabaseName("ux_fichas_lead");
+
+        // Os tres blocos viram colunas na mesma tabela, e nao tabelas proprias:
+        // eles nao existem sem a ficha e nunca sao consultados sozinhos.
+        e.OwnsOne(f => f.Empresa);
+        e.OwnsOne(f => f.Pessoa);
+        e.OwnsOne(f => f.Negocio);
+
+        // O historico vai como JSON numa coluna so, por conversor.
+        //
+        // A primeira tentativa foi `OwnsMany(...).ToJson()`, que e o caminho
+        // idiomatico, e ele NAO fecha aqui: `VersaoDaFicha` tem tres records
+        // aninhados, e o EF nao consegue ligar esses parametros de construtor
+        // dentro de um owned em JSON.
+        //
+        // A saida obvia seria achatar `VersaoDaFicha` em doze campos soltos —
+        // e ela esta errada. Seria o dominio se curvando ao ORM, quando o
+        // dominio e' quem tem razao para existir. O conversor deixa o modelo
+        // como esta e paga o preco no mapeamento, que e' o lugar certo para
+        // pagar.
+        //
+        // O historico e lista de LEITURA (a tela mostra "o que mudou e quando"),
+        // nunca alvo de consulta por campo, entao JSON nao custa nada aqui.
+        var conversor = new ValueConverter<List<VersaoDaFicha>, string>(
+            v => JsonSerializer.Serialize(v, Json),
+            s => JsonSerializer.Deserialize<List<VersaoDaFicha>>(s, Json) ?? new());
+
+        // Sem o comparador, o EF compara por REFERENCIA e nunca percebe que a
+        // lista mudou — a versao nova simplesmente nao seria gravada, sem erro.
+        var comparador = new ValueComparer<List<VersaoDaFicha>>(
+            (a, b) => JsonSerializer.Serialize(a, Json) == JsonSerializer.Serialize(b, Json),
+            v => JsonSerializer.Serialize(v, Json).GetHashCode(),
+            v => JsonSerializer.Deserialize<List<VersaoDaFicha>>(
+                     JsonSerializer.Serialize(v, Json), Json)!);
+
+        e.Property<List<VersaoDaFicha>>("_historico")
+            .HasColumnName("historico")
+            .HasConversion(conversor, comparador);
+
+        e.Ignore(f => f.Historico);
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Migrations/20260901160110_FichaDoCliente.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260901160110_FichaDoCliente.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901160110_FichaDoCliente")]
+    partial class FichaDoCliente
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260901160110_FichaDoCliente.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260901160110_FichaDoCliente.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class FichaDoCliente : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "fichas_cliente",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    LeadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CriadaEm = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    AtualizadaEm = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Empresa_Ramo = table.Column<string>(type: "text", nullable: true),
+                    Empresa_Porte = table.Column<string>(type: "text", nullable: true),
+                    Empresa_Momento = table.Column<string>(type: "text", nullable: true),
+                    Empresa_ComoChegou = table.Column<string>(type: "text", nullable: true),
+                    Pessoa_Cargo = table.Column<string>(type: "text", nullable: true),
+                    Pessoa_PapelNaDecisao = table.Column<string>(type: "text", nullable: true),
+                    Pessoa_QuemMaisDecide = table.Column<string>(type: "text", nullable: true),
+                    Pessoa_EstiloObservado = table.Column<string>(type: "text", nullable: true),
+                    Negocio_ProvavelNecessidade = table.Column<string>(type: "text", nullable: true),
+                    Negocio_UsaHoje = table.Column<string>(type: "text", nullable: true),
+                    Negocio_OrcamentoEstimado = table.Column<string>(type: "text", nullable: true),
+                    Negocio_RiscoConhecido = table.Column<string>(type: "text", nullable: true),
+                    historico = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_fichas_cliente", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_fichas_lead",
+                table: "fichas_cliente",
+                column: "LeadId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "fichas_cliente");
+        }
+    }
+}

--- a/src/Copiloto.Dominio/Fichas/CamadaC2.cs
+++ b/src/Copiloto.Dominio/Fichas/CamadaC2.cs
@@ -1,0 +1,42 @@
+namespace Copiloto.Dominio.Fichas;
+
+/// <summary>
+/// A ficha virando texto para o contexto do modelo — a camada C2, ao lado do
+/// playbook (C1) e da conversa (C3).
+///
+/// So o que esta PREENCHIDO entra. Mandar "Porte: não informado" gasta token
+/// para dizer nada e, pior, o modelo trata ausencia declarada como fato
+/// apurado — passa a raciocinar sobre "uma empresa cujo porte e desconhecido"
+/// em vez de simplesmente nao falar de porte.
+/// </summary>
+public static class CamadaC2
+{
+    /// <summary>O cabecalho que separa esta camada das outras no prompt.</summary>
+    public const string Titulo = "O QUE O VENDEDOR JA SABIA ANTES DA CONVERSA";
+
+    /// <summary>
+    /// Monta o texto. Ficha vazia devolve string vazia, e nao um bloco com
+    /// titulo e nada dentro: bloco vazio ocupa lugar e sugere que houve
+    /// pesquisa que nao houve.
+    /// </summary>
+    public static string Montar(FichaCliente? ficha)
+    {
+        if (ficha is null || ficha.EstaVazia) return "";
+
+        var linhas = ficha.Preenchidos.Select(p => $"- {p.Key}: {p.Value}");
+        return $"{Titulo}\n{string.Join("\n", linhas)}";
+    }
+
+    /// <summary>
+    /// Estimativa de tokens do bloco, para a tela mostrar o que a #52 mostra no
+    /// playbook.
+    ///
+    /// E ESTIMATIVA, e o nome diz: a conta real depende do tokenizador de cada
+    /// modelo, e chamar o provedor so para contar seria pagar para saber quanto
+    /// se vai pagar. A razao de ~4 caracteres por token vale para portugues em
+    /// tokenizadores BPE; o numero serve para o vendedor perceber que a ficha
+    /// cresceu demais, nao para faturar.
+    /// </summary>
+    public static int TokensEstimados(string texto) =>
+        string.IsNullOrEmpty(texto) ? 0 : (int)Math.Ceiling(texto.Length / 4.0);
+}

--- a/src/Copiloto.Dominio/Fichas/FichaCliente.cs
+++ b/src/Copiloto.Dominio/Fichas/FichaCliente.cs
@@ -1,0 +1,147 @@
+namespace Copiloto.Dominio.Fichas;
+
+/// <summary>O que o vendedor descobriu sobre a empresa. Tudo opcional.</summary>
+public record SobreAEmpresa(
+    string? Ramo = null,
+    string? Porte = null,
+    string? Momento = null,
+    string? ComoChegou = null);
+
+/// <summary>Quem esta do outro lado, e o poder que tem sobre a decisao.</summary>
+public record SobreAPessoa(
+    string? Cargo = null,
+    string? PapelNaDecisao = null,
+    string? QuemMaisDecide = null,
+    string? EstiloObservado = null);
+
+/// <summary>O negocio em si.</summary>
+public record SobreONegocio(
+    string? ProvavelNecessidade = null,
+    string? UsaHoje = null,
+    string? OrcamentoEstimado = null,
+    string? RiscoConhecido = null);
+
+/// <summary>Uma versao anterior da ficha, com quando e quem mudou.</summary>
+public record VersaoDaFicha(
+    DateTimeOffset Quando,
+    SobreAEmpresa Empresa,
+    SobreAPessoa Pessoa,
+    SobreONegocio Negocio);
+
+/// <summary>
+/// O que o vendedor descobriu ANTES de falar (#86).
+///
+/// Resolve o cold start, que era um buraco real: sem conversa, o copiloto nao
+/// servia para nada — justamente quando o vendedor mais precisa de ajuda.
+///
+/// TODOS os campos sao opcionais, e isso e a decisao central. Formulario longo
+/// com campo obrigatorio nao e preenchido: fica pela metade, e o que se ganha e
+/// um dado falso no campo que alguem foi forcado a inventar para salvar. Uma
+/// ficha de tres linhas verdadeiras vale mais que quinze campos preenchidos no
+/// chute.
+/// </summary>
+public class FichaCliente
+{
+    private readonly List<VersaoDaFicha> _historico = new();
+
+    public FichaCliente(Guid id, Guid leadId, DateTimeOffset criadaEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Ficha sem id.", nameof(id));
+        if (leadId == Guid.Empty) throw new ArgumentException("Ficha sem lead.", nameof(leadId));
+
+        Id = id;
+        LeadId = leadId;
+        CriadaEm = criadaEm;
+        AtualizadaEm = criadaEm;
+
+        Empresa = new SobreAEmpresa();
+        Pessoa = new SobreAPessoa();
+        Negocio = new SobreONegocio();
+    }
+
+    public Guid Id { get; }
+    public Guid LeadId { get; }
+    public DateTimeOffset CriadaEm { get; }
+    public DateTimeOffset AtualizadaEm { get; private set; }
+
+    public SobreAEmpresa Empresa { get; private set; }
+    public SobreAPessoa Pessoa { get; private set; }
+    public SobreONegocio Negocio { get; private set; }
+
+    /// <summary>
+    /// O que a ficha dizia antes de cada mudanca, do mais recente para o mais
+    /// antigo. "Ele era o decisor e agora nao e" e informacao de venda, nao
+    /// auditoria: a mudanca em si diz algo.
+    /// </summary>
+    public IReadOnlyList<VersaoDaFicha> Historico => _historico;
+
+    /// <summary>Ficha que ninguem preencheu. O sistema funciona assim.</summary>
+    public bool EstaVazia => Preenchidos.Count == 0;
+
+    /// <summary>
+    /// Atualiza, guardando a versao anterior. Passar null em um bloco mantem o
+    /// que ja estava — a ficha e PROGRESSIVA, cresce de tres linhas para quinze
+    /// sem exigir que alguem redigite o que ja sabia.
+    /// </summary>
+    public void Atualizar(
+        DateTimeOffset quando,
+        SobreAEmpresa? empresa = null,
+        SobreAPessoa? pessoa = null,
+        SobreONegocio? negocio = null)
+    {
+        if (empresa is null && pessoa is null && negocio is null) return;
+
+        _historico.Insert(0, new VersaoDaFicha(AtualizadaEm, Empresa, Pessoa, Negocio));
+
+        Empresa = empresa ?? Empresa;
+        Pessoa = pessoa ?? Pessoa;
+        Negocio = negocio ?? Negocio;
+        AtualizadaEm = quando;
+    }
+
+    /// <summary>Os campos que tem conteudo, com o rotulo que vai ao contexto.</summary>
+    public IReadOnlyDictionary<string, string> Preenchidos
+    {
+        get
+        {
+            var d = new Dictionary<string, string>();
+            void Por(string rotulo, string? valor)
+            {
+                if (!string.IsNullOrWhiteSpace(valor)) d[rotulo] = valor.Trim();
+            }
+
+            Por("Ramo", Empresa.Ramo);
+            Por("Porte", Empresa.Porte);
+            Por("Momento", Empresa.Momento);
+            Por("Como chegou", Empresa.ComoChegou);
+            Por("Cargo", Pessoa.Cargo);
+            Por("Papel na decisão", Pessoa.PapelNaDecisao);
+            Por("Quem mais decide", Pessoa.QuemMaisDecide);
+            Por("Estilo observado", Pessoa.EstiloObservado);
+            Por("Provável necessidade", Negocio.ProvavelNecessidade);
+            Por("Usa hoje", Negocio.UsaHoje);
+            Por("Orçamento estimado", Negocio.OrcamentoEstimado);
+            Por("Risco conhecido", Negocio.RiscoConhecido);
+
+            return d;
+        }
+    }
+
+    /// <summary>
+    /// O que ainda nao se sabe — os campos vazios, pelo rotulo.
+    ///
+    /// E o que fecha o ciclo da issue: a IA aponta a lacuna, o vendedor vai
+    /// descobrir, preenche, e a lacuna some. Sem isso a ficha seria formulario;
+    /// com isso o sistema para de pedir dado generico e passa a pedir o que
+    /// falta para dar um conselho melhor.
+    /// </summary>
+    public IReadOnlyList<string> Lacunas() =>
+        TodosOsRotulos.Where(r => !Preenchidos.ContainsKey(r)).ToList();
+
+    private static readonly string[] TodosOsRotulos =
+    [
+        "Ramo", "Porte", "Momento", "Como chegou",
+        "Cargo", "Papel na decisão", "Quem mais decide", "Estilo observado",
+        "Provável necessidade", "Usa hoje", "Orçamento estimado", "Risco conhecido",
+    ];
+}

--- a/testes/Copiloto.Testes/FichaClienteTeste.cs
+++ b/testes/Copiloto.Testes/FichaClienteTeste.cs
@@ -1,0 +1,134 @@
+using Copiloto.Dominio.Fichas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A Ficha do Cliente (#86), que resolve o cold start: sem conversa, o copiloto
+/// nao servia para nada — justamente quando o vendedor mais precisa de ajuda.
+/// </summary>
+public class FichaClienteTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static FichaCliente Nova() => new(Guid.NewGuid(), Guid.NewGuid(), T0);
+
+    [Fact]
+    public void Ficha_vazia_nao_quebra_nada()
+    {
+        // Criterio de aceite, e a razao: o sistema tem de funcionar sem ela.
+        var ficha = Nova();
+
+        Assert.True(ficha.EstaVazia);
+        Assert.Empty(ficha.Preenchidos);
+        Assert.Equal("", CamadaC2.Montar(ficha));
+        Assert.Equal(0, CamadaC2.TokensEstimados(CamadaC2.Montar(ficha)));
+    }
+
+    [Fact]
+    public void Nenhum_campo_e_obrigatorio()
+    {
+        // Formulario com campo obrigatorio fica pela metade, e o que se ganha e
+        // um dado FALSO no campo que alguem foi forcado a inventar para salvar.
+        var ficha = Nova();
+
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+
+        Assert.Single(ficha.Preenchidos);
+        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"]);
+    }
+
+    [Fact]
+    public void A_ficha_e_progressiva_e_nao_apaga_o_que_ja_sabia()
+    {
+        // Nasce com tres linhas e cresce. Exigir que alguem redigite o que ja
+        // preencheu e o mesmo que garantir que nao vao preencher de novo.
+        var ficha = Nova();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+
+        ficha.Atualizar(T0.AddDays(1), pessoa: new SobreAPessoa(Cargo: "sócio"));
+
+        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"]);
+        Assert.Equal("sócio", ficha.Preenchidos["Cargo"]);
+    }
+
+    [Fact]
+    public void O_historico_guarda_o_que_a_ficha_dizia_antes()
+    {
+        // "Ele era o decisor e agora nao e" e informacao de VENDA, nao
+        // auditoria: a mudanca em si diz algo.
+        var ficha = Nova();
+        ficha.Atualizar(T0, pessoa: new SobreAPessoa(PapelNaDecisao: "decisor"));
+        ficha.Atualizar(T0.AddDays(2), pessoa: new SobreAPessoa(PapelNaDecisao: "influenciador"));
+
+        Assert.Equal("influenciador", ficha.Preenchidos["Papel na decisão"]);
+        Assert.Equal(2, ficha.Historico.Count);
+        Assert.Equal("decisor", ficha.Historico[0].Pessoa.PapelNaDecisao);
+    }
+
+    [Fact]
+    public void Atualizar_sem_nada_nao_cria_versao()
+    {
+        // Salvar sem mudar nada encheria o historico de ruido, e ai ninguem le.
+        var ficha = Nova();
+        ficha.Atualizar(T0);
+
+        Assert.Empty(ficha.Historico);
+    }
+
+    [Fact]
+    public void As_lacunas_sao_os_campos_que_faltam()
+    {
+        // O que fecha o ciclo: a IA aponta a lacuna, o vendedor descobre,
+        // preenche, e a lacuna some.
+        var ficha = Nova();
+        Assert.Equal(12, ficha.Lacunas().Count);
+
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria", Porte: "3 lojas"));
+
+        Assert.Equal(10, ficha.Lacunas().Count);
+        Assert.DoesNotContain("Ramo", ficha.Lacunas());
+        Assert.Contains("Orçamento estimado", ficha.Lacunas());
+    }
+
+    [Fact]
+    public void So_o_que_esta_preenchido_entra_no_contexto()
+    {
+        // "Porte: não informado" gasta token para dizer nada e, pior, o modelo
+        // trata ausencia declarada como fato apurado — passa a raciocinar sobre
+        // "uma empresa cujo porte e desconhecido" em vez de nao falar de porte.
+        var ficha = Nova();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+
+        var c2 = CamadaC2.Montar(ficha);
+
+        Assert.Contains("Ramo: cafeteria", c2);
+        Assert.DoesNotContain("Porte", c2);
+        Assert.DoesNotContain("não informado", c2);
+    }
+
+    [Fact]
+    public void Ficha_vazia_nao_vira_bloco_vazio_no_prompt()
+    {
+        // Bloco com titulo e nada dentro ocupa lugar e sugere que houve pesquisa
+        // que nao houve.
+        Assert.Equal("", CamadaC2.Montar(Nova()));
+        Assert.Equal("", CamadaC2.Montar(null));
+    }
+
+    [Fact]
+    public void A_contagem_de_tokens_cresce_com_a_ficha()
+    {
+        // A #52 mostra isso no playbook; aqui e o mesmo sinal, para o vendedor
+        // perceber quando a ficha ficou grande demais.
+        var ficha = Nova();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria de bairro"));
+        var pequena = CamadaC2.TokensEstimados(CamadaC2.Montar(ficha));
+
+        ficha.Atualizar(T0, negocio: new SobreONegocio(
+            RiscoConhecido: "contrato vigente com fornecedor atual ate dezembro, "
+                          + "e o socio majoritario indicou esse fornecedor"));
+        var maior = CamadaC2.TokensEstimados(CamadaC2.Montar(ficha));
+
+        Assert.True(maior > pequena);
+    }
+}

--- a/testes/Copiloto.Testes/PersistenciaTeste.cs
+++ b/testes/Copiloto.Testes/PersistenciaTeste.cs
@@ -234,3 +234,93 @@ public class ResolvedorSobreBancoTeste : IDisposable
         Assert.Equal(1, ctx.Leads.Count());
     }
 }
+
+/// <summary>A Ficha do Cliente atravessando o banco (#86).</summary>
+public class FichaNoBancoTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public FichaNoBancoTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    [Fact]
+    public void A_ficha_volta_com_os_campos_preenchidos()
+    {
+        var id = Guid.NewGuid();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var ficha = new Copiloto.Dominio.Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0,
+                empresa: new Copiloto.Dominio.Fichas.SobreAEmpresa(Ramo: "cafeteria", Porte: "3 lojas"),
+                pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(Cargo: "sócio"));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.Equal("cafeteria", lida.Empresa.Ramo);
+        Assert.Equal("3 lojas", lida.Empresa.Porte);
+        Assert.Equal("sócio", lida.Pessoa.Cargo);
+        Assert.False(lida.EstaVazia);
+    }
+
+    [Fact]
+    public void O_historico_sobrevive_ao_banco()
+    {
+        // "Ele era o decisor e agora nao e" so vale se durar mais que a sessao.
+        var id = Guid.NewGuid();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var ficha = new Copiloto.Dominio.Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0, pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(PapelNaDecisao: "decisor"));
+            ficha.Atualizar(T0.AddDays(2), pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(PapelNaDecisao: "influenciador"));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.Equal(2, lida.Historico.Count);
+        Assert.Equal("decisor", lida.Historico[0].Pessoa.PapelNaDecisao);
+    }
+
+    [Fact]
+    public void Ficha_vazia_e_gravavel()
+    {
+        // O sistema funciona sem ela, e "funciona" inclui salvar.
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), Guid.NewGuid(), T0));
+
+        ctx.SaveChanges();
+
+        Assert.True(ctx.Fichas.Single().EstaVazia);
+    }
+
+    [Fact]
+    public void Um_lead_nao_tem_duas_fichas()
+    {
+        // Duas seriam duas versoes da verdade sem criterio de desempate.
+        var lead = Guid.NewGuid();
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+        ctx.SaveChanges();
+
+        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+
+        Assert.Throws<DbUpdateException>(() => ctx.SaveChanges());
+    }
+}


### PR DESCRIPTION
Parte da #86. **Não fecha a issue** — ver a ressalva no fim.

## Critério de aceite

- [x] Entidade `FichaCliente` vinculada ao Lead
- [ ] **Tela de edição** — não há frontend no projeto ainda
- [x] Ficha entra na camada C2 do contexto
- [x] Lacunas aparecem como campos a preencher
- [x] Histórico de versões
- [x] Ficha vazia não quebra nada

## As decisões que importam

**Nenhum campo é obrigatório.** Formulário com campo obrigatório fica pela metade, e o que se ganha é um dado **falso** no campo que alguém foi forçado a inventar para salvar. Uma ficha de três linhas verdadeiras vale mais que quinze campos preenchidos no chute.

**As lacunas são o que fecha o ciclo.** `Lacunas()` devolve os campos vazios — é com isso que o sistema para de pedir dado genérico e passa a pedir exatamente o que falta para dar um conselho melhor. Sem isso, a ficha seria formulário.

**Só o que está preenchido entra no contexto.** Mandar "Porte: não informado" gasta token para dizer nada e, pior, o modelo trata ausência declarada como fato apurado — passa a raciocinar sobre "uma empresa cujo porte é desconhecido" em vez de simplesmente não falar de porte.

**O histórico não é auditoria.** "Ele era o decisor e agora não é" é informação de venda.

## Uma decisão de mapeamento que vale revisão

`OwnsMany(...).ToJson()` é o caminho idiomático e **não fecha aqui**: `VersaoDaFicha` tem três records aninhados, e o EF não liga esses parâmetros de construtor dentro de um owned em JSON.

A saída óbvia seria achatar `VersaoDaFicha` em doze campos soltos — e ela está **errada**, porque seria o domínio se curvando ao ORM. O conversor deixa o modelo como está e paga o preço no mapeamento, que é o lugar certo para pagar.

Vai com `ValueComparer`: sem ele o EF compara por referência, nunca percebe que a lista mudou, e a versão nova **simplesmente não seria gravada** — sem erro nenhum.

## Ressalva

A **tela de edição não foi feita** porque não existe frontend no projeto. Prefiro deixar a issue aberta com um critério pendente a marcá-la como pronta.

132 testes em Release, 0 avisos.
