### PR TITLE
Ferramentas de ancoragem: buscar o dado antes de afirmar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,22 +30,24 @@ a mensagem" esta fora de escopo por decisao, nao por falta de tempo.
 
 > Esta secao envelhece rapido. **Quem fecha uma issue atualiza ela no mesmo PR.**
 
-- **Nao existe uma linha de C#.** Sem `.sln`, sem `.csproj`, sem front.
-- O que existe: `README.md`, `docs/ARQUITETURA.md` (13 secoes de decisao),
-  `docker-compose.yml`, `.env.example`, templates de issue.
-- `prompts/tecnicas/` e `seed/` existem e estao **vazias**.
-- **89 issues abertas, nenhuma fechada**, em 9 milestones (M0 Fundacao -> M8 LGPD).
+- **A solution existe**: `Copiloto.sln` com `Copiloto.Dominio` (POCO, sem pacote),
+  `Copiloto.Api` e a suite `Copiloto.Testes`. Front ainda nao existe.
+- Dominio: conversas e agrupamento de falas, dossie e sinais, ficha do cliente,
+  planos e ancoragem, deal e lead, roteamento de modelo.
+- Api: webhook do WhatsApp com fila, resolvedor de lead, EF Core + Postgres com
+  migrations, PII Shield e guarda de saida, catalogo fake de ancoragem.
+- `seed/conversas/` tem as tres conversas do cenario de cafe. `prompts/tecnicas/`
+  continua **vazia**.
+- Esteira: `.github/workflows/ci.yml` (build + test) e `segredo.yml`.
+- **77 issues abertas, 16 fechadas**, em 9 milestones (M0 Fundacao -> M8 LGPD).
 - Ordem acordada: **alicerce antes de morador** — estrutura primeiro, funcionalidade
   depois.
-
-Enquanto nao houver `.sln`, `dotnet build` **nao tem o que compilar**, e isso e
-resposta valida (ver "nao deu pra checar" abaixo), nunca um erro a esconder.
 
 ---
 
 ## Comandos
 
-Passam a valer a partir do esqueleto da solution; antes disso, nao existem.
+Todos valem: a solution existe e a suite roda offline.
 
 ```bash
 dotnet build                              # compila a solution
@@ -66,11 +68,14 @@ docker compose ps
 ## Regras que nao se negociam
 
 - **A IA nunca escreve para o cliente.** Ver a tese acima.
-- **Regra de ancoragem.** Escassez, prova social, desconto e prazo so viram
-  sugestao se existir dado no CRM que sustente. Sem dado, o agente devolve como
-  **pergunta ao vendedor**, nunca como fala pronta. Sugerir "restam 2 unidades"
-  quando existem 200 e publicidade enganosa, cria passivo para a empresa que usa
-  o produto e queima o vendedor com o cliente (#15, #16).
+- **Regra de ancoragem.** Escassez, prova social, desconto, prazo e preco so
+  viram sugestao se existir dado no CRM que sustente. Sem dado, o agente devolve
+  como **pergunta ao vendedor**, nunca como fala pronta. Sugerir "restam 2
+  unidades" quando existem 200 e publicidade enganosa, cria passivo para a
+  empresa que usa o produto e queima o vendedor com o cliente (#15, #16).
+  O dado vem de ferramenta consultada ANTES da fala (#57), e **dado que existe e
+  nao sustenta a fala barra a sugestao igual a dado ausente**: com 140kg em
+  estoque nao ha caminho de codigo que produza escassez.
 - **Todo sinal do dossie cita a fala que o originou.** Sem citacao, o bloco nao e
   exibido. E o que transforma "a IA ta ruim" de reclamacao subjetiva em defeito
   verificavel.
@@ -126,7 +131,7 @@ Excecao: limpeza trivial no arquivo ja tocado, em **commit separado**.
 
 ## Fluxo de trabalho
 
-**Uma issue por branch, uma branch por PR.** As 89 issues sao o plano; trabalho
+**Uma issue por branch, uma branch por PR.** As issues sao o plano; trabalho
 que nao tem issue, abre issue antes.
 
 ```bash

--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -226,6 +226,26 @@ Isso muda a natureza do guardrail: a ancoragem deixa de ser uma instrução no p
 existe o dado no contexto, então não há o que inventar). É a diferença entre pedir
 para o modelo se comportar e tornar o mau comportamento impossível.
 
