### PR TITLE
Router de modelo: tarefa, custo, latencia e circuito, com a tabela fora do codigo

### DIFF
--- a/src/Copiloto.Api/Ia/TabelaDeModelos.cs
+++ b/src/Copiloto.Api/Ia/TabelaDeModelos.cs
@@ -1,0 +1,45 @@
+using Copiloto.Dominio.Ia;
+
+namespace Copiloto.Api.Ia;
+
+/// <summary>
+/// Carrega a tabela do router a partir da configuracao (#29).
+///
+/// Ela vem de FORA por decisao. Trocar de modelo e a operacao mais frequente da
+/// vida deste sistema — preco muda, modelo novo sai, provedor cai. Em codigo,
+/// cada troca vira deploy; e o efeito pratico de "trocar exige deploy" e que
+/// ninguem troca, e o sistema fica no modelo de dois anos atras.
+///
+/// O padrao do `appsettings.json` e o provedor FAKE, com custo zero: a suite e
+/// a demo rodam offline e de graca, e ninguem sobe o projeto pela primeira vez
+/// gastando dinheiro sem ter pedido.
+/// </summary>
+public static class TabelaDeModelos
+{
+    public const string Secao = "Modelos";
+
+    public static IReadOnlyList<ModeloDisponivel> Carregar(IConfiguration config)
+    {
+        var lidos = config.GetSection(Secao).Get<List<ModeloConfigurado>>() ?? [];
+
+        if (lidos.Count == 0)
+            throw new InvalidOperationException(
+                $"Nenhum modelo na secao '{Secao}' do appsettings. O router nao tem o "
+                + "que escolher, e subir assim adiaria o erro para a primeira conversa "
+                + "real — que e o pior momento para descobrir.");
+
+        return lidos.Select(m => new ModeloDisponivel(
+            m.Nome, m.Provedor, m.CustoPorMilTokens, m.LatenciaTipicaMs,
+            m.Atende.Select(Enum.Parse<Tarefa>).ToList())).ToList();
+    }
+
+    /// <summary>A forma do JSON. Existe so para o binder da configuracao.</summary>
+    private sealed class ModeloConfigurado
+    {
+        public string Nome { get; set; } = "";
+        public string Provedor { get; set; } = "";
+        public decimal CustoPorMilTokens { get; set; }
+        public int LatenciaTipicaMs { get; set; }
+        public List<string> Atende { get; set; } = [];
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,5 +1,7 @@
+using Copiloto.Api.Ia;
 using Copiloto.Api.Ingestao;
 using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Ia;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,6 +14,10 @@ builder.Services.AddDbContext<CopilotoDbContext>(o =>
                 ?? "Host=localhost;Database=copiloto;Username=copiloto"));
 
 builder.Services.AddScoped<IRepositorioDeLeads, LeadsNoBanco>();
+
+// O router e a tabela dele: a tabela vem do appsettings, nunca de codigo.
+builder.Services.AddSingleton(_ => new RoteadorDeModelo(
+    TabelaDeModelos.Carregar(builder.Configuration)));
 
 builder.Services.AddSingleton<FilaDeMensagens>();
 

--- a/src/Copiloto.Api/appsettings.json
+++ b/src/Copiloto.Api/appsettings.json
@@ -5,5 +5,22 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "Modelos": [
+    {
+      "Nome": "fake-mini",
+      "Provedor": "fake",
+      "CustoPorMilTokens": 0,
+      "LatenciaTipicaMs": 1,
+      "Atende": [ "Triagem", "Leitura" ]
+    },
+    {
+      "Nome": "fake-forte",
+      "Provedor": "fake",
+      "CustoPorMilTokens": 0,
+      "LatenciaTipicaMs": 5,
+      "Atende": [ "Leitura", "Conselho" ]
+    }
+  ]
 }

