### PR TITLE
Modo abordagem inicial quando o lead ainda nao tem conversa

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -53,6 +53,18 @@ implícita de `string`, então nada entra como fato por omissão, e `BlocoSugeri
 (tática livre) e nada além disso. A âncora que chega ao vendedor carrega a procedência
 junto — "isso saiu de uma impressão sua de 01/09" é o que lhe dá a chance de discordar.
 
+**Dois modos, e o frio é o difícil (#87).** Sem nenhuma mensagem no fio, o copiloto
+opera em *abordagem inicial*: monta ângulos a partir dos **fatos** da ficha, propõe o
+"por que agora" (só a partir de um fato que justifique o momento — ramo diz quem o
+cliente é, não o que mudou nele), sugere o canal por onde o lead chegou, e pergunta o
+horário, que nenhum campo sustenta.
+
+Ficha sem fato não produz mensagem: o copiloto pede informação, citando o campo. Aqui não
+há segunda chance — a sugestão ruim não é descartada na tela, ela vai para o cliente —, e
+saudação genérica com ficha vazia é pior que copiloto nenhum, porque dá ao vendedor a
+falsa sensação de que a mensagem foi pensada. Com um fato só, sai **um** ângulo: dois
+recortes do mesmo dado são a aparência de escolha sem a escolha.
+
 ---
 
 ## 3. Roteamento de modelos

--- a/src/Copiloto.Dominio/Planos/AbordagemInicial.cs
+++ b/src/Copiloto.Dominio/Planos/AbordagemInicial.cs
@@ -1,0 +1,158 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Fichas;
+
+namespace Copiloto.Dominio.Planos;
+
+/// <summary>
+/// Em que modo o copiloto opera para este lead (#87).
+/// </summary>
+public enum ModoDoCopiloto
+{
+    /// <summary>Ainda nao houve conversa: a proxima fala e a PRIMEIRA.</summary>
+    AbordagemInicial = 0,
+
+    /// <summary>Ja existe conversa: dossie do que foi dito + plano de continuidade.</summary>
+    Continuidade = 1,
+}
+
+/// <summary>
+/// A abordagem fria, que e o caso MAIS dificil e nao o mais facil (#87).
+///
+/// Na continuidade, sugestao ruim e descartada pelo vendedor e a conversa
+/// segue. Aqui nao ha segunda chance: o erro vai para o cliente e queima o
+/// lead de forma permanente — com menos contexto disponivel, porque sinal de
+/// conversa, a materia-prima mais confiavel do sistema, ainda nao existe.
+///
+/// Por isso a classe monta ANGULO ancorado, e nao mensagem pronta. "Olá João,
+/// espero que esteja bem! Vi que a empresa X..." e reconhecivel a um quilometro
+/// e produz o efeito oposto — e um copiloto que gera isso com ficha vazia e
+/// pior que copiloto nenhum, porque da ao vendedor a falsa sensacao de que a
+/// mensagem foi pensada. Quem escreve continua sendo o vendedor.
+/// </summary>
+public static class AbordagemInicial
+{
+    /// <summary>
+    /// Fatos que justificam falar HOJE, e nao em outro dia qualquer. Sao os
+    /// unicos rotulos da ficha que respondem "por que agora": os demais dizem
+    /// quem e o cliente, nao o que mudou nele.
+    /// </summary>
+    private static readonly string[] Ganchos =
+        ["Momento", "Como chegou", "Usa hoje", "Risco conhecido"];
+
+    /// <summary>Ausencia de conversa muda o modo do copiloto.</summary>
+    public static ModoDoCopiloto ModoPara(Conversa? conversa) =>
+        conversa is null || conversa.Mensagens.Count == 0
+            ? ModoDoCopiloto.AbordagemInicial
+            : ModoDoCopiloto.Continuidade;
+
+    /// <summary>
+    /// O plano da primeira fala, construido a partir de FATO especifico da
+    /// ficha.
+    ///
+    /// Ficha sem fato devolve so perguntas. Recusar-se a inventar quando nao ha
+    /// material e o comportamento correto — e o mesmo raciocinio da regra de
+    /// ancoragem (#15), aplicado ao momento em que o vendedor mais procrastina.
+    /// </summary>
+    public static Plano Montar(
+        Guid planoId, Guid dealId, FichaCliente? ficha, DateTimeOffset agora)
+    {
+        var plano = new Plano(planoId, dealId, agora);
+        var fatos = ficha?.Fatos ?? new Dictionary<string, Anotacao>();
+
+        if (fatos.Count == 0)
+        {
+            foreach (var bloco in SemMaterial(ficha)) plano.Adicionar(bloco);
+            return plano;
+        }
+
+        foreach (var bloco in Aberturas(fatos)) plano.Adicionar(bloco);
+        plano.Adicionar(PorQueAgora(fatos));
+        plano.Adicionar(Canal(fatos));
+
+        // O horario nao tem campo na ficha, entao nunca ha dado que o sustente:
+        // sugerir "mande de manha" seria palpite com cara de recomendacao.
+        plano.Adicionar(BlocoSugerido.Perguntar(Tatica.Livre,
+            "Você sabe o horário em que essa pessoa costuma responder? "
+            + "Sem isso, não dá para sugerir o momento do envio."));
+
+        return plano;
+    }
+
+    /// <summary>
+    /// Duas aberturas, de angulos diferentes, cada uma presa a um fato seu.
+    ///
+    /// Com um fato so, sai UMA abertura e uma pergunta — inventar o segundo
+    /// angulo a partir do mesmo fato daria duas versoes do mesmo texto, que e'
+    /// a aparencia de escolha sem a escolha.
+    /// </summary>
+    private static IEnumerable<BlocoSugerido> Aberturas(
+        IReadOnlyDictionary<string, Anotacao> fatos)
+    {
+        foreach (var (rotulo, fato) in fatos.Take(2))
+        {
+            yield return BlocoSugerido.AncoradoEm(Tatica.Livre,
+                $"Ângulo: abrir por {rotulo.ToLowerInvariant()} — {fato.Valor}. "
+                + "A primeira linha é o motivo do contato, e não saudação.",
+                fato);
+        }
+
+        if (fatos.Count == 1)
+        {
+            yield return BlocoSugerido.Perguntar(Tatica.Livre,
+                "Só há um fato apurado, então só há um ângulo honesto. "
+                + "O que mais você sabe desse cliente que eu possa usar como segundo?");
+        }
+    }
+
+    private static BlocoSugerido PorQueAgora(IReadOnlyDictionary<string, Anotacao> fatos)
+    {
+        var gancho = Ganchos.Where(fatos.ContainsKey).Select(g => (Rotulo: g, Fato: fatos[g]))
+                            .FirstOrDefault();
+
+        return gancho.Fato is null
+            ? BlocoSugerido.Perguntar(Tatica.Livre,
+                "O que justifica falar com ele HOJE? Sem gancho, a mensagem vira "
+                + "contato sem motivo — e é o tipo de coisa que só dá para mandar uma vez.")
+            : BlocoSugerido.AncoradoEm(Tatica.Livre,
+                $"Por que agora: {gancho.Fato.Valor}", gancho.Fato);
+    }
+
+    /// <summary>
+    /// O canal sai de "Como chegou": quem veio pelo Instagram responde no
+    /// Instagram. E dado, nao preferencia inventada.
+    /// </summary>
+    private static BlocoSugerido Canal(IReadOnlyDictionary<string, Anotacao> fatos) =>
+        fatos.TryGetValue("Como chegou", out var origem)
+            ? BlocoSugerido.AncoradoEm(Tatica.Livre,
+                $"Canal: responder por onde ele chegou — {origem.Valor}", origem)
+            : BlocoSugerido.Perguntar(Tatica.Livre,
+                "Por onde esse lead chegou? É o que diz em qual canal falar com ele.");
+
+    /// <summary>
+    /// Ficha sem fato: o copiloto PEDE informacao, e nao produz mensagem.
+    ///
+    /// Impressao registrada na ficha nao muda isso — ela vira pergunta de
+    /// confirmacao, porque "parece desconfiado" nao sustenta a primeira frase
+    /// que o cliente vai ler na vida dele sobre esta empresa (#88).
+    /// </summary>
+    private static IEnumerable<BlocoSugerido> SemMaterial(FichaCliente? ficha)
+    {
+        yield return BlocoSugerido.Perguntar(Tatica.Livre,
+            "Não há nenhum fato apurado sobre esse cliente, então não vou escrever "
+            + "uma abordagem: ela sairia genérica, e primeira mensagem genérica "
+            + "queima o lead de vez. Me diga uma coisa concreta e eu monto os ângulos.");
+
+        foreach (var (rotulo, impressao) in ficha?.Impressoes ?? new Dictionary<string, Anotacao>())
+        {
+            yield return BlocoSugerido.Perguntar(Tatica.Livre,
+                $"Você anotou uma impressão em {rotulo.ToLowerInvariant()}: "
+                + $"\"{impressao.Valor}\". Dá para confirmar isso como fato antes de eu usar?");
+        }
+
+        foreach (var lacuna in (ficha?.Lacunas() ?? []).Take(3))
+        {
+            yield return BlocoSugerido.Perguntar(Tatica.Livre,
+                $"O que você sabe sobre {lacuna.ToLowerInvariant()}?");
+        }
+    }
+}

--- a/testes/Copiloto.Testes/AbordagemInicialTeste.cs
+++ b/testes/Copiloto.Testes/AbordagemInicialTeste.cs
@@ -1,0 +1,193 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Fichas;
+using Copiloto.Dominio.Planos;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A abordagem fria (#87), que precisa de MAIS cuidado que a continuidade.
+///
+/// Na continuidade o vendedor descarta a sugestao ruim e a conversa segue.
+/// Aqui o erro vai para o cliente, e nao ha segunda mensagem inicial.
+/// </summary>
+public class AbordagemInicialTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+
+    private static FichaCliente FichaVazia() => new(Guid.NewGuid(), Guid.NewGuid(), T0);
+
+    private static Plano Montar(FichaCliente? ficha) =>
+        AbordagemInicial.Montar(Guid.NewGuid(), Guid.NewGuid(), ficha, T0);
+
+    [Fact]
+    public void Sem_conversa_o_copiloto_muda_de_modo()
+    {
+        Assert.Equal(ModoDoCopiloto.AbordagemInicial, AbordagemInicial.ModoPara(null));
+
+        var vazia = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        Assert.Equal(ModoDoCopiloto.AbordagemInicial, AbordagemInicial.ModoPara(vazia));
+    }
+
+    [Fact]
+    public void Com_uma_mensagem_ja_e_continuidade()
+    {
+        var conversa = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "bom dia", T0));
+
+        Assert.Equal(ModoDoCopiloto.Continuidade, AbordagemInicial.ModoPara(conversa));
+    }
+
+    [Fact]
+    public void Ficha_vazia_nao_produz_mensagem_pronta()
+    {
+        // O criterio inegociavel. Copiloto que gera saudacao generica com ficha
+        // vazia e PIOR que copiloto nenhum: da ao vendedor a falsa sensacao de
+        // que a mensagem foi pensada.
+        var plano = Montar(FichaVazia());
+
+        Assert.NotEmpty(plano.Blocos);
+        Assert.All(plano.Blocos, b => Assert.True(b.EhPergunta));
+    }
+
+    [Fact]
+    public void Sem_ficha_nenhuma_o_comportamento_e_o_mesmo()
+    {
+        var plano = Montar(null);
+
+        Assert.All(plano.Blocos, b => Assert.True(b.EhPergunta));
+    }
+
+    [Fact]
+    public void Ficha_vazia_pede_informacao_especifica_e_nao_generica()
+    {
+        // "Me manda mais dados" nao ajuda ninguem: a pergunta cita o campo.
+        var plano = Montar(FichaVazia());
+
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("ramo"));
+    }
+
+    [Fact]
+    public void So_com_impressao_ainda_nao_ha_abordagem()
+    {
+        // "Parece desconfiado" nao sustenta a primeira frase que o cliente vai
+        // ler na vida dele sobre esta empresa (#88).
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, pessoa: new SobreAPessoa(
+            EstiloObservado: Anotacao.Impressao("parece desconfiado")));
+
+        var plano = Montar(ficha);
+
+        Assert.All(plano.Blocos, b => Assert.True(b.EhPergunta));
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("confirmar isso como fato"));
+    }
+
+    [Fact]
+    public void Com_dois_fatos_saem_dois_angulos_diferentes()
+    {
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0,
+            empresa: new SobreAEmpresa(
+                Ramo: Anotacao.Fato("cafeteria de bairro"),
+                Momento: Anotacao.Fato("abriu a segunda loja em agosto", "Instagram")));
+
+        var angulos = Montar(ficha).Blocos.Where(b => !b.EhPergunta && b.Texto.StartsWith("Ângulo")).ToList();
+
+        Assert.Equal(2, angulos.Count);
+        Assert.NotEqual(angulos[0].Ancora, angulos[1].Ancora);
+    }
+
+    [Fact]
+    public void Cada_angulo_fica_preso_ao_fato_que_o_sustenta()
+    {
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(
+            Momento: Anotacao.Fato("abriu a segunda loja em agosto", "Instagram")));
+
+        var angulo = Montar(ficha).Blocos.First(b => b.Texto.StartsWith("Ângulo"));
+
+        Assert.Contains("segunda loja", angulo.Texto);
+        Assert.Contains("fato, Instagram", angulo.Ancora);
+    }
+
+    [Fact]
+    public void Com_um_fato_so_sai_um_angulo_e_um_pedido_do_segundo()
+    {
+        // Duas versoes do mesmo texto sao a aparencia de escolha sem a escolha.
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
+
+        var plano = Montar(ficha);
+
+        Assert.Single(plano.Blocos, b => b.Texto.StartsWith("Ângulo"));
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("segundo"));
+    }
+
+    [Fact]
+    public void O_porque_agora_sai_de_um_fato_que_justifique_o_momento()
+    {
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(
+            Momento: Anotacao.Fato("abriu a segunda loja em agosto")));
+
+        var plano = Montar(ficha);
+
+        var porQue = plano.Blocos.First(b => b.Texto.StartsWith("Por que agora"));
+        Assert.False(porQue.EhPergunta);
+        Assert.Contains("segunda loja", porQue.Texto);
+    }
+
+    [Fact]
+    public void Fato_que_nao_justifica_o_momento_nao_vira_gancho()
+    {
+        // "É cafeteria" diz quem o cliente e, nao o que mudou nele. Sem gancho,
+        // o contato nao tem motivo — e isso so da para mandar uma vez.
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
+
+        var plano = Montar(ficha);
+
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("HOJE"));
+    }
+
+    [Fact]
+    public void O_canal_sai_de_por_onde_o_lead_chegou()
+    {
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(
+            ComoChegou: Anotacao.Fato("respondeu um story no Instagram")));
+
+        var canal = Montar(ficha).Blocos.First(b => b.Texto.StartsWith("Canal"));
+
+        Assert.False(canal.EhPergunta);
+        Assert.Contains("Instagram", canal.Texto);
+    }
+
+    [Fact]
+    public void Sem_dado_de_canal_e_de_horario_os_dois_viram_pergunta()
+    {
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")));
+
+        var plano = Montar(ficha);
+
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("canal"));
+        Assert.Contains(plano.Perguntas, p => p.Texto.Contains("horário"));
+    }
+
+    [Fact]
+    public void Nenhum_bloco_e_mensagem_pronta_para_o_cliente()
+    {
+        // A tese do produto: o vendedor copia, edita e manda. O plano entrega
+        // ANGULO ancorado, e nao texto assinado por um robo.
+        var ficha = FichaVazia();
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(
+            Ramo: Anotacao.Fato("cafeteria"),
+            Momento: Anotacao.Fato("abriu a segunda loja em agosto")));
+
+        var plano = Montar(ficha);
+
+        Assert.DoesNotContain(plano.Blocos, b => b.Texto.Contains("Olá"));
+        Assert.DoesNotContain(plano.Blocos, b => b.Texto.Contains("espero que esteja bem"));
+        Assert.All(plano.Blocos.Where(b => !b.EhPergunta), b => Assert.NotNull(b.Ancora));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `88-fato-impressao` (#88).

## O que muda
Sem conversa, o copiloto monta angulos ancorados em FATO da ficha. Ficha sem fato devolve so perguntas, citando o campo que falta.

## Decisoes
- Um fato so gera UM angulo: dois recortes do mesmo dado sao aparencia de escolha sem escolha.
- "Por que agora" so sai de fato que justifique o momento; ramo diz quem o cliente e, nao o que mudou nele.
- Horario vira pergunta sempre: nenhum campo da ficha o sustenta.

Closes #87