### PR TITLE
Ficha: fato separado de impressao, com procedencia

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -28,7 +28,7 @@ montado em camadas com orçamento de tokens:
 |---|---|---|---|
 | **C0** | Identidade do agente, o que pode afirmar, regra de ancoragem | ~200 | **nunca** |
 | **C1** | Playbook da empresa: produto, preço, política de desconto, tom | ~800 | não |
-| **C2** | Ficha do negócio: lead, valor, estágio, dias parado, proposta | ~1000 | parcial |
+| **C2** | Ficha do cliente: o que o vendedor já sabia, em fatos e impressões separados | ~1000 | parcial |
 | **C3** | A conversa: mensagens literais + resumo progressivo do que veio antes | resto | sim |
 
 **Regra de corte:** estourou o orçamento, corta C3 do mais antigo para o mais novo,
@@ -38,6 +38,20 @@ substituindo mensagens literais por resumo. C0 nunca é cortada.
 por escrito") só sobrevivem no literal. Resumir a conversa recente destrói exatamente o
 sinal que o dossiê existe para captar. Por isso o resumo progressivo age no passado
 distante, nunca nas últimas mensagens.
+
+**C2 vai dividida em duas seções, e isso não é cosmético (#88):** cada linha da ficha
+nasce marcada como **fato** ("é gerente de compras", com fonte opcional — site, LinkedIn,
+o próprio cliente disse) ou **impressão** ("parece desconfiado", datada, sem fonte, porque
+a fonte é quem anotou). Numa lista única as duas chegam ao modelo com o mesmo peso, e o
+palpite do vendedor volta para ele reembalado como conclusão do sistema — uma câmara de
+eco que confirma o viés original em vez de corrigi-lo, e que ainda cobra um modelo por
+volta.
+
+A separação é estrutural, não uma instrução de prompt: `Anotacao` não tem conversão
+implícita de `string`, então nada entra como fato por omissão, e `BlocoSugerido.AncoradoEm`
+**recusa** impressão em qualquer tática que precise de âncora. Impressão sustenta hipótese
+(tática livre) e nada além disso. A âncora que chega ao vendedor carrega a procedência
+junto — "isso saiu de uma impressão sua de 01/09" é o que lhe dá a chance de discordar.
 
 ---
 

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/AnotacaoJson.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/AnotacaoJson.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Copiloto.Dominio.Fichas;
+
+namespace Copiloto.Api.Persistencia.Mapeamentos;
+
+/// <summary>
+/// Le e escreve <see cref="Anotacao"/> no JSON da ficha.
+///
+/// Existe porque `Anotacao` so nasce por `Fato(...)` ou `Impressao(...)`, e o
+/// construtor privado e' o que garante isso — o `System.Text.Json` nao alcanca
+/// construtor privado e reclama na desserializacao.
+///
+/// A saida barata seria abrir um construtor publico, ou marcar o privado com
+/// `[JsonConstructor]`. As duas fazem o dominio carregar uma decisao de
+/// serializacao, e a primeira ainda abriria o caminho que a #88 fechou: criar
+/// anotacao sem dizer se e fato ou impressao. O conversor paga o preco aqui, no
+/// mapeamento, que e' o lugar certo para pagar.
+/// </summary>
+public class AnotacaoJson : JsonConverter<Anotacao>
+{
+    /// <summary>A anotacao como ela esta no banco, antes de virar dominio.</summary>
+    private record Bruta(
+        string Valor,
+        NaturezaDaInformacao Natureza,
+        string? Fonte = null,
+        DateTimeOffset? Quando = null);
+
+    public override Anotacao? Read(
+        ref Utf8JsonReader reader, Type tipo, JsonSerializerOptions opcoes)
+    {
+        var bruta = JsonSerializer.Deserialize<Bruta>(ref reader, SemEsteConversor(opcoes));
+        if (bruta is null) return null;
+
+        return bruta.Natureza == NaturezaDaInformacao.Fato
+            ? Anotacao.Fato(bruta.Valor, bruta.Fonte, bruta.Quando)
+            : Anotacao.Impressao(bruta.Valor, bruta.Quando);
+    }
+
+    public override void Write(
+        Utf8JsonWriter escritor, Anotacao anotacao, JsonSerializerOptions opcoes) =>
+        JsonSerializer.Serialize(
+            escritor,
+            new Bruta(anotacao.Valor, anotacao.Natureza, anotacao.Fonte, anotacao.Quando),
+            SemEsteConversor(opcoes));
+
+    /// <summary>
+    /// `Bruta` e um record comum, mas serializa-lo com as mesmas opcoes traria
+    /// este conversor de volta para um tipo que nao e o dele. Tirar da lista
+    /// evita a duvida.
+    /// </summary>
+    private static JsonSerializerOptions SemEsteConversor(JsonSerializerOptions opcoes)
+    {
+        var limpas = new JsonSerializerOptions(opcoes);
+        for (var i = limpas.Converters.Count - 1; i >= 0; i--)
+            if (limpas.Converters[i] is AnotacaoJson) limpas.Converters.RemoveAt(i);
+
+        return limpas;
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/FichaClienteMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/FichaClienteMap.cs
@@ -9,7 +9,8 @@ namespace Copiloto.Api.Persistencia.Mapeamentos;
 
 public class FichaClienteMap : IEntityTypeConfiguration<FichaCliente>
 {
-    private static readonly JsonSerializerOptions Json = new();
+    private static readonly JsonSerializerOptions Json =
+        new() { Converters = { new AnotacaoJson() } };
 
     public void Configure(EntityTypeBuilder<FichaCliente> e)
     {
@@ -23,43 +24,59 @@ public class FichaClienteMap : IEntityTypeConfiguration<FichaCliente>
         // seriam duas versoes da verdade sem criterio de desempate.
         e.HasIndex(f => f.LeadId).IsUnique().HasDatabaseName("ux_fichas_lead");
 
-        // Os tres blocos viram colunas na mesma tabela, e nao tabelas proprias:
-        // eles nao existem sem a ficha e nunca sao consultados sozinhos.
-        e.OwnsOne(f => f.Empresa);
-        e.OwnsOne(f => f.Pessoa);
-        e.OwnsOne(f => f.Negocio);
+        // Os tres blocos e o historico vao como JSON, por conversor.
+        //
+        // Os blocos ERAM `OwnsOne` com quatro colunas de texto cada, e a #88
+        // derrubou isso: cada campo virou `Anotacao` (valor + natureza + fonte +
+        // quando), e o EF nao consegue ligar parametro de construtor a um owned
+        // aninhado — "No suitable constructor was found for entity type
+        // 'SobreAEmpresa'".
+        //
+        // As duas saidas eram achatar `Anotacao` em quatro colunas por campo
+        // (48 colunas na ficha) ou serializar o bloco. A primeira e o dominio se
+        // curvando ao ORM, e o dominio e' quem tem razao para existir. O
+        // conversor paga o preco no mapeamento, que e' o lugar certo para pagar
+        // — foi o mesmo raciocinio que o historico ja tinha feito aqui.
+        //
+        // O que isso custa: nao da para consultar "fichas cujo ramo e cafeteria"
+        // por indice. Ninguem consulta — a ficha e sempre lida pelo lead, e a
+        // busca por conteudo de ficha nao existe em nenhuma issue aberta.
+        var (deEmpresa, comparaEmpresa) = ComoJson<SobreAEmpresa>();
+        var (dePessoa, comparaPessoa) = ComoJson<SobreAPessoa>();
+        var (deNegocio, comparaNegocio) = ComoJson<SobreONegocio>();
+        var (deHistorico, comparaHistorico) = ComoJson<List<VersaoDaFicha>>();
 
-        // O historico vai como JSON numa coluna so, por conversor.
-        //
-        // A primeira tentativa foi `OwnsMany(...).ToJson()`, que e o caminho
-        // idiomatico, e ele NAO fecha aqui: `VersaoDaFicha` tem tres records
-        // aninhados, e o EF nao consegue ligar esses parametros de construtor
-        // dentro de um owned em JSON.
-        //
-        // A saida obvia seria achatar `VersaoDaFicha` em doze campos soltos —
-        // e ela esta errada. Seria o dominio se curvando ao ORM, quando o
-        // dominio e' quem tem razao para existir. O conversor deixa o modelo
-        // como esta e paga o preco no mapeamento, que e' o lugar certo para
-        // pagar.
-        //
-        // O historico e lista de LEITURA (a tela mostra "o que mudou e quando"),
-        // nunca alvo de consulta por campo, entao JSON nao custa nada aqui.
-        var conversor = new ValueConverter<List<VersaoDaFicha>, string>(
-            v => JsonSerializer.Serialize(v, Json),
-            s => JsonSerializer.Deserialize<List<VersaoDaFicha>>(s, Json) ?? new());
-
-        // Sem o comparador, o EF compara por REFERENCIA e nunca percebe que a
-        // lista mudou — a versao nova simplesmente nao seria gravada, sem erro.
-        var comparador = new ValueComparer<List<VersaoDaFicha>>(
-            (a, b) => JsonSerializer.Serialize(a, Json) == JsonSerializer.Serialize(b, Json),
-            v => JsonSerializer.Serialize(v, Json).GetHashCode(),
-            v => JsonSerializer.Deserialize<List<VersaoDaFicha>>(
-                     JsonSerializer.Serialize(v, Json), Json)!);
+        e.Property(f => f.Empresa).HasColumnName("empresa")
+            .HasConversion(deEmpresa, comparaEmpresa);
+        e.Property(f => f.Pessoa).HasColumnName("pessoa")
+            .HasConversion(dePessoa, comparaPessoa);
+        e.Property(f => f.Negocio).HasColumnName("negocio")
+            .HasConversion(deNegocio, comparaNegocio);
 
         e.Property<List<VersaoDaFicha>>("_historico")
             .HasColumnName("historico")
-            .HasConversion(conversor, comparador);
+            .HasConversion(deHistorico, comparaHistorico);
 
         e.Ignore(f => f.Historico);
+        e.Ignore(f => f.Preenchidos);
+        e.Ignore(f => f.Fatos);
+        e.Ignore(f => f.Impressoes);
     }
+
+    /// <summary>
+    /// Conversor e comparador de um tipo do dominio para JSON.
+    ///
+    /// O comparador NAO e opcional, e o modo de falhar e o pior possivel: sem
+    /// ele o EF compara por REFERENCIA, nunca percebe que o bloco mudou, e a
+    /// gravacao simplesmente nao acontece — sem excecao, sem log, com o
+    /// SaveChanges devolvendo sucesso.
+    /// </summary>
+    private static (ValueConverter<T, string>, ValueComparer<T>) ComoJson<T>() => (
+        new ValueConverter<T, string>(
+            v => JsonSerializer.Serialize(v, Json),
+            s => JsonSerializer.Deserialize<T>(s, Json)!),
+        new ValueComparer<T>(
+            (a, b) => JsonSerializer.Serialize(a, Json) == JsonSerializer.Serialize(b, Json),
+            v => JsonSerializer.Serialize(v, Json).GetHashCode(),
+            v => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(v, Json), Json)!));
 }

--- a/src/Copiloto.Api/Persistencia/Migrations/20260903225054_FatoEImpressaoNaFicha.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260903225054_FatoEImpressaoNaFicha.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903225054_FatoEImpressaoNaFicha")]
+    partial class FatoEImpressaoNaFicha
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260903225054_FatoEImpressaoNaFicha.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260903225054_FatoEImpressaoNaFicha.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class FatoEImpressaoNaFicha : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // As doze colunas de texto da ficha viram tres colunas JSON: cada
+            // campo passou a ser uma Anotacao (valor + natureza + fonte + quando)
+            // na #88, e achatar isso daria 48 colunas.
+            //
+            // O DROP APAGA o conteudo das fichas existentes, e o `ef` avisou
+            // disso. Nao ha instalacao com dados — nenhuma ficha foi preenchida
+            // fora de teste —, entao migrar campo a campo seria escrever (e ter
+            // de conferir) um backfill para zero linhas. Se isso mudar antes do
+            // primeiro deploy, o backfill entra AQUI, lendo as colunas antigas
+            // antes do drop e gravando como fato sem fonte.
+            migrationBuilder.DropColumn(
+                name: "Empresa_ComoChegou",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Empresa_Momento",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Empresa_Porte",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Empresa_Ramo",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Negocio_OrcamentoEstimado",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Negocio_ProvavelNecessidade",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Negocio_RiscoConhecido",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Negocio_UsaHoje",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Pessoa_Cargo",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Pessoa_EstiloObservado",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Pessoa_PapelNaDecisao",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "Pessoa_QuemMaisDecide",
+                table: "fichas_cliente");
+
+            migrationBuilder.AddColumn<string>(
+                name: "empresa",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "negocio",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "pessoa",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "empresa",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "negocio",
+                table: "fichas_cliente");
+
+            migrationBuilder.DropColumn(
+                name: "pessoa",
+                table: "fichas_cliente");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Empresa_ComoChegou",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Empresa_Momento",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Empresa_Porte",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Empresa_Ramo",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Negocio_OrcamentoEstimado",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Negocio_ProvavelNecessidade",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Negocio_RiscoConhecido",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Negocio_UsaHoje",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Pessoa_Cargo",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Pessoa_EstiloObservado",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Pessoa_PapelNaDecisao",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Pessoa_QuemMaisDecide",
+                table: "fichas_cliente",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/src/Copiloto.Dominio/Fichas/Anotacao.cs
+++ b/src/Copiloto.Dominio/Fichas/Anotacao.cs
@@ -1,0 +1,89 @@
+namespace Copiloto.Dominio.Fichas;
+
+/// <summary>
+/// De onde a informacao veio, e quanto peso ela aguenta (#88).
+///
+/// "E gerente de compras" e "parece desconfiado" sao coisas de naturezas
+/// diferentes, e entrar no contexto com o mesmo peso e o risco mais silencioso
+/// da ficha: o palpite do vendedor volta para ele reembalado como analise do
+/// sistema, o que CONFIRMA o vies original em vez de corrigi-lo.
+/// </summary>
+public enum NaturezaDaInformacao
+{
+    /// <summary>Apurado. Sustenta afirmacao.</summary>
+    Fato = 0,
+
+    /// <summary>Percebido por alguem. Sustenta, no maximo, hipotese.</summary>
+    Impressao = 1,
+}
+
+/// <summary>
+/// Uma linha da ficha: o que se sabe, se e fato ou impressao, e de onde saiu.
+///
+/// Nao ha conversao implicita de string, e isso e decisao: `Ramo = "cafeteria"`
+/// compilando viraria fato por omissao, e "parece apressado" entraria como dado
+/// apurado sem ninguem escolher isso. Quem anota diz qual das duas coisas esta
+/// anotando — e o custo de digitar `Anotacao.Fato(...)` e exatamente o momento
+/// de pensar na diferenca.
+/// </summary>
+public record Anotacao
+{
+    private Anotacao(string valor, NaturezaDaInformacao natureza, string? fonte, DateTimeOffset? quando)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+            throw new ArgumentException("Anotacao sem conteudo.", nameof(valor));
+
+        Valor = valor.Trim();
+        Natureza = natureza;
+        Fonte = string.IsNullOrWhiteSpace(fonte) ? null : fonte.Trim();
+        Quando = quando;
+    }
+
+    public string Valor { get; init; }
+    public NaturezaDaInformacao Natureza { get; init; }
+
+    /// <summary>
+    /// Site, LinkedIn, o proprio cliente disse, um terceiro contou. Opcional:
+    /// exigir fonte faria o vendedor inventar uma para salvar o formulario, e
+    /// fonte inventada e pior que fonte ausente — ela parece verificavel.
+    /// </summary>
+    public string? Fonte { get; init; }
+
+    /// <summary>
+    /// Quando foi anotado. Serve a impressao mais que ao fato: "me pareceu
+    /// apressado" de tres semanas atras e outra coisa de "me pareceu apressado"
+    /// ontem, e e' isso que da ao vendedor a chance de discordar.
+    /// </summary>
+    public DateTimeOffset? Quando { get; init; }
+
+    public static Anotacao Fato(string valor, string? fonte = null, DateTimeOffset? quando = null) =>
+        new(valor, NaturezaDaInformacao.Fato, fonte, quando);
+
+    /// <summary>
+    /// Impressao nao aceita fonte: a fonte E quem anotou, e escrever "site" ao
+    /// lado de um palpite e o disfarce que a issue existe para impedir.
+    /// </summary>
+    public static Anotacao Impressao(string valor, DateTimeOffset? quando = null) =>
+        new(valor, NaturezaDaInformacao.Impressao, fonte: null, quando);
+
+    public bool EhFato => Natureza == NaturezaDaInformacao.Fato;
+
+    /// <summary>
+    /// O que a ficha manda para o contexto e para a tela. A procedencia vai
+    /// JUNTO do valor, e nao numa coluna ao lado: o modelo le uma linha de
+    /// texto, e separar valor de rotulo e' como a impressao vira fato no
+    /// caminho.
+    /// </summary>
+    public string Rotulado()
+    {
+        var procedencia = (EhFato, Fonte, Quando) switch
+        {
+            (true, null, _) => "fato",
+            (true, var f, _) => $"fato, {f}",
+            (false, _, null) => "impressão do vendedor",
+            (false, _, var q) => $"impressão do vendedor em {q:dd/MM/yyyy}",
+        };
+
+        return $"{Valor} [{procedencia}]";
+    }
+}

--- a/src/Copiloto.Dominio/Fichas/CamadaC2.cs
+++ b/src/Copiloto.Dominio/Fichas/CamadaC2.cs
@@ -14,18 +14,48 @@ public static class CamadaC2
     /// <summary>O cabecalho que separa esta camada das outras no prompt.</summary>
     public const string Titulo = "O QUE O VENDEDOR JA SABIA ANTES DA CONVERSA";
 
+    public const string TituloDosFatos = "FATOS APURADOS (podem sustentar afirmacao)";
+
+    public const string TituloDasImpressoes =
+        "IMPRESSOES DO VENDEDOR (podem sustentar no maximo uma hipotese, nunca uma afirmacao)";
+
+    /// <summary>
+    /// A instrucao vai NO BLOCO, e nao no prompt de sistema, porque e' aqui que
+    /// ela e' verificavel: o texto que carrega a impressao carrega junto o que
+    /// pode ser feito com ela, e as duas coisas nao se separam no caminho.
+    /// </summary>
+    public const string Instrucao =
+        "Impressao nao ancora escassez, prazo, preco nem desconto. Ao usar uma "
+        + "impressao, diga que e' hipotese e de onde ela saiu.";
+
     /// <summary>
     /// Monta o texto. Ficha vazia devolve string vazia, e nao um bloco com
     /// titulo e nada dentro: bloco vazio ocupa lugar e sugere que houve
     /// pesquisa que nao houve.
+    ///
+    /// Fatos e impressoes vao em secoes SEPARADAS (#88). Numa lista unica,
+    /// "Cargo: gerente de compras" e "Estilo: parece desconfiado" chegam ao
+    /// modelo com o mesmo peso, e o palpite do vendedor volta para ele
+    /// reembalado como conclusao do sistema — o que confirma o vies em vez de
+    /// corrigi-lo.
     /// </summary>
     public static string Montar(FichaCliente? ficha)
     {
         if (ficha is null || ficha.EstaVazia) return "";
 
-        var linhas = ficha.Preenchidos.Select(p => $"- {p.Key}: {p.Value}");
-        return $"{Titulo}\n{string.Join("\n", linhas)}";
+        var partes = new List<string> { Titulo };
+
+        if (ficha.Fatos.Count > 0)
+            partes.Add($"{TituloDosFatos}\n{Listar(ficha.Fatos)}");
+
+        if (ficha.Impressoes.Count > 0)
+            partes.Add($"{TituloDasImpressoes}\n{Listar(ficha.Impressoes)}\n{Instrucao}");
+
+        return string.Join("\n", partes);
     }
+
+    private static string Listar(IReadOnlyDictionary<string, Anotacao> anotacoes) =>
+        string.Join("\n", anotacoes.Select(a => $"- {a.Key}: {a.Value.Rotulado()}"));
 
     /// <summary>
     /// Estimativa de tokens do bloco, para a tela mostrar o que a #52 mostra no

--- a/src/Copiloto.Dominio/Fichas/FichaCliente.cs
+++ b/src/Copiloto.Dominio/Fichas/FichaCliente.cs
@@ -2,24 +2,24 @@ namespace Copiloto.Dominio.Fichas;
 
 /// <summary>O que o vendedor descobriu sobre a empresa. Tudo opcional.</summary>
 public record SobreAEmpresa(
-    string? Ramo = null,
-    string? Porte = null,
-    string? Momento = null,
-    string? ComoChegou = null);
+    Anotacao? Ramo = null,
+    Anotacao? Porte = null,
+    Anotacao? Momento = null,
+    Anotacao? ComoChegou = null);
 
 /// <summary>Quem esta do outro lado, e o poder que tem sobre a decisao.</summary>
 public record SobreAPessoa(
-    string? Cargo = null,
-    string? PapelNaDecisao = null,
-    string? QuemMaisDecide = null,
-    string? EstiloObservado = null);
+    Anotacao? Cargo = null,
+    Anotacao? PapelNaDecisao = null,
+    Anotacao? QuemMaisDecide = null,
+    Anotacao? EstiloObservado = null);
 
 /// <summary>O negocio em si.</summary>
 public record SobreONegocio(
-    string? ProvavelNecessidade = null,
-    string? UsaHoje = null,
-    string? OrcamentoEstimado = null,
-    string? RiscoConhecido = null);
+    Anotacao? ProvavelNecessidade = null,
+    Anotacao? UsaHoje = null,
+    Anotacao? OrcamentoEstimado = null,
+    Anotacao? RiscoConhecido = null);
 
 /// <summary>Uma versao anterior da ficha, com quando e quem mudou.</summary>
 public record VersaoDaFicha(
@@ -100,14 +100,14 @@ public class FichaCliente
     }
 
     /// <summary>Os campos que tem conteudo, com o rotulo que vai ao contexto.</summary>