--- a/src/Copiloto.Dominio/Ia/Roteamento.cs
+++ b/src/Copiloto.Dominio/Ia/Roteamento.cs
@@ -1,0 +1,124 @@
+namespace Copiloto.Dominio.Ia;
+
+/// <summary>
+/// O que se esta pedindo ao modelo. A tarefa e o que decide o gasto.
+/// </summary>
+public enum Tarefa
+{
+    /// <summary>A0: vale a pena olhar esta fala? Precisa ser barato e rapido.</summary>
+    Triagem = 0,
+
+    /// <summary>A1, A3, A4: ler a conversa, detectar sinal, apontar lacuna.</summary>
+    Leitura = 1,
+
+    /// <summary>A5: montar conselho de plano. Pode gastar segundos.</summary>
+    Conselho = 2,
+}
+
+/// <summary>
+/// Um modelo que o router pode escolher. Vem de CONFIGURACAO, nunca de codigo.
+/// </summary>
+/// <param name="Nome">Como o provedor o chama.</param>
+/// <param name="Provedor">Quem hospeda — e a unidade do circuito.</param>
+/// <param name="CustoPorMilTokens">Em reais.</param>
+/// <param name="LatenciaTipicaMs">Medida, nao prometida pelo fornecedor.</param>
+/// <param name="Atende">As tarefas para as quais ele serve.</param>
+public record ModeloDisponivel(
+    string Nome,
+    string Provedor,
+    decimal CustoPorMilTokens,
+    int LatenciaTipicaMs,
+    IReadOnlyList<Tarefa> Atende);
+
+/// <summary>Qual modelo, e POR QUE — o registro que vai ao ledger.</summary>
+public record DecisaoDeRoteamento(
+    string Modelo,
+    string Provedor,
+    string Motivo,
+    IReadOnlyList<string> Descartados);
+
+/// <summary>
+/// Escolhe o modelo por tarefa, custo, latencia e estado do circuito (#29).
+///
+/// A tabela vem de fora por decisao: trocar de modelo e a operacao mais
+/// frequente da vida deste sistema — preco muda, modelo novo sai, provedor cai.
+/// Se ela morasse em codigo, cada troca seria deploy, e o efeito pratico e que
+/// ninguem troca e o sistema fica no modelo de dois anos atras.
+///
+/// A ORDEM DOS CRITERIOS E A DECISAO INTEIRA:
+///
+///   1. atende a tarefa?          filtro, nao criterio — quem nao atende sai
+///   2. circuito fechado?         filtro — provedor caido nao e escolhido,
+///                                mesmo sendo o ideal
+///   3. custo                     criterio principal
+///   4. latencia                  desempate
+///
+/// Custo antes de latencia porque, entre dois modelos que ATENDEM a tarefa, o
+/// mais lento ja foi considerado bom o bastante por quem escreveu a tabela. Se
+/// a latencia importasse mais que o preco para uma tarefa, o jeito de dizer
+/// isso e nao listar o modelo lento nela — e nao inverter o criterio aqui e
+/// deixar a triagem escolher o modelo forte "porque respondeu rapido".
+/// </summary>
+public class RoteadorDeModelo
+{
+    private readonly IReadOnlyList<ModeloDisponivel> _tabela;
+    private readonly Func<string, bool> _circuitoAberto;
+
+    /// <param name="tabela">A configuracao carregada de fora.</param>
+    /// <param name="circuitoAberto">
+    /// Dado o provedor, ele esta fora do ar? Injetado como funcao porque o
+    /// estado do circuito e' da BORDA (mora em Redis, #66) e o router e regra —
+    /// ele decide, nao consulta infraestrutura.
+    /// </param>
+    public RoteadorDeModelo(
+        IReadOnlyList<ModeloDisponivel> tabela, Func<string, bool>? circuitoAberto = null)
+    {
+        ArgumentNullException.ThrowIfNull(tabela);
+        if (tabela.Count == 0)
+            throw new ArgumentException(
+                "Tabela de modelos vazia: o router nao tem o que escolher, e "
+                + "subir assim adiaria o erro para a primeira conversa real.",
+                nameof(tabela));
+
+        _tabela = tabela;
+        _circuitoAberto = circuitoAberto ?? (_ => false);
+    }
+
+    /// <summary>
+    /// Escolhe. Devolve null quando nao ha candidato — e null e a resposta
+    /// honesta: cair no "melhor disponivel" mandaria a triagem para o modelo
+    /// caro justamente quando o barato caiu, que e o pior momento para gastar.
+    /// </summary>
+    public DecisaoDeRoteamento? Escolher(Tarefa tarefa)
+    {
+        var atendem = _tabela.Where(m => m.Atende.Contains(tarefa)).ToList();
+        if (atendem.Count == 0) return null;
+
+        var descartados = new List<string>();
+        var disponiveis = new List<ModeloDisponivel>();
+
+        foreach (var m in atendem)
+        {
+            if (_circuitoAberto(m.Provedor))
+                descartados.Add($"{m.Nome}: circuito aberto em {m.Provedor}");
+            else
+                disponiveis.Add(m);
+        }
+
+        if (disponiveis.Count == 0) return null;
+
+        var escolhido = disponiveis
+            .OrderBy(m => m.CustoPorMilTokens)
+            .ThenBy(m => m.LatenciaTipicaMs)
+            .First();
+
+        foreach (var m in disponiveis.Where(m => m != escolhido))
+            descartados.Add($"{m.Nome}: mais caro (R$ {m.CustoPorMilTokens}/1k)");
+
+        var motivo = descartados.Any(d => d.Contains("circuito aberto"))
+            ? $"mais barato entre os que atendem {tarefa} e estao de pe"
+            : $"mais barato entre os que atendem {tarefa}";
+
+        return new DecisaoDeRoteamento(escolhido.Nome, escolhido.Provedor, motivo, descartados);
+    }
+}

