### PR TITLE
Direitos do titular alem da exclusao

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -161,6 +161,30 @@ reter para sempre, indexar à vontade e dispensar controle de acesso. Nenhuma da
 coisas é verdade aqui — e isso vale especialmente para o índice de embeddings do RAG,
 que é uma base de dados pessoais como qualquer outra.
 
+### 7.35 Direitos do titular, além da exclusão
+
+Confirmação, acesso, correção, portabilidade, informação sobre compartilhamento e
+oposição (#81). Três decisões que o art. 18 não escreve por você:
+
+**A exportação inclui o que o sistema produziu**, não só o que entrou. O titular tem
+direito de saber que foi classificado como "sensível a preço" ou "esfriando" — é dado
+pessoal sobre ele, gerado por nós, e ele pode contestar. A ficha sai com **natureza e
+procedência**: ver "anotaram uma *impressão* de que eu pareço desconfiada" é outra coisa
+de ver uma lista de campos. E como o dossiê é recalculado, e não guardado, o arquivo
+**diz isso** — senão o titular conclui que aquilo é tudo, e contesta o dado sem poder
+contestar a conclusão.
+
+**Oposição para a análise sem apagar o histórico comercial.** O negócio continua, a
+conversa continua guardada pela mesma finalidade, o vendedor continua vendendo — o que
+para é o dossiê. Se opor-se custasse o histórico, ninguém se oporia, e a base de legítimo
+interesse ficaria frágil justamente por falta de canal real. O estado vive no banco: um
+"parem de me analisar" que vale até a próxima subida não é oposição.
+
+**O prazo mora no código.** 15 dias do art. 19 para a resposta completa, com aviso *antes*
+do vencimento — prazo que ninguém mede só aparece depois de vencido, e o que chega depois
+disso não é um lembrete, é uma notificação da ANPD. Pedido atendido não vence depois:
+alarme falso esconde os que ainda importam.
+
 ### 7.4 Controles de engenharia
 
 - **PII Shield** mascarando antes da saída da rede, com teste que **falha o build** se

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
@@ -14,6 +14,12 @@ public class LeadMap : IEntityTypeConfiguration<Lead>
         e.Property(l => l.Nome).HasMaxLength(200);
         e.Property(l => l.CriadoEm).IsRequired();
 
+        // A oposicao a analise (#81) e' estado do titular, nao configuracao de
+        // uso: ela precisa sobreviver a restart, a deploy e a troca de
+        // instancia — senao o "parem de me analisar" vale ate a proxima subida.
+        e.Property(l => l.AnaliseDeIaSuspensa).IsRequired();
+        e.Property(l => l.OpostoEm);
+
         // O indice UNICO e o ponto que nao da para deixar so no codigo.
         //
         // A #22 resolveu a normalizacao, mas duas instancias processando a mesma

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904030959_OposicaoDoTitular.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904030959_OposicaoDoTitular.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904030959_OposicaoDoTitular")]
+    partial class OposicaoDoTitular
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904030959_OposicaoDoTitular.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904030959_OposicaoDoTitular.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class OposicaoDoTitular : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AnaliseDeIaSuspensa",
+                table: "leads",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "OpostoEm",
+                table: "leads",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AnaliseDeIaSuspensa",
+                table: "leads");
+
+            migrationBuilder.DropColumn(
+                name: "OpostoEm",
+                table: "leads");
+        }
+    }
+}