-    public IReadOnlyDictionary<string, string> Preenchidos
+    public IReadOnlyDictionary<string, Anotacao> Preenchidos
     {
         get
         {
-            var d = new Dictionary<string, string>();
-            void Por(string rotulo, string? valor)
+            var d = new Dictionary<string, Anotacao>();
+            void Por(string rotulo, Anotacao? anotacao)
             {
-                if (!string.IsNullOrWhiteSpace(valor)) d[rotulo] = valor.Trim();
+                if (anotacao is not null) d[rotulo] = anotacao;
             }
 
             Por("Ramo", Empresa.Ramo);
@@ -137,6 +137,20 @@ public class FichaCliente
     /// </summary>
     public IReadOnlyList<string> Lacunas() =>
         TodosOsRotulos.Where(r => !Preenchidos.ContainsKey(r)).ToList();
+
+    /// <summary>O que foi apurado. E so daqui que sai afirmacao (#88).</summary>
+    public IReadOnlyDictionary<string, Anotacao> Fatos =>
+        Preenchidos.Where(p => p.Value.EhFato).ToDictionary(p => p.Key, p => p.Value);
+
+    /// <summary>
+    /// O que alguem achou. Sustenta hipotese, e nada alem disso.
+    ///
+    /// Nao e' ruido a descartar: "parece desconfiado" muda a abordagem do
+    /// vendedor e tem lugar na ficha. O que nao pode e' virar premissa de uma
+    /// conclusao que volta com a autoridade do sistema.
+    /// </summary>
+    public IReadOnlyDictionary<string, Anotacao> Impressoes =>
+        Preenchidos.Where(p => !p.Value.EhFato).ToDictionary(p => p.Key, p => p.Value);
 
     private static readonly string[] TodosOsRotulos =
     [

--- a/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
+++ b/src/Copiloto.Dominio/Planos/BlocoSugerido.cs
@@ -1,3 +1,5 @@
+using Copiloto.Dominio.Fichas;
+
 namespace Copiloto.Dominio.Planos;
 
 /// <summary>
@@ -57,6 +59,36 @@ public class BlocoSugerido
                 nameof(ancora));
 
         return new BlocoSugerido(tatica, texto.Trim(), ancora?.Trim(), ehPergunta: false);
+    }
+
+    /// <summary>
+    /// Sugestao ancorada numa anotacao da ficha, com a procedencia junto (#88).
+    ///
+    /// Impressao nao ancora tatica que exige dado, e a recusa e aqui e nao no
+    /// prompt: "parece que ele tem pressa" sustentando um prazo e o palpite do
+    /// vendedor voltando para ele com a autoridade do sistema — e' camara de
+    /// eco cara, porque confirma o vies em vez de corrigi-lo.
+    ///
+    /// A #88 cita escassez, prazo e preco. A regra ficou geral, valendo para
+    /// desconto e prova social tambem, porque a distincao fato/impressao nao e'
+    /// sobre a tatica: e' sobre AFIRMAR. Impressao sustenta hipotese, e
+    /// hipotese nao e' o que uma dessas taticas devolve ao cliente.
+    /// </summary>
+    public static BlocoSugerido AncoradoEm(Tatica tatica, string texto, Anotacao anotacao)
+    {
+        ArgumentNullException.ThrowIfNull(anotacao);
+
+        if (PrecisaDeAncora(tatica) && !anotacao.EhFato)
+            throw new ArgumentException(
+                $"A tatica {tatica} exige FATO, e '{anotacao.Valor}' e impressao. "
+                + "Impressao sustenta no maximo hipotese: use Perguntar() para o "
+                + "vendedor confirmar antes de a fala existir.",
+                nameof(anotacao));
+
+        // A ancora carrega a procedencia, e nao so o valor: ver "isso saiu de
+        // uma impressao sua de tres semanas atras" e o que da ao vendedor a
+        // chance de discordar. Conclusao sem procedencia ele so pode aceitar.
+        return Ancorado(tatica, texto, anotacao.Rotulado());
     }
 
     /// <summary>O caminho de saida quando o dado nao existe.</summary>

--- a/testes/Copiloto.Testes/FatoOuImpressaoTeste.cs
+++ b/testes/Copiloto.Testes/FatoOuImpressaoTeste.cs
@@ -1,0 +1,170 @@
+using Copiloto.Dominio.Fichas;
+using Copiloto.Dominio.Planos;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Fato e impressao separados na ficha, com procedencia (#88).
+///
+/// O risco que estes testes cobrem nao e a IA errar: e ela ACERTAR o eco. O
+/// palpite do vendedor volta para ele reembalado como analise do sistema, o
+/// que confirma o vies original em vez de corrigi-lo — e sai caro, porque cada
+/// volta passa por um modelo pago.
+/// </summary>
+public class FatoOuImpressaoTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static FichaCliente Nova() => new(Guid.NewGuid(), Guid.NewGuid(), T0);
+
+    [Fact]
+    public void Anotacao_nasce_dizendo_qual_das_duas_e()
+    {
+        // Nao ha conversao implicita de string: `Ramo = "cafeteria"` nao
+        // compila, entao nada entra como fato por omissao.
+        Assert.True(Anotacao.Fato("gerente de compras").EhFato);
+        Assert.False(Anotacao.Impressao("parece desconfiado").EhFato);
+    }
+
+    [Fact]
+    public void Fato_carrega_a_fonte_quando_ela_existe()
+    {
+        var comFonte = Anotacao.Fato("12 lojas", fonte: "site da empresa");
+
+        Assert.Equal("site da empresa", comFonte.Fonte);
+        Assert.Contains("fato, site da empresa", comFonte.Rotulado());
+    }
+
+    [Fact]
+    public void Fonte_e_opcional_no_fato()
+    {
+        // Exigir fonte faria o vendedor inventar uma para salvar, e fonte
+        // inventada e pior que fonte ausente: ela parece verificavel.
+        Assert.Equal("é gerente [fato]", Anotacao.Fato("é gerente").Rotulado());
+    }
+
+    [Fact]
+    public void Impressao_nao_aceita_fonte()
+    {
+        // A assinatura nao tem o parametro: escrever "site" ao lado de um
+        // palpite e o disfarce que a issue existe para impedir.
+        var impressao = Anotacao.Impressao("acho que odeia enrolação");
+
+        Assert.Null(impressao.Fonte);
+        Assert.Contains("impressão do vendedor", impressao.Rotulado());
+    }
+
+    [Fact]
+    public void Impressao_datada_diz_de_quando_e()
+    {
+        // "Isso saiu de uma impressao sua de tres semanas atras" e diferente de
+        // uma conclusao sem procedencia: a primeira o vendedor pode contestar.
+        var bloco = Anotacao.Impressao("me pareceu apressado", quando: T0).Rotulado();
+
+        Assert.Contains("01/09/2026", bloco);
+    }
+
+    [Fact]
+    public void A_ficha_separa_o_que_foi_apurado_do_que_foi_percebido()
+    {
+        var ficha = Nova();
+        ficha.Atualizar(T0,
+            empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria", "o cliente disse")),
+            pessoa: new SobreAPessoa(
+                Cargo: Anotacao.Fato("sócio", "LinkedIn"),
+                EstiloObservado: Anotacao.Impressao("parece desconfiado")));
+
+        Assert.Equal(2, ficha.Fatos.Count);
+        Assert.Single(ficha.Impressoes);
+        Assert.Equal("parece desconfiado", ficha.Impressoes["Estilo observado"].Valor);
+    }
+
+    [Fact]
+    public void No_prompt_as_duas_vao_em_secoes_separadas()
+    {
+        // Numa lista unica, "Cargo: sócio" e "parece desconfiado" chegam ao
+        // modelo com o mesmo peso.
+        var ficha = Nova();
+        ficha.Atualizar(T0,
+            pessoa: new SobreAPessoa(
+                Cargo: Anotacao.Fato("sócio", "LinkedIn"),
+                EstiloObservado: Anotacao.Impressao("parece desconfiado")));
+
+        var c2 = CamadaC2.Montar(ficha);
+
+        Assert.Contains(CamadaC2.TituloDosFatos, c2);
+        Assert.Contains(CamadaC2.TituloDasImpressoes, c2);
+        Assert.True(c2.IndexOf(CamadaC2.TituloDosFatos, StringComparison.Ordinal)
+                    < c2.IndexOf(CamadaC2.TituloDasImpressoes, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void O_bloco_leva_junto_o_que_pode_ser_feito_com_a_impressao()
+    {
+        var ficha = Nova();
+        ficha.Atualizar(T0, pessoa: new SobreAPessoa(
+            EstiloObservado: Anotacao.Impressao("parece apressado")));
+
+        var c2 = CamadaC2.Montar(ficha);
+
+        Assert.Contains(CamadaC2.Instrucao, c2);
+        Assert.Contains("impressão do vendedor", c2);
+    }
+
+    [Fact]
+    public void Ficha_so_de_fatos_nao_carrega_secao_de_impressao_vazia()
+    {
+        // Titulo sem conteudo gasta token e sugere que ha palpite onde nao ha.
+        var ficha = Nova();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
+
+        var c2 = CamadaC2.Montar(ficha);
+
+        Assert.Contains(CamadaC2.TituloDosFatos, c2);
+        Assert.DoesNotContain(CamadaC2.TituloDasImpressoes, c2);
+    }
+
+    // --- O encontro com a ancoragem (#15, #57) ---
+
+    [Fact]
+    public void Impressao_nunca_ancora_escassez_prazo_ou_preco()
+    {
+        // O criterio de aceite. "Parece que ele tem pressa" sustentando um
+        // prazo e o palpite do vendedor voltando com a autoridade do sistema.
+        var impressao = Anotacao.Impressao("parece que ele tem pressa");
+
+        foreach (var tatica in new[] { Tatica.Escassez, Tatica.Prazo, Tatica.Preco,
+                                       Tatica.Desconto, Tatica.ProvaSocial })
+        {
+            var erro = Assert.Throws<ArgumentException>(
+                () => BlocoSugerido.AncoradoEm(tatica, "fala qualquer", impressao));
+
+            Assert.Contains("Perguntar", erro.Message);
+        }
+    }
+
+    [Fact]
+    public void Fato_ancora_e_a_sugestao_diz_de_onde_saiu()
+    {
+        // O quarto criterio: a ancoragem diz de qual dos dois a sugestao veio.
+        var bloco = BlocoSugerido.AncoradoEm(
+            Tatica.Prazo, "Entrega em 2 dias úteis",
+            Anotacao.Fato("2 dias úteis para a zona sul", "tabela de frete"));
+
+        Assert.False(bloco.EhPergunta);
+        Assert.Contains("fato, tabela de frete", bloco.Ancora);
+    }
+
+    [Fact]
+    public void Impressao_ainda_sustenta_a_tatica_livre()
+    {
+        // Impressao nao e ruido a descartar: "parece desconfiado" muda a
+        // abordagem, e a tatica Livre e onde isso vale.
+        var bloco = BlocoSugerido.AncoradoEm(
+            Tatica.Livre, "Vale ir direto ao ponto com ele",
+            Anotacao.Impressao("parece que odeia enrolação", quando: T0));
+
+        Assert.False(bloco.EhPergunta);
+        Assert.Contains("impressão do vendedor em 01/09/2026", bloco.Ancora);
+    }
+}

--- a/testes/Copiloto.Testes/FichaClienteTeste.cs
+++ b/testes/Copiloto.Testes/FichaClienteTeste.cs
@@ -31,10 +31,10 @@ public class FichaClienteTeste
         // um dado FALSO no campo que alguem foi forcado a inventar para salvar.
         var ficha = Nova();
 
-        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
 
         Assert.Single(ficha.Preenchidos);
-        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"]);
+        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"].Valor);
     }
 
     [Fact]
@@ -43,12 +43,12 @@ public class FichaClienteTeste
         // Nasce com tres linhas e cresce. Exigir que alguem redigite o que ja
         // preencheu e o mesmo que garantir que nao vao preencher de novo.
         var ficha = Nova();
-        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
 
-        ficha.Atualizar(T0.AddDays(1), pessoa: new SobreAPessoa(Cargo: "sócio"));
+        ficha.Atualizar(T0.AddDays(1), pessoa: new SobreAPessoa(Cargo: Anotacao.Fato("sócio")));
 
-        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"]);
-        Assert.Equal("sócio", ficha.Preenchidos["Cargo"]);
+        Assert.Equal("cafeteria", ficha.Preenchidos["Ramo"].Valor);
+        Assert.Equal("sócio", ficha.Preenchidos["Cargo"].Valor);
     }
 
     [Fact]
@@ -57,12 +57,12 @@ public class FichaClienteTeste
         // "Ele era o decisor e agora nao e" e informacao de VENDA, nao
         // auditoria: a mudanca em si diz algo.
         var ficha = Nova();
-        ficha.Atualizar(T0, pessoa: new SobreAPessoa(PapelNaDecisao: "decisor"));
-        ficha.Atualizar(T0.AddDays(2), pessoa: new SobreAPessoa(PapelNaDecisao: "influenciador"));
+        ficha.Atualizar(T0, pessoa: new SobreAPessoa(PapelNaDecisao: Anotacao.Fato("decisor")));
+        ficha.Atualizar(T0.AddDays(2), pessoa: new SobreAPessoa(PapelNaDecisao: Anotacao.Fato("influenciador")));
 
-        Assert.Equal("influenciador", ficha.Preenchidos["Papel na decisão"]);
+        Assert.Equal("influenciador", ficha.Preenchidos["Papel na decisão"].Valor);
         Assert.Equal(2, ficha.Historico.Count);
-        Assert.Equal("decisor", ficha.Historico[0].Pessoa.PapelNaDecisao);
+        Assert.Equal("decisor", ficha.Historico[0].Pessoa.PapelNaDecisao!.Valor);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class FichaClienteTeste
         var ficha = Nova();
         Assert.Equal(12, ficha.Lacunas().Count);
 
-        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria", Porte: "3 lojas"));
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria"), Porte: Anotacao.Fato("3 lojas")));
 
         Assert.Equal(10, ficha.Lacunas().Count);
         Assert.DoesNotContain("Ramo", ficha.Lacunas());
@@ -97,7 +97,7 @@ public class FichaClienteTeste
         // trata ausencia declarada como fato apurado — passa a raciocinar sobre
         // "uma empresa cujo porte e desconhecido" em vez de nao falar de porte.
         var ficha = Nova();
-        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria"));
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
 
         var c2 = CamadaC2.Montar(ficha);
 
@@ -121,12 +121,12 @@ public class FichaClienteTeste
         // A #52 mostra isso no playbook; aqui e o mesmo sinal, para o vendedor
         // perceber quando a ficha ficou grande demais.
         var ficha = Nova();
-        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: "cafeteria de bairro"));
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria de bairro")));
         var pequena = CamadaC2.TokensEstimados(CamadaC2.Montar(ficha));
 
         ficha.Atualizar(T0, negocio: new SobreONegocio(
-            RiscoConhecido: "contrato vigente com fornecedor atual ate dezembro, "
-                          + "e o socio majoritario indicou esse fornecedor"));
+            RiscoConhecido: Anotacao.Fato("contrato vigente com fornecedor atual ate dezembro, "
+                          + "e o socio majoritario indicou esse fornecedor")));
         var maior = CamadaC2.TokensEstimados(CamadaC2.Montar(ficha));
 
         Assert.True(maior > pequena);