--- a/testes/Copiloto.Testes/RoteadorDeModeloTeste.cs
+++ b/testes/Copiloto.Testes/RoteadorDeModeloTeste.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using Copiloto.Api.Ia;
+using Microsoft.Extensions.Configuration;
+using Copiloto.Dominio.Ia;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O router (#29). E a peca central: sem ele, "orquestracao multi-modelo" e so
+/// uma palavra no README.
+/// </summary>
+public class RoteadorDeModeloTeste
+{
+    // Tabela de exemplo, com a forma que a configuracao real tera.
+    private static readonly ModeloDisponivel Barato =
+        new("mini", "provedor-a", 0.0005m, 300, [Tarefa.Triagem, Tarefa.Leitura]);
+
+    private static readonly ModeloDisponivel Medio =
+        new("medio", "provedor-b", 0.0080m, 900, [Tarefa.Leitura, Tarefa.Conselho]);
+
+    private static readonly ModeloDisponivel Forte =
+        new("forte", "provedor-a", 0.0400m, 2500, [Tarefa.Conselho]);
+
+    private static RoteadorDeModelo Router(Func<string, bool>? circuito = null) =>
+        new([Barato, Medio, Forte], circuito);
+
+    [Fact]
+    public void Triagem_nunca_escolhe_modelo_caro()
+    {
+        // Criterio de aceite. A triagem roda em TODA fala; escolher o forte ali
+        // multiplica a conta do mes por um fator de oitenta.
+        var d = Router().Escolher(Tarefa.Triagem);
+
+        Assert.Equal("mini", d!.Modelo);
+    }
+
+    [Fact]
+    public void Conselho_pode_gastar_porque_o_barato_nao_atende()
+    {
+        // O "nao escolher caro" nao pode virar "nunca escolher caro": o filtro e
+        // a capacidade, e quem decide isso e a tabela.
+        var d = Router().Escolher(Tarefa.Conselho);
+
+        Assert.Equal("medio", d!.Modelo);
+    }
+
+    [Fact]
+    public void Com_circuito_aberto_no_preferido_escolhe_o_proximo()
+    {
+        // Criterio de aceite. Provedor caido nao e escolhido, mesmo sendo o ideal.
+        var d = Router(p => p == "provedor-a").Escolher(Tarefa.Leitura);
+
+        Assert.Equal("medio", d!.Modelo);
+        Assert.Contains(d.Descartados, x => x.Contains("circuito aberto"));
+    }
+
+    [Fact]
+    public void A_decisao_diz_qual_modelo_e_por_que()
+    {
+        // Vai ao ledger. Sem o motivo, "usou o medio" nao permite auditar gasto
+        // nem entender por que a conta subiu no mes passado.
+        var d = Router().Escolher(Tarefa.Leitura);
+
+        Assert.Equal("mini", d!.Modelo);
+        Assert.Equal("provedor-a", d.Provedor);
+        Assert.Contains("mais barato", d.Motivo);
+        Assert.Contains(d.Descartados, x => x.StartsWith("medio"));
+    }
+
+    [Fact]
+    public void Quando_tudo_da_tarefa_esta_fora_a_resposta_e_null()
+    {
+        // Cair no "melhor disponivel" mandaria a triagem para o modelo caro
+        // justamente quando o barato caiu — o pior momento para gastar.
+        var d = Router(_ => true).Escolher(Tarefa.Triagem);
+
+        Assert.Null(d);
+    }
+
+    [Fact]
+    public void Tarefa_sem_modelo_na_tabela_devolve_null_e_nao_improvisa()
+    {
+        var so_triagem = new RoteadorDeModelo([Barato]);
+
+        Assert.Null(so_triagem.Escolher(Tarefa.Conselho));
+        Assert.NotNull(so_triagem.Escolher(Tarefa.Triagem));
+    }
+
+    [Fact]
+    public void Empate_de_custo_e_desfeito_pela_latencia()
+    {
+        var a = new ModeloDisponivel("lento", "p1", 0.001m, 3000, [Tarefa.Leitura]);
+        var b = new ModeloDisponivel("rapido", "p2", 0.001m, 200, [Tarefa.Leitura]);
+
+        var d = new RoteadorDeModelo([a, b]).Escolher(Tarefa.Leitura);
+
+        Assert.Equal("rapido", d!.Modelo);
+    }
+
+    [Fact]
+    public void Tabela_vazia_nao_sobe()
+    {
+        // Adiar o erro para a primeira conversa real seria descobri-lo no pior
+        // momento possivel.
+        Assert.Throws<ArgumentException>(() => new RoteadorDeModelo([]));
+    }
+
+    [Fact]
+    public void O_circuito_e_por_PROVEDOR_e_nao_por_modelo()
+    {
+        // Quando um provedor cai, caem TODOS os modelos dele. Tratar por modelo
+        // faria o router tentar o segundo modelo do mesmo provedor caido, e
+        // gastar mais um timeout para descobrir o que ja sabia.
+        var d = Router(p => p == "provedor-a").Escolher(Tarefa.Conselho);
+
+        Assert.Equal("medio", d!.Modelo);
+        Assert.Contains(d.Descartados, x => x.StartsWith("forte") && x.Contains("circuito"));
+    }
+}
+
+/// <summary>
+/// A tabela vem de CONFIGURACAO, e nao de codigo (#29) — e este arquivo prova
+/// que o appsettings de verdade fecha.
+/// </summary>
+public class TabelaDeModelosTeste
+{
+    private static IConfiguration Config(string json) =>
+        new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)))
+            .Build();
+
+    [Fact]
+    public void O_appsettings_do_projeto_carrega_e_o_router_sobe_com_ele()
+    {
+        // Sobre o arquivo REAL, e nao sobre um JSON escrito no teste: JSON
+        // escrito para passar passa sempre, e o que quebra em producao e o
+        // arquivo que esta no repositorio.
+        var raiz = typeof(TabelaDeModelosTeste).Assembly
+            .GetCustomAttributes<System.Reflection.AssemblyMetadataAttribute>()
+            .First(a => a.Key == "RaizDoRepositorio").Value!;
+        var caminho = Path.Combine(raiz, "src", "Copiloto.Api", "appsettings.json");
+
+        var config = new ConfigurationBuilder().AddJsonFile(caminho).Build();
+        var tabela = TabelaDeModelos.Carregar(config);
+
+        Assert.NotEmpty(tabela);
+        var router = new RoteadorDeModelo(tabela);
+        Assert.NotNull(router.Escolher(Tarefa.Triagem));
+        Assert.NotNull(router.Escolher(Tarefa.Conselho));
+    }
+
+    [Fact]
+    public void O_padrao_do_projeto_e_o_provedor_fake_e_custo_zero()
+    {
+        // Ninguem sobe o projeto pela primeira vez gastando dinheiro sem ter
+        // pedido — e a suite roda offline por decisao do CLAUDE.md.
+        var raiz = typeof(TabelaDeModelosTeste).Assembly
+            .GetCustomAttributes<System.Reflection.AssemblyMetadataAttribute>()
+            .First(a => a.Key == "RaizDoRepositorio").Value!;
+        var config = new ConfigurationBuilder()
+            .AddJsonFile(Path.Combine(raiz, "src", "Copiloto.Api", "appsettings.json")).Build();
+
+        var tabela = TabelaDeModelos.Carregar(config);
+
+        Assert.All(tabela, m => Assert.Equal("fake", m.Provedor));
+        Assert.All(tabela, m => Assert.Equal(0m, m.CustoPorMilTokens));
+    }
+
+    [Fact]
+    public void Trocar_de_modelo_e_editar_JSON_e_nao_recompilar()
+    {
+        // O ponto da issue: a tabela em configuracao. Se isto exigisse deploy,
+        // o efeito pratico seria ninguem trocar nunca.
+        var config = Config("""
+        {
+          "Modelos": [
+            { "Nome": "novo-barato", "Provedor": "outro", "CustoPorMilTokens": 0.0001,
+              "LatenciaTipicaMs": 50, "Atende": [ "Triagem" ] }
+          ]
+        }
+        """);
+
+        var d = new RoteadorDeModelo(TabelaDeModelos.Carregar(config)).Escolher(Tarefa.Triagem);
+
+        Assert.Equal("novo-barato", d!.Modelo);
+    }
+
+    [Fact]
+    public void Secao_ausente_falha_dizendo_o_que_e()
+    {
+        var erro = Assert.Throws<InvalidOperationException>(
+            () => TabelaDeModelos.Carregar(Config("{}")));
+
+        Assert.Contains("Modelos", erro.Message);
+    }
+}