--- a/src/Copiloto.Api/Titulares/ExportacaoDoTitular.cs
+++ b/src/Copiloto.Api/Titulares/ExportacaoDoTitular.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Fichas;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Api.Titulares;
+
+/// <summary>Uma linha da ficha, como ela sai para o titular.</summary>
+public record AnotacaoExportada(string Campo, string Valor, string Natureza, string? Fonte);
+
+/// <summary>Uma fala, como ela sai para o titular.</summary>
+public record MensagemExportada(string Autor, string Texto, DateTimeOffset EnviadaEm);
+
+/// <summary>Um negocio, e o que o sistema concluiu dentro dele.</summary>
+public record NegocioExportado(Guid Id, string Estagio, DateTimeOffset AbertoEm);
+
+/// <summary>
+/// Tudo que o sistema tem sobre um titular, no formato que ele leva embora.
+/// </summary>
+public record DadosDoTitular(
+    Guid LeadId,
+    string Telefone,
+    string? Nome,
+    DateTimeOffset CriadoEm,
+    bool AnaliseDeIaSuspensa,
+    IReadOnlyList<AnotacaoExportada> FichaDoCliente,
+    IReadOnlyList<MensagemExportada> Conversas,
+    IReadOnlyList<NegocioExportado> Negocios,
+    IReadOnlyList<string> CompartilhadoCom,
+    IReadOnlyList<string> Observacoes);
+
+/// <summary>
+/// Confirmacao, acesso e portabilidade num lugar so (#81).
+///
+/// O criterio dificil da issue e o primeiro, e ele nao e tecnico: o titular tem
+/// direito de saber que o sistema o classificou como "sensivel a preco" ou
+/// "esfriando". Isso e dado pessoal SOBRE ELE, gerado por nos, e ele pode
+/// contestar — protege-se o que entrou e esquece-se o que o sistema produziu.
+///
+/// Por isso a exportacao inclui a ficha com natureza e procedencia (#88): ver
+/// "anotaram uma IMPRESSAO de que eu pareco desconfiado" e outra coisa de ver
+/// uma lista de campos.
+/// </summary>
+public class ExportacaoDoTitular
+{
+    private static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
+
+    private readonly CopilotoDbContext _ctx;
+    private readonly IReadOnlyList<string> _suboperadores;
+
+    /// <param name="suboperadores">
+    /// Com quem o dado foi compartilhado (art. 18, VII). Vem de CONFIGURACAO e
+    /// nao de constante: a lista muda quando alguem troca o provedor de modelo,
+    /// e uma resposta ao titular que envelhece em silencio e pior que nenhuma.
+    /// </param>
+    public ExportacaoDoTitular(CopilotoDbContext ctx, IReadOnlyList<string> suboperadores)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        _ctx = ctx;
+        _suboperadores = suboperadores;
+    }
+
+    /// <summary>Sim ou nao: existe tratamento de dado deste titular?</summary>
+    public Task<bool> Confirmar(Guid leadId, CancellationToken ct) =>
+        _ctx.Leads.AnyAsync(l => l.Id == leadId, ct);
+
+    public async Task<DadosDoTitular?> Exportar(Guid leadId, CancellationToken ct)
+    {
+        var lead = await _ctx.Leads.AsNoTracking().FirstOrDefaultAsync(l => l.Id == leadId, ct);
+        if (lead is null) return null;
+
+        var ficha = await _ctx.Fichas.AsNoTracking().FirstOrDefaultAsync(f => f.LeadId == leadId, ct);
+        var conversas = await _ctx.Conversas.AsNoTracking()
+            .Include(c => c.Mensagens)
+            .Where(c => c.LeadId == leadId)
+            .ToListAsync(ct);
+        var negocios = await _ctx.Deals.AsNoTracking()
+            .Where(d => d.LeadId == leadId)
+            .ToListAsync(ct);
+
+        var anotacoes = (ficha?.Preenchidos ?? new Dictionary<string, Anotacao>())
+            .Select(p => new AnotacaoExportada(
+                p.Key, p.Value.Valor,
+                p.Value.EhFato ? "fato" : "impressão do vendedor",
+                p.Value.Fonte))
+            .ToList();
+
+        var mensagens = conversas
+            .SelectMany(c => c.Mensagens)
+            .OrderBy(m => m.EnviadaEm)
+            .Select(m => new MensagemExportada(m.Autor.ToString(), m.Texto, m.EnviadaEm))
+            .ToList();
+
+        return new DadosDoTitular(
+            lead.Id, lead.Telefone, lead.Nome, lead.CriadoEm,
+            lead.AnaliseDeIaSuspensa,
+            anotacoes,
+            mensagens,
+            negocios.Select(d => new NegocioExportado(d.Id, d.Estagio.ToString(), d.AbertoEm)).ToList(),
+            _suboperadores,
+            Observacoes(anotacoes));
+    }
+
+    /// <summary>
+    /// JSON identado — "formato estruturado e de uso comum" do art. 18, V.
+    ///
+    /// Identado de proposito: portabilidade que sai como uma linha de 40 mil
+    /// caracteres atende a letra e nao serve ao titular, que e uma pessoa
+    /// abrindo um arquivo.
+    /// </summary>
+    public async Task<string?> ExportarComoJson(Guid leadId, CancellationToken ct)
+    {
+        var dados = await Exportar(leadId, ct);
+        return dados is null ? null : JsonSerializer.Serialize(dados, Json);
+    }
+
+    /// <summary>
+    /// O que a exportacao precisa DIZER, alem do que ela mostra.
+    ///
+    /// Arquivo que so lista campos deixa o titular concluir que aquilo e tudo, e
+    /// duas coisas aqui nao sao obvias: impressao nao e fato apurado, e o
+    /// dossie nao esta no arquivo porque ele e recalculado, nao guardado.
+    /// </summary>
+    private static IReadOnlyList<string> Observacoes(IReadOnlyList<AnotacaoExportada> anotacoes)
+    {
+        var notas = new List<string>
+        {
+            "As inferências do sistema (estágio, objeção, \"esfriando\") são recalculadas "
+            + "a partir das conversas acima e não ficam guardadas: o que as origina está "
+            + "neste arquivo, e você pode contestar tanto o dado quanto a conclusão.",
+        };
+
+        if (anotacoes.Any(a => a.Natureza.StartsWith("impressão")))
+        {
+            notas.Add(
+                "Algumas linhas da ficha são IMPRESSÕES de quem atendeu, e não fatos "
+                + "apurados. Elas estão marcadas como tal, e você pode pedir correção "
+                + "ou remoção delas.");
+        }
+
+        return notas;
+    }
+}