--- a/testes/Copiloto.Testes/PersistenciaTeste.cs
+++ b/testes/Copiloto.Testes/PersistenciaTeste.cs
@@ -5,6 +5,7 @@ using Copiloto.Dominio.Ia;
 using Copiloto.Dominio.Vendas;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Fichas = Copiloto.Dominio.Fichas;
 
 namespace Copiloto.Testes;
 
@@ -260,10 +261,10 @@ public class FichaNoBancoTeste : IDisposable
         var id = Guid.NewGuid();
         using (var ctx = new CopilotoDbContext(_opcoes))
         {
-            var ficha = new Copiloto.Dominio.Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
             ficha.Atualizar(T0,
-                empresa: new Copiloto.Dominio.Fichas.SobreAEmpresa(Ramo: "cafeteria", Porte: "3 lojas"),
-                pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(Cargo: "sócio"));
+                empresa: new Fichas.SobreAEmpresa(Ramo: Fichas.Anotacao.Fato("cafeteria"), Porte: Fichas.Anotacao.Fato("3 lojas")),
+                pessoa: new Fichas.SobreAPessoa(Cargo: Fichas.Anotacao.Fato("sócio")));
             ctx.Fichas.Add(ficha);
             ctx.SaveChanges();
         }
@@ -271,9 +272,9 @@ public class FichaNoBancoTeste : IDisposable
         using var leitura = new CopilotoDbContext(_opcoes);
         var lida = leitura.Fichas.Single(f => f.Id == id);
 