+**O que já existe (#57).** `IFerramentasDeAncoragem` no domínio declara as cinco
+ferramentas (`consultar_estoque`, `preco_vigente`, `politica_desconto`,
+`clientes_semelhantes_que_compraram`, `prazo_entrega`), e o `MontadorAncorado`
+monta o bloco consultando antes de afirmar: nenhum método dele aceita o número
+que vai ser dito ao cliente, então não há assinatura por onde um valor inventado
+entre. Cada consulta entra na lista `Chamadas` com ferramenta, argumento, se
+achou e latência.
+
+Duas consequências que só aparecem no código: **dado que existe e não sustenta a
+fala barra a sugestão do mesmo jeito que dado ausente** — com 140kg em estoque, o
+caminho de escassez fica fechado, e é o teste que prova isso que dá sentido à
+seção inteira; e **prova social abaixo de cinco compradores não é devolvida pela
+ferramenta**, porque agregado pequeno identifica gente.
+
+A fonte hoje é `FerramentasFake`, um catálogo em processo com os produtos e os
+preços do `seed/` — a suíte e a demo rodam offline. O **transporte** MCP (servidor
+em #56, cliente com laço de tool-calling em #59) troca a implementação sem tocar
+no domínio, que só conhece o contrato. Persistir as chamadas no ledger junto das
+invocações de modelo entra com o orquestrador, em #110.
+
 ---
 
 ## 11. RAG: onde entra e — mais importante — onde não entra

--- a/src/Copiloto.Api/Ancoragem/FerramentasFake.cs
+++ b/src/Copiloto.Api/Ancoragem/FerramentasFake.cs
@@ -92,9 +92,12 @@ public class FerramentasFake : IFerramentasDeAncoragem
         var porKg = item.PrecoPorKg * (1 - desconto);
         var preco = $"{porKg.ToString("C", Brasil)}/kg";
 
+        // A cultura vai EXPLICITA tambem aqui. `{desconto:P0}` usaria a cultura do
+        // processo, e o mesmo desconto sai "8%" numa maquina e "8 %" noutra —
+        // a fala que chega ao vendedor mudaria conforme o servidor onde roda.
         return Achado.De(desconto == 0
             ? preco
-            : $"{preco} (-{desconto:P0} na faixa de {quantidade}kg)");
+            : $"{preco} (-{desconto.ToString("P0", Brasil)} na faixa de {quantidade}kg)");
     }
 
     /// <summary>