--- a/src/Copiloto.Dominio/Titulares/PedidoDoTitular.cs
+++ b/src/Copiloto.Dominio/Titulares/PedidoDoTitular.cs
@@ -1,0 +1,68 @@
+namespace Copiloto.Dominio.Titulares;
+
+/// <summary>O que o titular pediu (art. 18).</summary>
+public enum TipoDePedido
+{
+    /// <summary>"Voces tratam dado meu?"</summary>
+    Confirmacao = 0,
+
+    /// <summary>"Me mostrem tudo que voces tem sobre mim."</summary>
+    Acesso = 1,
+
+    Correcao = 2,
+
+    /// <summary>Em formato estruturado, para levar embora.</summary>
+    Portabilidade = 3,
+
+    /// <summary>"Com quem voces compartilharam?"</summary>
+    Compartilhamento = 4,
+
+    /// <summary>"Parem de me analisar" — sem apagar o historico comercial.</summary>
+    Oposicao = 5,
+
+    Exclusao = 6,
+}
+
+/// <summary>
+/// Um pedido de titular, com o relogio correndo (#81).
+///
+/// O prazo mora aqui, e nao numa planilha, porque prazo que ninguem mede so
+/// aparece depois de vencido — e o que chega depois disso nao e um lembrete, e
+/// uma notificacao da ANPD.
+/// </summary>
+public record PedidoDoTitular(
+    Guid Id, Guid LeadId, TipoDePedido Tipo, DateTimeOffset RecebidoEm,
+    DateTimeOffset? AtendidoEm = null)
+{
+    /// <summary>
+    /// Quinze dias, o prazo do art. 19 para a declaracao clara e completa.
+    ///
+    /// A lei tambem preve resposta em formato SIMPLIFICADO de imediato — e o
+    /// caso da confirmacao, que e um sim ou nao. O prazo aqui e o da resposta
+    /// completa, que e a que exige trabalho e portanto a que atrasa.
+    /// </summary>
+    public static readonly TimeSpan Prazo = TimeSpan.FromDays(15);
+
+    /// <summary>Quando este pedido passa a estar atrasado.</summary>
+    public DateTimeOffset VenceEm => RecebidoEm + Prazo;
+
+    public bool Atendido => AtendidoEm is not null;
+
+    /// <summary>
+    /// Passou do prazo e ninguem atendeu. Pedido ATENDIDO nao vence depois —
+    /// contar atraso de quem ja respondeu encheria o painel de alarme falso e
+    /// esconderia os que ainda importam.
+    /// </summary>
+    public bool Vencido(DateTimeOffset agora) => !Atendido && agora > VenceEm;
+
+    /// <summary>
+    /// Falta pouco. Serve para o alerta chegar ANTES, que e a unica hora em que
+    /// ele muda alguma coisa.
+    /// </summary>
+    public bool VencendoEm(DateTimeOffset agora, TimeSpan antecedencia) =>
+        !Atendido && !Vencido(agora) && agora >= VenceEm - antecedencia;
+
+    public PedidoDoTitular Atender(DateTimeOffset quando) => this with { AtendidoEm = quando };
+
+    public TimeSpan? TempoDeResposta => AtendidoEm - RecebidoEm;
+}