-        Assert.Equal("cafeteria", lida.Empresa.Ramo);
-        Assert.Equal("3 lojas", lida.Empresa.Porte);
-        Assert.Equal("sócio", lida.Pessoa.Cargo);
+        Assert.Equal("cafeteria", lida.Empresa.Ramo!.Valor);
+        Assert.Equal("3 lojas", lida.Empresa.Porte!.Valor);
+        Assert.Equal("sócio", lida.Pessoa.Cargo!.Valor);
         Assert.False(lida.EstaVazia);
     }
 
@@ -284,9 +285,9 @@ public class FichaNoBancoTeste : IDisposable
         var id = Guid.NewGuid();
         using (var ctx = new CopilotoDbContext(_opcoes))
         {
-            var ficha = new Copiloto.Dominio.Fichas.FichaCliente(id, Guid.NewGuid(), T0);
-            ficha.Atualizar(T0, pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(PapelNaDecisao: "decisor"));
-            ficha.Atualizar(T0.AddDays(2), pessoa: new Copiloto.Dominio.Fichas.SobreAPessoa(PapelNaDecisao: "influenciador"));
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("decisor")));
+            ficha.Atualizar(T0.AddDays(2), pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("influenciador")));
             ctx.Fichas.Add(ficha);
             ctx.SaveChanges();
         }