--- a/src/Copiloto.Api/Ancoragem/FerramentasFake.cs
+++ b/src/Copiloto.Api/Ancoragem/FerramentasFake.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using Copiloto.Dominio.Ancoragem;
+
+namespace Copiloto.Api.Ancoragem;
+
+/// <summary>Um item do catalogo: o que existe, e por quanto sai o quilo.</summary>
+public record ProdutoDoCatalogo(string Nome, int EstoqueEmKg, decimal PrecoPorKg);
+
+/// <summary>
+/// As ferramentas de ancoragem sobre um catalogo em memoria (#57).
+///
+/// E o padrao, pelo mesmo motivo do <c>FakeSource</c>: a suite e a demo rodam
+/// offline e de graca. Trocar por ERP de verdade e implementar esta interface
+/// noutra classe — o dominio nao fica sabendo, porque so conhece o contrato.
+///
+/// O que NAO e fake aqui e o comportamento de nao achar: sao os buracos do
+/// catalogo que fazem a sugestao virar pergunta, e um fake que responde tudo
+/// esconderia justamente o caminho que a issue existe para provar.
+/// </summary>
+public class FerramentasFake : IFerramentasDeAncoragem
+{
+    /// <summary>
+    /// Abaixo disto, prova social identifica gente. "Dois clientes do seu porte
+    /// na sua regiao compraram" e, para quem conhece o mercado local, um nome —
+    /// entao o piso e da ferramenta, e nao um cuidado que quem chama precise
+    /// lembrar de ter (#62, #89).
+    /// </summary>
+    public const int MinimoParaProvaSocialNaoIdentificar = 5;
+
+    private static readonly CultureInfo Brasil = new("pt-BR");
+
+    private readonly IReadOnlyDictionary<string, ProdutoDoCatalogo> _catalogo;
+    private readonly IReadOnlyDictionary<string, string> _politicaPorPerfil;
+    private readonly IReadOnlyDictionary<string, int> _compradoresPorPerfil;
+    private readonly IReadOnlyDictionary<string, string> _prazoPorRegiao;
+
+    public FerramentasFake(
+        IEnumerable<ProdutoDoCatalogo> catalogo,
+        IReadOnlyDictionary<string, string> politicaPorPerfil,
+        IReadOnlyDictionary<string, int> compradoresPorPerfil,
+        IReadOnlyDictionary<string, string> prazoPorRegiao)
+    {
+        _catalogo = catalogo.ToDictionary(p => p.Nome, StringComparer.OrdinalIgnoreCase);
+        _politicaPorPerfil = politicaPorPerfil;
+        _compradoresPorPerfil = compradoresPorPerfil;
+        _prazoPorRegiao = prazoPorRegiao;
+    }
+
+    /// <summary>
+    /// O cenario de cafe do `seed/conversas` — mesmos produtos e mesmos precos
+    /// das conversas gravadas. Quando a demo mostra o dossie da Marina e a
+    /// ancora diz "R$ 68,00/kg", o numero e o mesmo que o vendedor falou ali.
+    /// </summary>
+    public static FerramentasFake DoCenarioDeCafe() => new(
+        catalogo: new[]
+        {
+            new ProdutoDoCatalogo("Bourbon Amarelo", 140, 68m),
+            new ProdutoDoCatalogo("Catuai Vermelho", 60, 54m),
+            // Microlote: e o unico produto em que escassez e verdade, e por isso
+            // ele existe no seed — sem ele, o caminho ancorado nunca roda na demo.
+            new ProdutoDoCatalogo("Geisha Microlote", 4, 190m),
+        },
+        politicaPorPerfil: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["cafeteria"] = "ate 12% a partir de 5kg, faturado em 21 dias",
+            ["revenda"] = "ate 18% a partir de 20kg, com contrato",
+        },
+        compradoresPorPerfil: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["cafeteria"] = 23,
+            ["revenda"] = 8,
+            // Tres compradores: existe o dado e ele NAO pode virar fala.
+            ["assinatura corporativa"] = 3,
+        },
+        prazoPorRegiao: new Dictionary<string, string>
+        {
+            ["04"] = "2 dias uteis",
+            ["01"] = "1 dia util",
+            ["13"] = "4 dias uteis",
+        });
+
+    public Achado ConsultarEstoque(string produto) =>
+        _catalogo.TryGetValue(produto.Trim(), out var item)
+            ? Achado.De(item.EstoqueEmKg.ToString(CultureInfo.InvariantCulture))
+            : Achado.Nada;
+
+    public Achado PrecoVigente(string produto, int quantidade)
+    {
+        if (!_catalogo.TryGetValue(produto.Trim(), out var item)) return Achado.Nada;
+
+        var desconto = DescontoPorFaixa(quantidade);
+        var porKg = item.PrecoPorKg * (1 - desconto);
+        var preco = $"{porKg.ToString("C", Brasil)}/kg";
+
+        return Achado.De(desconto == 0
+            ? preco
+            : $"{preco} (-{desconto:P0} na faixa de {quantidade}kg)");
+    }
+
+    /// <summary>
+    /// A faixa e da tabela, nao do vendedor: desconto negociado na conversa e
+    /// margem que ninguem aprovou.
+    /// </summary>
+    private static decimal DescontoPorFaixa(int quantidade) => quantidade switch
+    {
+        >= 20 => 0.15m,
+        >= 5 => 0.08m,
+        _ => 0m,
+    };
+
+    public Achado PoliticaDesconto(string perfilCliente) =>
+        _politicaPorPerfil.TryGetValue(perfilCliente.Trim(), out var politica)
+            ? Achado.De(politica)
+            // Perfil sem politica nao e' "desconto zero": e' "ninguem decidiu".
+            // Devolver 0% autorizaria o agente a afirmar que nao ha desconto.
+            : Achado.Nada;
+
+    public Achado ClientesSemelhantesQueCompraram(string perfil)
+    {
+        if (!_compradoresPorPerfil.TryGetValue(perfil.Trim(), out var quantos))
+            return Achado.Nada;
+
+        return quantos < MinimoParaProvaSocialNaoIdentificar
+            ? Achado.Nada
+            : Achado.De($"{quantos} clientes do perfil {perfil.Trim()} nos ultimos 90 dias");
+    }
+
+    public Achado PrazoEntrega(string cep, string produto)
+    {
+        var digitos = new string(cep.Where(char.IsDigit).ToArray());
+        if (digitos.Length < 8) return Achado.Nada;
+
+        // Sem estoque, o prazo da regiao e' mentira: o relogio so comeca quando
+        // o lote existe, e essa e' a data que o cliente vai cobrar.
+        if (!_catalogo.TryGetValue(produto.Trim(), out var item) || item.EstoqueEmKg == 0)
+            return Achado.Nada;
+
+        return _prazoPorRegiao.TryGetValue(digitos[..2], out var prazo)
+            ? Achado.De(prazo)
+            : Achado.Nada;
+    }
+}