--- a/src/Copiloto.Dominio/Vendas/Lead.cs
+++ b/src/Copiloto.Dominio/Vendas/Lead.cs
@@ -27,10 +27,56 @@ public class Lead
     public string? Nome { get; private set; }
     public DateTimeOffset CriadoEm { get; }
 
+    /// <summary>
+    /// O titular se opos a analise por IA (art. 18, #81).
+    ///
+    /// Nao apaga nada: o historico comercial continua, o vendedor continua
+    /// vendendo, e a conversa continua sendo guardada pela mesma finalidade de
+    /// antes. O que para e a ANALISE — dossie, sinais, plano.
+    ///
+    /// Separar as duas coisas e o que faz a oposicao ser usavel: se opor-se
+    /// custasse o historico do negocio, ninguem se oporia, e a base de legitimo
+    /// interesse ficaria fragil justamente por falta de canal real.
+    /// </summary>
+    public bool AnaliseDeIaSuspensa { get; private set; }
+
+    public DateTimeOffset? OpostoEm { get; private set; }
+
     /// <summary>Nome descoberto no meio da conversa, que e como ele costuma chegar.</summary>
     public void Identificar(string nome)
     {
         if (string.IsNullOrWhiteSpace(nome)) return;
         Nome = nome.Trim();
+    }
+
+    /// <summary>
+    /// Correcao de dado cadastral (art. 18, III).
+    ///
+    /// Vale para o nome, que e o que costuma vir errado — soletrado no
+    /// atendimento, ou de outra pessoa que usou o mesmo telefone. O telefone
+    /// nao muda aqui: ele e a identidade pratica do Lead, e troca-lo em silencio
+    /// misturaria dois titulares num registro so.
+    /// </summary>
+    public void CorrigirNome(string nome)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+            throw new ArgumentException(
+                "Correcao precisa do valor certo. Para APAGAR o nome, o pedido e "
+                + "de exclusao (#46), que tem outro rito.", nameof(nome));
+
+        Nome = nome.Trim();
+    }
+
+    public void OporSeAAnalise(DateTimeOffset quando)
+    {
+        AnaliseDeIaSuspensa = true;
+        OpostoEm = quando;
+    }
+
+    /// <summary>O titular mudou de ideia. Acontece, e precisa ser tao facil quanto opor-se.</summary>
+    public void RetomarAnalise()
+    {
+        AnaliseDeIaSuspensa = false;
+        OpostoEm = null;
     }
 }