### PR DESCRIPTION
Closes #29.

## Critério de aceite

- [x] **Tabela em configuração, não em código**
- [x] Decisão registrada (qual modelo e por quê), pronta para o ledger
- [x] Teste: com circuito aberto no preferido, escolhe o próximo
- [x] Teste: tarefa de triagem nunca escolhe modelo caro

## A ordem dos critérios é a decisão inteira

```
1. atende a tarefa?    filtro — quem não atende sai
2. circuito fechado?   filtro — provedor caído não é escolhido, mesmo ideal
3. custo               critério principal
4. latência            desempate
```

**Custo antes de latência**, e isso merece revisão sua: entre dois modelos que *atendem* a tarefa, o mais lento já foi considerado bom o bastante por quem escreveu a tabela. Se a latência importasse mais que o preço numa tarefa, o jeito de dizer isso é **não listar o modelo lento nela** — e não inverter o critério aqui, deixando a triagem escolher o forte "porque respondeu rápido".

A triagem roda em **toda fala**. Escolher o forte ali multiplica a conta do mês por oitenta.

## Outras decisões

**O circuito é por provedor, não por modelo.** Quando um provedor cai, caem todos os modelos dele; tratar por modelo faria o router tentar o segundo modelo do mesmo provedor caído e gastar mais um timeout para descobrir o que já sabia.

**Sem candidato, a resposta é `null`.** Cair no "melhor disponível" mandaria a triagem para o modelo caro justamente quando o barato caiu — o pior momento para gastar.

**O estado do circuito entra como função injetada.** Ele mora na borda (Redis, #66) e o router é regra: ele decide, não consulta infraestrutura.

## Sobre a tabela vir de fora

É o critério mais importante da issue. Trocar de modelo é a operação mais frequente da vida deste sistema — preço muda, modelo novo sai, provedor cai. Se cada troca virasse deploy, o efeito prático é que **ninguém troca**, e o sistema fica no modelo de dois anos atrás.

Há teste que carrega o `appsettings.json` **real** e sobe o router com ele: JSON escrito dentro do teste passa sempre, e o que quebra em produção é o arquivo que está no repositório.

O padrão é o provedor `fake` com custo zero — ninguém sobe o projeto pela primeira vez gastando dinheiro sem ter pedido.

145 testes em Release, 0 avisos.