--- a/src/Copiloto.Dominio/Ancoragem/Ferramentas.cs
+++ b/src/Copiloto.Dominio/Ancoragem/Ferramentas.cs
@@ -1,0 +1,55 @@
+namespace Copiloto.Dominio.Ancoragem;
+
+/// <summary>
+/// O que uma ferramenta devolveu. `Achou = false` NAO e erro: e a resposta
+/// legitima de "nao ha dado para sustentar isso", e e ela que faz a sugestao
+/// virar pergunta em vez de afirmacao.
+/// </summary>
+public record Achado(bool Achou, string? Valor = null)
+{
+    public static readonly Achado Nada = new(false);
+    public static Achado De(string valor) => new(true, valor);
+}
+
+/// <summary>
+/// As ferramentas que o agente chama ANTES de afirmar (#57).
+///
+/// Este e o encaixe que justifica MCP no projeto, e ele e maior do que parece:
+/// a ancoragem deixa de ser instrucao no prompt — que o modelo pode ignorar — e
+/// vira PROPRIEDADE DA ARQUITETURA. Se o dado nao esta no contexto porque a
+/// ferramenta nao devolveu nada, nao ha o que inventar.
+///
+/// E a diferenca entre pedir ao modelo que se comporte e tornar o mau
+/// comportamento impossivel.
+/// </summary>
+public interface IFerramentasDeAncoragem
+{
+    /// <summary>Escassez real. Devolve o numero quando ele sustenta a fala.</summary>
+    Achado ConsultarEstoque(string produto);
+
+    /// <summary>Preco vigente e faixa autorizada para a quantidade.</summary>
+    Achado PrecoVigente(string produto, int quantidade);
+
+    /// <summary>O que o vendedor PODE oferecer para este perfil.</summary>
+    Achado PoliticaDesconto(string perfilCliente);
+
+    /// <summary>Prova social real, agregada — nunca cliente nominal.</summary>
+    Achado ClientesSemelhantesQueCompraram(string perfil);
+
+    /// <summary>Prazo real para o CEP.</summary>
+    Achado PrazoEntrega(string cep, string produto);
+}
+
+/// <summary>
+/// Uma chamada de ferramenta, para o ledger: qual, com que argumento, quanto
+/// demorou e se achou.
+///
+/// A latencia entra porque ancoragem que demora demais deixa de ser usada —
+/// alguem "desliga para testar" e nunca religa. Medir e o que permite descobrir
+/// isso antes de virar decisao silenciosa.
+/// </summary>
+public record ChamadaDeFerramenta(
+    string Ferramenta,
+    string Argumento,
+    bool Achou,
+    int LatenciaMs);