--- a/testes/Copiloto.Testes/DireitosDoTitularTeste.cs
+++ b/testes/Copiloto.Testes/DireitosDoTitularTeste.cs
@@ -1,0 +1,272 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Api.Titulares;
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Fichas;
+using Copiloto.Dominio.Titulares;
+using Copiloto.Dominio.Vendas;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Os direitos do art. 18 alem da exclusao (#81).
+///
+/// O criterio dificil nao e tecnico: o titular tem direito de saber que o
+/// sistema o classificou. Protege-se o dado que entrou e esquece-se o que o
+/// sistema produziu — e o segundo tambem e dado pessoal sobre ele.
+/// </summary>
+public class DireitosDoTitularTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public DireitosDoTitularTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    private Guid GravarTitularCompleto()
+    {
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var leadId = Guid.NewGuid();
+
+        var lead = new Lead(leadId, "+55 11 98888-1111", T0, "Marina");
+        var deal = new Deal(Guid.NewGuid(), leadId, T0);
+        var conversa = new Conversa(Guid.NewGuid(), leadId);
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "qual o valor do kg?", T0));
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Vendedor, "R$ 68", T0.AddMinutes(4)));
+
+        var ficha = new FichaCliente(Guid.NewGuid(), leadId, T0);
+        ficha.Atualizar(T0,
+            empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria", "o cliente disse")),
+            pessoa: new SobreAPessoa(EstiloObservado: Anotacao.Impressao("parece desconfiada", T0)));
+
+        ctx.Leads.Add(lead);
+        ctx.Deals.Add(deal);
+        ctx.Conversas.Add(conversa);
+        ctx.Fichas.Add(ficha);
+        ctx.SaveChanges();
+
+        return leadId;
+    }
+
+    private ExportacaoDoTitular Exportador(CopilotoDbContext ctx) =>
+        new(ctx, ["Provedor de modelo: nenhum (MODEL_PROVIDER=fake)"]);
+
+    // --- Confirmacao e acesso ---
+
+    [Fact]
+    public async Task Confirmacao_responde_sim_ou_nao()
+    {
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.True(await Exportador(ctx).Confirmar(leadId, default));
+        Assert.False(await Exportador(ctx).Confirmar(Guid.NewGuid(), default));
+    }
+
+    [Fact]
+    public async Task O_acesso_traz_conversa_ficha_e_negocio()
+    {
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var dados = await Exportador(ctx).Exportar(leadId, default);
+
+        Assert.NotNull(dados);
+        Assert.Equal("Marina", dados!.Nome);
+        Assert.Equal(2, dados.Conversas.Count);
+        Assert.Equal(2, dados.FichaDoCliente.Count);
+        Assert.Single(dados.Negocios);
+    }
+
+    [Fact]
+    public async Task A_exportacao_diz_o_que_e_fato_e_o_que_e_impressao()
+    {
+        // Ver "anotaram uma IMPRESSAO de que eu pareco desconfiada" e outra
+        // coisa de ver uma lista de campos (#88).
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var dados = await Exportador(ctx).Exportar(leadId, default);
+
+        Assert.Contains(dados!.FichaDoCliente, a => a.Natureza == "fato" && a.Fonte == "o cliente disse");
+        Assert.Contains(dados.FichaDoCliente, a => a.Natureza.StartsWith("impressão"));
+        Assert.Contains(dados.Observacoes, o => o.Contains("IMPRESSÕES"));
+    }
+
+    [Fact]
+    public async Task A_exportacao_explica_as_inferencias_que_nao_estao_no_arquivo()
+    {
+        // Arquivo que so lista campos deixa o titular concluir que aquilo e
+        // tudo. O dossie e recalculado, e ele precisa saber disso para poder
+        // contestar a CONCLUSAO, e nao so o dado.
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var dados = await Exportador(ctx).Exportar(leadId, default);
+
+        Assert.Contains(dados!.Observacoes, o => o.Contains("recalculadas"));
+        Assert.Contains(dados.Observacoes, o => o.Contains("contestar"));
+    }
+
+    [Fact]
+    public async Task O_titular_recebe_com_quem_o_dado_foi_compartilhado()
+    {
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var dados = await Exportador(ctx).Exportar(leadId, default);
+
+        Assert.Contains(dados!.CompartilhadoCom, c => c.Contains("Provedor de modelo"));
+    }
+
+    [Fact]
+    public async Task Titular_que_nao_existe_nao_vira_arquivo_vazio()
+    {
+        // Devolver um JSON com campos em branco pareceria "temos um cadastro
+        // seu, mas esta vazio" — que e uma resposta errada, e nao uma resposta
+        // pobre.
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.Null(await Exportador(ctx).Exportar(Guid.NewGuid(), default));
+        Assert.Null(await Exportador(ctx).ExportarComoJson(Guid.NewGuid(), default));
+    }
+
+    // --- Portabilidade ---
+
+    [Fact]
+    public async Task A_portabilidade_sai_em_json_legivel_por_maquina_e_por_gente()
+    {
+        var leadId = GravarTitularCompleto();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var json = await Exportador(ctx).ExportarComoJson(leadId, default);
+
+        Assert.NotNull(json);
+        Assert.Contains("\"telefone\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("qual o valor do kg?", json);
+        Assert.Contains("\n", json);   // identado: quem abre e uma pessoa
+    }
+
+    // --- Correcao ---
+
+    [Fact]
+    public void Correcao_arruma_o_nome_errado()
+    {
+        var lead = new Lead(Guid.NewGuid(), "+55 11 98888-1111", T0, "Marinna");
+
+        lead.CorrigirNome("Marina");
+
+        Assert.Equal("Marina", lead.Nome);
+    }
+
+    [Fact]
+    public void Correcao_vazia_nao_e_jeito_de_apagar_o_nome()
+    {
+        // Apagar tem outro rito, que e a exclusao (#46).
+        var lead = new Lead(Guid.NewGuid(), "+55 11 98888-1111", T0, "Marina");
+
+        Assert.Throws<ArgumentException>(() => lead.CorrigirNome("  "));
+        Assert.Equal("Marina", lead.Nome);
+    }
+
+    // --- Oposicao ---
+
+    [Fact]
+    public void Oposicao_para_a_analise_sem_apagar_o_historico()
+    {
+        // Se opor-se custasse o historico do negocio, ninguem se oporia — e a
+        // base de legitimo interesse ficaria fragil por falta de canal real.
+        var lead = new Lead(Guid.NewGuid(), "+55 11 98888-1111", T0, "Marina");
+
+        lead.OporSeAAnalise(T0);
+
+        Assert.True(lead.AnaliseDeIaSuspensa);
+        Assert.Equal(T0, lead.OpostoEm);
+        Assert.Equal("Marina", lead.Nome);
+        Assert.Equal("+55 11 98888-1111", lead.Telefone);
+    }
+
+    [Fact]
+    public void Quem_se_opos_pode_mudar_de_ideia()
+    {
+        var lead = new Lead(Guid.NewGuid(), "+55 11 98888-1111", T0);
+        lead.OporSeAAnalise(T0);
+
+        lead.RetomarAnalise();
+
+        Assert.False(lead.AnaliseDeIaSuspensa);
+        Assert.Null(lead.OpostoEm);
+    }
+
+    [Fact]
+    public async Task A_oposicao_sobrevive_ao_banco()
+    {
+        // "Parem de me analisar" que vale ate a proxima subida nao e oposicao.
+        var leadId = GravarTitularCompleto();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var lead = ctx.Leads.Single(l => l.Id == leadId);
+            lead.OporSeAAnalise(T0);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.True(leitura.Leads.Single(l => l.Id == leadId).AnaliseDeIaSuspensa);
+        Assert.True((await Exportador(leitura).Exportar(leadId, default))!.AnaliseDeIaSuspensa);
+    }
+
+    // --- Prazo ---
+
+    [Fact]
+    public void O_prazo_de_atendimento_corre_do_recebimento()
+    {
+        var pedido = new PedidoDoTitular(Guid.NewGuid(), Guid.NewGuid(), TipoDePedido.Acesso, T0);
+
+        Assert.Equal(T0.AddDays(15), pedido.VenceEm);
+        Assert.False(pedido.Vencido(T0.AddDays(14)));
+        Assert.True(pedido.Vencido(T0.AddDays(16)));
+    }
+
+    [Fact]
+    public void O_aviso_chega_antes_de_vencer_que_e_quando_ainda_adianta()
+    {
+        var pedido = new PedidoDoTitular(Guid.NewGuid(), Guid.NewGuid(), TipoDePedido.Portabilidade, T0);
+
+        Assert.False(pedido.VencendoEm(T0.AddDays(9), TimeSpan.FromDays(5)));
+        Assert.True(pedido.VencendoEm(T0.AddDays(11), TimeSpan.FromDays(5)));
+    }
+
+    [Fact]
+    public void Pedido_atendido_nao_vence_depois()
+    {
+        // Contar atraso de quem ja respondeu encheria o painel de alarme falso
+        // e esconderia os pedidos que ainda importam.
+        var pedido = new PedidoDoTitular(Guid.NewGuid(), Guid.NewGuid(), TipoDePedido.Acesso, T0)
+            .Atender(T0.AddDays(2));
+
+        Assert.False(pedido.Vencido(T0.AddDays(30)));
+        Assert.False(pedido.VencendoEm(T0.AddDays(30), TimeSpan.FromDays(5)));
+        Assert.Equal(TimeSpan.FromDays(2), pedido.TempoDeResposta);
+    }
+
+    [Fact]
+    public void Pedido_novo_ainda_nao_tem_tempo_de_resposta()
+    {
+        var pedido = new PedidoDoTitular(Guid.NewGuid(), Guid.NewGuid(), TipoDePedido.Oposicao, T0);
+
+        Assert.Null(pedido.TempoDeResposta);
+        Assert.False(pedido.Atendido);
+    }
+}


### PR DESCRIPTION
**Base:** sai de `87-abordagem-inicial` (#87).

## O que muda
Confirmacao, acesso, correcao, portabilidade, compartilhamento e oposicao. A exportacao inclui a ficha com natureza e procedencia, e o prazo do art. 19 e medido em codigo.

## Decisoes
- O arquivo DIZ o que nao esta nele: o dossie e recalculado, nao guardado — sem isso o titular contesta o dado sem saber que pode contestar a conclusao.
- Oposicao suspende a analise sem apagar o historico comercial. Se custasse o historico, ninguem se oporia, e a base de legitimo interesse ficaria fragil.
- Titular inexistente devolve null, e nao JSON de campos vazios.

Closes #81