@@ -295,7 +296,7 @@ public class FichaNoBancoTeste : IDisposable
         var lida = leitura.Fichas.Single(f => f.Id == id);
 
         Assert.Equal(2, lida.Historico.Count);
-        Assert.Equal("decisor", lida.Historico[0].Pessoa.PapelNaDecisao);
+        Assert.Equal("decisor", lida.Historico[0].Pessoa.PapelNaDecisao!.Valor);
     }
 
     [Fact]
@@ -303,11 +304,38 @@ public class FichaNoBancoTeste : IDisposable
     {
         // O sistema funciona sem ela, e "funciona" inclui salvar.
         using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), Guid.NewGuid(), T0));
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), Guid.NewGuid(), T0));
 
         ctx.SaveChanges();
 
         Assert.True(ctx.Fichas.Single().EstaVazia);
+    }
+
+    [Fact]
+    public void A_natureza_da_anotacao_sobrevive_ao_banco()
+    {
+        // O conversor JSON e' quem reconstroi a Anotacao na leitura, e se ele
+        // errasse a natureza a impressao voltaria do banco como FATO — sem
+        // erro, sem log, e ancorando preco na proxima analise.
+        var id = Guid.NewGuid();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(
+                Cargo: Fichas.Anotacao.Fato("sócio", "LinkedIn"),
+                EstiloObservado: Fichas.Anotacao.Impressao("parece desconfiado", T0)));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.True(lida.Pessoa.Cargo!.EhFato);
+        Assert.Equal("LinkedIn", lida.Pessoa.Cargo!.Fonte);
+        Assert.False(lida.Pessoa.EstiloObservado!.EhFato);
+        Assert.Equal(T0, lida.Pessoa.EstiloObservado!.Quando);
+        Assert.Single(lida.Impressoes);
     }
 
     [Fact]
@@ -316,10 +344,10 @@ public class FichaNoBancoTeste : IDisposable
         // Duas seriam duas versoes da verdade sem criterio de desempate.
         var lead = Guid.NewGuid();
         using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
         ctx.SaveChanges();
 
-        ctx.Fichas.Add(new Copiloto.Dominio.Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
 
         Assert.Throws<DbUpdateException>(() => ctx.SaveChanges());
     }


### PR DESCRIPTION
**Base:** sai de `57-ancoragem-mcp` (#57), mexe no mesmo `BlocoSugerido`.

## O que muda
Cada linha da ficha vira `Anotacao` (valor, natureza, fonte, data). Sem conversao implicita de string: nada entra como fato por omissao. No prompt, fatos e impressoes vao em secoes separadas.

## Decisoes
- `AncoradoEm` recusa impressao em qualquer tatica que exija ancora (a issue citava tres; a distincao e sobre AFIRMAR, nao sobre a tatica).
- Persistencia: os tres blocos viraram JSON por conversor — o EF nao liga construtor a owned aninhado, e a alternativa era achatar `Anotacao` em 48 colunas.
- A migration DROPA as 12 colunas antigas; nao ha instalacao com dados, e o backfill esta comentado no arquivo.

Closes #88