--- a/src/Copiloto.Dominio/Ancoragem/MontadorAncorado.cs
+++ b/src/Copiloto.Dominio/Ancoragem/MontadorAncorado.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics;
+using Copiloto.Dominio.Planos;
+
+namespace Copiloto.Dominio.Ancoragem;
+
+/// <summary>
+/// Monta blocos do plano consultando a ferramenta ANTES de afirmar (#57).
+///
+/// Nenhum metodo daqui aceita o numero QUE VAI SER AFIRMADO. Quem quiser
+/// sugerir escassez informa o PRODUTO, e o valor vem da ferramenta — nao ha
+/// assinatura por onde um numero inventado entre. A regra deixa de depender de
+/// o modelo obedecer e passa a depender do formato da chamada.
+///
+/// A quantidade em <see cref="Preco"/> e a excecao que confirma a regra: ela e
+/// o que o CLIENTE pediu, dito na conversa, e nao um dado da empresa que o
+/// modelo poderia inventar — o preco dessa quantidade continua vindo da tabela.
+/// </summary>
+public class MontadorAncorado
+{
+    /// <summary>
+    /// Acima disto, escassez e' mentira. Fica aqui e nao na ferramenta porque e'
+    /// julgamento de VENDA ("dois e pouco, duzentos nao e"), nao de estoque —
+    /// a ferramenta responde quanto tem; quem decide se isso e pouco e o
+    /// dominio.
+    /// </summary>
+    public const int EstoqueQueJaNaoEEscasso = 10;
+
+    private readonly IFerramentasDeAncoragem _ferramentas;
+    private readonly List<ChamadaDeFerramenta> _chamadas = new();
+
+    public MontadorAncorado(IFerramentasDeAncoragem ferramentas)
+    {
+        ArgumentNullException.ThrowIfNull(ferramentas);
+        _ferramentas = ferramentas;
+    }
+
+    /// <summary>O que foi consultado, para o ledger.</summary>
+    public IReadOnlyList<ChamadaDeFerramenta> Chamadas => _chamadas;
+
+    public BlocoSugerido Escassez(string produto)
+    {
+        var achado = Medir("consultar_estoque", produto,
+                           () => _ferramentas.ConsultarEstoque(produto));
+
+        if (!achado.Achou)
+            return BlocoSugerido.Perguntar(Tatica.Escassez,
+                $"Temos pouco estoque de {produto}? Não consegui confirmar.");
+
+        // Estoque FARTO tambem impede a sugestao, e este e o ponto da issue:
+        // a ferramenta respondeu, o dado existe, e ele NAO sustenta a fala.
+        // Sugerir "restam poucas" com duzentas em estoque e publicidade
+        // enganosa — e o erro nao seria do modelo, seria de quem so conferiu
+        // se veio resposta.
+        if (int.TryParse(achado.Valor, out var quantidade)
+            && quantidade > EstoqueQueJaNaoEEscasso)
+        {
+            return BlocoSugerido.Perguntar(Tatica.Escassez,
+                $"Estoque de {produto} está em {quantidade} — não dá para falar em "
+                + "escassez. Vale destacar outra coisa?");
+        }
+
+        return BlocoSugerido.Ancorado(Tatica.Escassez,
+            $"Restam {achado.Valor} de {produto}",
+            $"consultar_estoque({produto})={achado.Valor}");
+    }
+
+    /// <summary>
+    /// Preco vigente para a quantidade. A quantidade entra como parametro e o
+    /// PRECO nao: quem chama diz quantos quilos o cliente quer, e o valor sai da
+    /// tabela — preco combinado na conversa e divida que a empresa honra depois.
+    /// </summary>
+    public BlocoSugerido Preco(string produto, int quantidade)
+    {
+        if (quantidade <= 0)
+            throw new ArgumentOutOfRangeException(nameof(quantidade),
+                "Quantidade nao positiva nao tem preco: a faixa de desconto e' "
+                + "escolhida por ela, e zero cairia na primeira faixa por acidente.");
+
+        var achado = Medir("preco_vigente", $"{produto}/{quantidade}",
+                           () => _ferramentas.PrecoVigente(produto, quantidade));
+
+        return achado.Achou
+            ? BlocoSugerido.Ancorado(Tatica.Preco,
+                $"{quantidade} de {produto}: {achado.Valor}",
+                $"preco_vigente({produto},{quantidade})={achado.Valor}")
+            : BlocoSugerido.Perguntar(Tatica.Preco,
+                $"Qual o preço vigente de {produto} para {quantidade}? "
+                + "Não achei na tabela.");
+    }
+
+    public BlocoSugerido Desconto(string perfilCliente)
+    {
+        var achado = Medir("politica_desconto", perfilCliente,
+                           () => _ferramentas.PoliticaDesconto(perfilCliente));
+
+        return achado.Achou
+            ? BlocoSugerido.Ancorado(Tatica.Desconto,
+                $"Condição autorizada: {achado.Valor}",
+                $"politica_desconto({perfilCliente})={achado.Valor}")
+            : BlocoSugerido.Perguntar(Tatica.Desconto,
+                "Existe política de desconto para este perfil? Não achei registro.");
+    }
+
+    public BlocoSugerido ProvaSocial(string perfil)
+    {
+        var achado = Medir("clientes_semelhantes", perfil,
+                           () => _ferramentas.ClientesSemelhantesQueCompraram(perfil));
+
+        return achado.Achou
+            ? BlocoSugerido.Ancorado(Tatica.ProvaSocial,
+                $"Outros clientes parecidos já compraram: {achado.Valor}",
+                $"clientes_semelhantes({perfil})={achado.Valor}")
+            : BlocoSugerido.Perguntar(Tatica.ProvaSocial,
+                "Temos caso parecido para citar? Não encontrei na base.");
+    }
+
+    public BlocoSugerido Prazo(string cep, string produto)
+    {
+        var achado = Medir("prazo_entrega", $"{cep}/{produto}",
+                           () => _ferramentas.PrazoEntrega(cep, produto));
+
+        return achado.Achou
+            ? BlocoSugerido.Ancorado(Tatica.Prazo,
+                $"Prazo de entrega: {achado.Valor}",
+                $"prazo_entrega({cep})={achado.Valor}")
+            : BlocoSugerido.Perguntar(Tatica.Prazo,
+                $"Qual o prazo para o CEP {cep}? A consulta não retornou.");
+    }
+
+    private Achado Medir(string ferramenta, string argumento, Func<Achado> chamar)
+    {
+        var relogio = Stopwatch.StartNew();
+        var achado = chamar();
+        relogio.Stop();
+
+        _chamadas.Add(new ChamadaDeFerramenta(
+            ferramenta, argumento, achado.Achou, (int)relogio.ElapsedMilliseconds));
+
+        return achado;
+    }
+}

--- a/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
+++ b/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
@@ -3,8 +3,11 @@ namespace Copiloto.Dominio.Planos;
 /// <summary>
 /// Tatica que precisa de dado do CRM para poder ser sugerida (#15, #16).
 /// Fora desta lista, a sugestao e livre — nao ha o que ancorar.
+///
+/// `Preco` entra em #57: preco dito errado ao cliente e o erro que a empresa
+/// tem de honrar depois, entao ele exige a mesma ancora que a escassez.
 /// </summary>
-public enum Tatica { Escassez = 0, ProvaSocial = 1, Desconto = 2, Prazo = 3, Livre = 4 }
+public enum Tatica { Escassez = 0, ProvaSocial = 1, Desconto = 2, Prazo = 3, Livre = 4, Preco = 5 }
 
 /// <summary>
 /// Um item do plano de abordagem: ou sugestao ancorada, ou pergunta ao vendedor.

--- a/testes/Copiloto.Testes/AncoragemMcpTeste.cs
+++ b/testes/Copiloto.Testes/AncoragemMcpTeste.cs
@@ -1,0 +1,244 @@
+using Copiloto.Api.Ancoragem;
+using Copiloto.Dominio.Ancoragem;
+using Copiloto.Dominio.Planos;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A ancoragem como propriedade da arquitetura, e nao como instrucao no prompt
+/// (#57).
+///
+/// O teste que interessa e o do estoque farto: nao e' "o agente foi orientado a
+/// nao mentir", e' "nao existe caminho de codigo que produza a fala". Um teste
+/// que so conferisse o caminho feliz aprovaria uma implementacao que aceita
+/// qualquer numero que o modelo devolva.
+/// </summary>
+public class AncoragemMcpTeste
+{
+    /// <summary>
+    /// Ferramenta que responde o que o teste mandar. `Nada` por padrao: o
+    /// caminho sem dado e' o mais importante daqui, entao ele e' o default.
+    /// </summary>
+    private class FerramentaCombinada : IFerramentasDeAncoragem
+    {
+        public Achado Estoque { get; init; } = Achado.Nada;
+        public Achado Preco { get; init; } = Achado.Nada;
+        public Achado Politica { get; init; } = Achado.Nada;
+        public Achado Semelhantes { get; init; } = Achado.Nada;
+        public Achado Prazo { get; init; } = Achado.Nada;
+
+        public int Chamadas { get; private set; }
+
+        public Achado ConsultarEstoque(string produto) { Chamadas++; return Estoque; }
+        public Achado PrecoVigente(string produto, int quantidade) { Chamadas++; return Preco; }
+        public Achado PoliticaDesconto(string perfil) { Chamadas++; return Politica; }
+        public Achado ClientesSemelhantesQueCompraram(string perfil) { Chamadas++; return Semelhantes; }
+        public Achado PrazoEntrega(string cep, string produto) { Chamadas++; return Prazo; }
+    }
+
+    [Fact]
+    public void Com_estoque_farto_o_agente_nao_consegue_produzir_escassez()
+    {
+        // O criterio de aceite da issue, e o unico que prova a tese: a
+        // ferramenta RESPONDEU, o dado existe, e ele nao sustenta a fala.
+        // Conferir so "veio resposta?" aprovaria "restam 200 unidades!".
+        var montador = new MontadorAncorado(new FerramentaCombinada
+        {
+            Estoque = Achado.De("200"),
+        });
+
+        var bloco = montador.Escassez("Bourbon Amarelo");
+
+        Assert.True(bloco.EhPergunta);
+        Assert.Null(bloco.Ancora);
+        Assert.Contains("200", bloco.Texto);
+    }
+
+    [Fact]
+    public void Com_estoque_baixo_a_escassez_sai_ancorada_na_ferramenta()
+    {
+        var montador = new MontadorAncorado(new FerramentaCombinada
+        {
+            Estoque = Achado.De("4"),
+        });
+
+        var bloco = montador.Escassez("Geisha Microlote");
+
+        Assert.False(bloco.EhPergunta);
+        Assert.Equal("consultar_estoque(Geisha Microlote)=4", bloco.Ancora);
+    }
+
+    [Fact]
+    public void Ferramenta_sem_resultado_vira_pergunta_ao_vendedor_nunca_afirmacao()
+    {
+        var montador = new MontadorAncorado(new FerramentaCombinada());
+
+        var blocos = new[]
+        {
+            montador.Escassez("cafe qualquer"),
+            montador.Preco("cafe qualquer", 3),
+            montador.Desconto("perfil novo"),
+            montador.ProvaSocial("perfil novo"),
+            montador.Prazo("04567-000", "cafe qualquer"),
+        };
+
+        Assert.All(blocos, b => Assert.True(b.EhPergunta));
+        Assert.All(blocos, b => Assert.Null(b.Ancora));
+    }
+
+    [Fact]
+    public void Nao_ha_montador_sem_ferramenta()
+    {
+        // "Chama a ferramenta ANTES de afirmar" nao e' disciplina de quem
+        // escreve: sem ferramenta o objeto nao chega a existir.
+        Assert.Throws<ArgumentNullException>(() => new MontadorAncorado(null!));
+    }
+
+    [Fact]
+    public void Toda_chamada_entra_no_ledger_com_latencia()
+    {
+        var montador = new MontadorAncorado(new FerramentaCombinada
+        {
+            Estoque = Achado.De("4"),
+        });
+
+        montador.Escassez("Geisha Microlote");
+        montador.Desconto("cafeteria");
+
+        Assert.Equal(2, montador.Chamadas.Count);
+        Assert.All(montador.Chamadas, c => Assert.True(c.LatenciaMs >= 0));
+        Assert.Equal("consultar_estoque", montador.Chamadas[0].Ferramenta);
+        Assert.True(montador.Chamadas[0].Achou);
+    }
+
+    [Fact]
+    public void A_chamada_que_nao_achou_tambem_entra_no_ledger()
+    {
+        // E' a mais util das duas: buraco de catalogo aparece como serie de
+        // `Achou=false` numa ferramenta so, e sem o registro ele viraria "a IA
+        // pergunta demais".
+        var montador = new MontadorAncorado(new FerramentaCombinada());
+
+        montador.ProvaSocial("perfil que nao existe");
+
+        var chamada = Assert.Single(montador.Chamadas);
+        Assert.False(chamada.Achou);
+    }
+
+    [Fact]
+    public void Quantidade_nao_positiva_nao_chega_a_consultar_preco()
+    {
+        var ferramentas = new FerramentaCombinada();
+        var montador = new MontadorAncorado(ferramentas);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => montador.Preco("Bourbon Amarelo", 0));
+        Assert.Equal(0, ferramentas.Chamadas);
+    }
+
+    // --- O catalogo fake, que e' o que roda na demo (#20) ---
+
+    [Fact]
+    public void Catalogo_de_cafe_ancora_o_preco_do_seed()
+    {
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        var bloco = montador.Preco("Bourbon Amarelo", 3);
+
+        Assert.False(bloco.EhPergunta);
+        Assert.Contains("68", bloco.Texto);
+    }
+
+    [Fact]
+    public void Faixa_de_desconto_sai_da_tabela_e_nao_da_conversa()
+    {
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        var bloco = montador.Preco("Bourbon Amarelo", 5);
+
+        Assert.Contains("8%", bloco.Texto);
+        Assert.Contains("preco_vigente(Bourbon Amarelo,5)", bloco.Ancora);
+    }
+
+    [Fact]
+    public void Produto_fora_do_catalogo_nao_tem_preco_afirmavel()
+    {
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        Assert.True(montador.Preco("Cafe que nao vendemos", 2).EhPergunta);
+    }
+
+    [Fact]
+    public void Estoque_farto_do_catalogo_real_tambem_barra_a_escassez()
+    {
+        // 140kg de Bourbon no catalogo: o caminho de escassez fica fechado para
+        // o produto mais vendido, que e' exatamente onde a tentacao existe.
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        Assert.True(montador.Escassez("Bourbon Amarelo").EhPergunta);
+        Assert.False(montador.Escassez("Geisha Microlote").EhPergunta);
+    }
+
+    [Fact]
+    public void Prova_social_com_poucos_compradores_nao_sai_da_ferramenta()
+    {
+        // Tres compradores identificam gente. A ferramenta responde `Nada`, e o
+        // agente nao tem o que agregar por conta propria.
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        Assert.True(montador.ProvaSocial("assinatura corporativa").EhPergunta);
+        Assert.False(montador.ProvaSocial("cafeteria").EhPergunta);
+    }
+
+    [Fact]
+    public void Prova_social_nunca_cita_cliente_nominal()
+    {
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        var bloco = montador.ProvaSocial("cafeteria");
+
+        Assert.Contains("23 clientes", bloco.Ancora);
+        Assert.DoesNotContain("Marina", bloco.Texto);
+    }
+
+    [Fact]
+    public void Prazo_de_produto_sem_estoque_nao_e_afirmado()
+    {
+        var esgotado = new FerramentasFake(
+            catalogo: new[] { new ProdutoDoCatalogo("Geisha Microlote", 0, 190m) },
+            politicaPorPerfil: new Dictionary<string, string>(),
+            compradoresPorPerfil: new Dictionary<string, int>(),
+            prazoPorRegiao: new Dictionary<string, string> { ["04"] = "2 dias uteis" });
+
+        var montador = new MontadorAncorado(esgotado);
+
+        Assert.True(montador.Prazo("04567-000", "Geisha Microlote").EhPergunta);
+    }
+
+    [Fact]
+    public void Cep_incompleto_nao_vira_prazo_chutado()
+    {
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        Assert.True(montador.Prazo("04567", "Bourbon Amarelo").EhPergunta);
+        Assert.False(montador.Prazo("04567-000", "Bourbon Amarelo").EhPergunta);
+    }
+
+    [Fact]
+    public void Perfil_sem_politica_nao_vira_desconto_zero()
+    {
+        // "Ninguem decidiu" nao e' "nao ha desconto": afirmar o segundo fecha
+        // negocio que o gestor teria aberto.
+        var montador = new MontadorAncorado(FerramentasFake.DoCenarioDeCafe());
+
+        Assert.True(montador.Desconto("assinatura corporativa").EhPergunta);
+        Assert.False(montador.Desconto("cafeteria").EhPergunta);
+    }
+
+    [Fact]
+    public void Bloco_de_preco_exige_ancora_como_as_demais_taticas()
+    {
+        Assert.True(BlocoSugerido.PrecisaDeAncora(Tatica.Preco));
+        Assert.Throws<ArgumentException>(
+            () => BlocoSugerido.Ancorado(Tatica.Preco, "sai a R$ 40 o quilo", ""));
+    }
+}


### PR DESCRIPTION
## O que muda
`IFerramentasDeAncoragem` e `MontadorAncorado`: nenhum metodo aceita o numero que vai ser dito ao cliente. O valor vem da ferramenta, e cada consulta entra no ledger com latencia.

## Decisao que mudou o desenho
Conferir "a ferramenta respondeu?" nao basta. Com 140kg em estoque a resposta VEM e nao sustenta a fala — dado que existe e nao sustenta barra a sugestao igual a dado ausente.

## Fora deste PR
Persistir as chamadas no ledger fica para #110: sem orquestrador, a tabela nasceria vazia.

Closes #57