### PR TITLE
Dado sensivel em regime proprio

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -191,7 +191,16 @@ alarme falso esconde os que ainda importam.
   vazar em log ou payload.
 - **Dado sensível** (saúde, religião, origem racial) chega sozinho em conversa livre.
   Nunca entra no índice, nunca vira inferência de perfil, nunca calibra técnica de
-  persuasão.
+  persuasão — e a garantia é estrutural (#82): a `MolduraDeContexto`, único caminho da
+  fala do cliente até o modelo, troca o trecho por `[SENSIVEL:categoria]` antes de montar
+  o bloco. O que não está lá não calibra nada. O trecho sai, a **frase fica**: em "to com
+  refluxo, posso tomar café?" o pedido está na segunda metade, e descartar a fala inteira
+  perderia a venda junto com o dado. Retenção própria, de 30 dias.
+- **Frequência é sinal de processo, não de cliente.** Dado sensível em cinco *conversas*
+  distintas numa semana dispara alerta ao gestor: quase nunca é coincidência, e costuma
+  ser um formulário, um roteiro de abordagem ou uma campanha pedindo informação que a
+  empresa não precisa. Cinco menções na mesma conversa não disparam nada — é um cliente
+  falante.
 - **Retenção** configurável por finalidade; conversa antiga vira resumo ou é expurgada.
 - **Exclusão em cascata**, incluindo os embeddings — apagar o Lead sem apagar o vetor
   deixa o dado vivo depois de o titular pedir exclusão.

--- a/src/Copiloto.Api/Seguranca/DadoSensivel.cs
+++ b/src/Copiloto.Api/Seguranca/DadoSensivel.cs
@@ -1,0 +1,147 @@
+using System.Text.RegularExpressions;
+
+namespace Copiloto.Api.Seguranca;
+
+/// <summary>As categorias do art. 11 que aparecem em conversa de venda.</summary>
+public enum CategoriaSensivel
+{
+    Saude = 0,
+    ConviccaoReligiosa = 1,
+    OrigemRacialOuEtnica = 2,
+    OpiniaoPolitica = 3,
+    FiliacaoSindical = 4,
+    VidaSexual = 5,
+
+    /// <summary>Genetico ou biometrico.</summary>
+    CorpoIdentificavel = 6,
+}
+
+/// <summary>Onde o indicio apareceu, e de que categoria ele e.</summary>
+public record IndicioSensivel(CategoriaSensivel Categoria, string Trecho);
+
+/// <summary>
+/// Dado sensivel que chega sozinho na conversa, e o regime proprio dele (#82).
+///
+/// Ninguem planeja coletar dado sensivel: conversa de WhatsApp e livre, e o
+/// cliente conta da vida dele. "To com refluxo, posso tomar cafe?" e dado de
+/// saude — art. 11, regime mais rigoroso, consentimento especifico e destacado
+/// como regra.
+///
+/// O que mais importa aqui e eticamente: mencao de saude ou de fe NAO pode
+/// calibrar tecnica de persuasao. Usar "nao bebo por questao de fe" para
+/// escolher o angulo da venda e exatamente o uso que a lei trata com rigor, e
+/// que destruiria a confianca do cliente se viesse a publico.
+///
+/// A garantia nao e uma instrucao no prompt: o trecho sensivel nao chega ao
+/// modelo (<see cref="ForaDoContextoDeSugestao"/>) e nao entra no indice
+/// (<see cref="PodeIndexar"/>). O que nao esta la nao calibra nada.
+/// </summary>
+public static class DadoSensivel
+{
+    /// <summary>
+    /// Retencao mais curta que a da conversa comum.
+    ///
+    /// O numero e conservador de proposito e vai virar configuracao quando a
+    /// politica por finalidade existir (ARQUITETURA secao 7). Enquanto isso,
+    /// vale o principio: dado que ninguem pediu, e que a empresa nao tem
+    /// finalidade para usar, nao pode ficar pelo prazo do que ela pediu.
+    /// </summary>
+    public static readonly TimeSpan Retencao = TimeSpan.FromDays(30);
+
+    // Os padroes sao amplos, pelo mesmo motivo do `DetectorDePii`: falso
+    // positivo custa um trecho a menos no contexto; falso negativo custa dado
+    // de saude do cliente indexado num banco vetorial.
+    //
+    // O que ficou DE FORA, e por que — e a parte que erra caro:
+    //
+    //   "preto"   — "cafe preto" e a frase mais provavel deste produto
+    //   "direita" — "a prateleira da direita"
+    //   "digital" — "marketing digital"
+    //   "fe"      — dentro de "cafe" nao casa com \b, mas "fe" solto tambem
+    //               aparece em "fe em voces"; so entra com "questao de fe"
+    //
+    // Um detector que marca metade das conversas de uma cafeteria como
+    // sensiveis nao protege ninguem: ele e desligado na primeira semana.
+    private static readonly (CategoriaSensivel Categoria, Regex Padrao)[] Indicios =
+    [
+        (CategoriaSensivel.Saude, new Regex(
+            @"\b(refluxo|gastrite|[úu]lcera|diabet\w*|hipertens\w*|press[ãa]o alta|"
+            + @"colesterol|ins[ôo]nia|ansiedade|depress[ãa]o|gr[áa]vid\w*|gesta[çc][ãa]o|"
+            + @"amamenta\w*|rem[ée]dio|medicamento|al[ée]rgic\w*|alergia|intoler[âa]ncia|"
+            + @"cirurgia|quimioterapia|doen[çc]a|diagn[óo]stico|laudo m[ée]dico)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.ConviccaoReligiosa, new Regex(
+            @"\b(quest[ãa]o de f[ée]|religi[ãa]o|religios\w*|evang[ée]lic\w*|cat[óo]lic\w*|"
+            + @"esp[íi]rita|umbanda|candombl[ée]|judeu|judaica|kosher|halal|"
+            + @"mu[çc]ulman\w*|igreja|jejum|quaresma|ramad[ãa])\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.OrigemRacialOuEtnica, new Regex(
+            @"\b(pessoa negra|pessoas negras|afrodescendente|afro-brasileir\w*|"
+            + @"ind[íi]gena|quilombola|etnia)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.OpiniaoPolitica, new Regex(
+            @"\b(votei|voto n\w+|candidat\w+|partido|elei[çc][ãa]o|elei[çc][õo]es)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.FiliacaoSindical, new Regex(
+            @"\b(sindicato|sindicaliz\w*|sindical)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.VidaSexual, new Regex(
+            @"\b(orienta[çc][ãa]o sexual|homossexual|bissexual|LGBT\w*|transexual|transg[êe]nero)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+
+        (CategoriaSensivel.CorpoIdentificavel, new Regex(
+            @"\b(exame de DNA|DNA|biometria|biom[ée]tric\w*|impress[ãa]o digital|"
+            + @"reconhecimento facial)\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase)),
+    ];
+
+    /// <summary>O que na fala indica dado sensivel. Vazio e o caso comum.</summary>
+    public static IReadOnlyList<IndicioSensivel> Detectar(string? texto)
+    {
+        if (string.IsNullOrWhiteSpace(texto)) return [];
+
+        var achados = new List<IndicioSensivel>();
+        foreach (var (categoria, padrao) in Indicios)
+            foreach (Match m in padrao.Matches(texto))
+                achados.Add(new IndicioSensivel(categoria, m.Value));
+
+        return achados;
+    }
+
+    /// <summary>
+    /// Se a fala pode ir para o indice de embeddings (#62).
+    ///
+    /// Indice e o pior destino possivel para dado sensivel: ele deixa de estar
+    /// numa conversa e passa a ser RECUPERAVEL por semelhanca, aparecendo em
+    /// analise de outro cliente sem que ninguem tenha pedido.
+    /// </summary>
+    public static bool PodeIndexar(string? texto) => Detectar(texto).Count == 0;
+
+    /// <summary>
+    /// A fala como ela vai ao modelo: o trecho sensivel sai, o resto fica.
+    ///
+    /// Descartar a fala INTEIRA seria perder a venda junto com o dado — em "to
+    /// com refluxo, posso tomar cafe?" o pedido esta na segunda metade. O
+    /// marcador tambem diz ao modelo que ali havia algo que ele nao vai ver, o
+    /// que evita a leitura de que a frase estava truncada.
+    /// </summary>
+    public static string ForaDoContextoDeSugestao(string? texto)
+    {
+        if (string.IsNullOrEmpty(texto)) return texto ?? "";
+
+        var saida = texto;
+        foreach (var (categoria, padrao) in Indicios)
+            saida = padrao.Replace(saida, $"[SENSIVEL:{categoria}]");
+
+        return saida;
+    }
+
+    /// <summary>Passou do prazo proprio, mais curto que o da conversa.</summary>
+    public static bool DeveExpurgar(DateTimeOffset registradaEm, DateTimeOffset agora) =>
+        agora - registradaEm >= Retencao;
+}

--- a/src/Copiloto.Api/Seguranca/IncidenciaDeDadoSensivel.cs
+++ b/src/Copiloto.Api/Seguranca/IncidenciaDeDadoSensivel.cs
@@ -1,0 +1,51 @@
+namespace Copiloto.Api.Seguranca;
+
+/// <summary>
+/// Conta com que frequencia dado sensivel aparece, e avisa o gestor (#82).
+///
+/// O alerta NAO e sobre o cliente que falou: e sobre o PROCESSO. Dado sensivel
+/// chegando toda semana quase nunca e coincidencia — costuma ser um formulario
+/// que pergunta restricao alimentar, um vendedor que puxa assunto de saude, uma
+/// campanha que convida o cliente a contar da vida. Nenhuma dessas coisas
+/// aparece num log de erro, e todas mudam a base legal do que a empresa esta
+/// coletando.
+/// </summary>
+public class IncidenciaDeDadoSensivel
+{
+    /// <summary>
+    /// CONVERSAS distintas na janela, e nao mencoes.
+    ///
+    /// Um cliente falante que cita o refluxo cinco vezes na mesma conversa e um
+    /// cliente falante. Cinco conversas diferentes com dado sensivel e um
+    /// padrao de coleta — e so o segundo justifica incomodar o gestor.
+    /// </summary>
+    public const int ConversasQueJaSaoPadrao = 5;
+
+    public static readonly TimeSpan Janela = TimeSpan.FromDays(7);
+
+    private readonly Dictionary<Guid, DateTimeOffset> _ultimaPorConversa = new();
+
+    public void Registrar(Guid conversaId, DateTimeOffset quando)
+    {
+        if (conversaId == Guid.Empty)
+            throw new ArgumentException("Incidencia sem conversa.", nameof(conversaId));
+
+        _ultimaPorConversa[conversaId] = quando;
+    }
+
+    public int ConversasNaJanela(DateTimeOffset agora) =>
+        _ultimaPorConversa.Count(o => agora - o.Value < Janela);
+
+    public bool DeveAlertarGestor(DateTimeOffset agora) =>
+        ConversasNaJanela(agora) >= ConversasQueJaSaoPadrao;
+
+    /// <summary>
+    /// O texto do alerta. Diz o que fazer, e nao so que aconteceu: aviso que
+    /// nao aponta para uma acao vira aviso que se aprende a fechar.
+    /// </summary>
+    public string Alerta(DateTimeOffset agora) =>
+        $"Dado sensível apareceu em {ConversasNaJanela(agora)} conversas nos últimos "
+        + $"{Janela.Days} dias. Isso costuma indicar coleta pelo processo — formulário, "
+        + "roteiro de abordagem ou campanha pedindo informação que a empresa não precisa. "
+        + "Vale revisar por onde essa pergunta está sendo feita.";
+}

--- a/src/Copiloto.Api/Seguranca/MolduraDeContexto.cs
+++ b/src/Copiloto.Api/Seguranca/MolduraDeContexto.cs
@@ -50,7 +50,12 @@ public class MolduraDeContexto
         var abre = $"<<<CLIENTE:{nonce}>>>";
         var fecha = $"<<<FIM:{nonce}>>>";
 
-        var conteudo = Neutralizar(falaDoCliente ?? "", nonce);
+        // Dado sensivel sai ANTES de o bloco existir (#82). A moldura e o unico
+        // caminho da fala do cliente para o modelo, e por isso a limpeza mora
+        // aqui e nao em quem chama: garantia que depende de alguem lembrar de
+        // chamar e garantia ate a primeira pressa.
+        var semSensivel = DadoSensivel.ForaDoContextoDeSugestao(falaDoCliente ?? "");
+        var conteudo = Neutralizar(semSensivel, nonce);
 
         return ($"{abre}\n{conteudo}\n{fecha}", nonce);
     }

--- a/testes/Copiloto.Testes/DadoSensivelTeste.cs
+++ b/testes/Copiloto.Testes/DadoSensivelTeste.cs
@@ -1,0 +1,142 @@
+using Copiloto.Api.Seguranca;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Dado sensivel que chega sozinho na conversa (#82).
+///
+/// As falas plantadas aqui sao do cenario de cafe, porque e ali que o problema
+/// nasce: ninguem PERGUNTA sobre saude — o cliente conta, porque quer saber se
+/// pode tomar o produto.
+/// </summary>
+public class DadoSensivelTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    [InlineData("to com refluxo, posso tomar cafe?", CategoriaSensivel.Saude)]
+    [InlineData("minha esposa está grávida, o descafeinado serve?", CategoriaSensivel.Saude)]
+    [InlineData("não bebo por questão de fé", CategoriaSensivel.ConviccaoReligiosa)]
+    [InlineData("é para o jejum da igreja", CategoriaSensivel.ConviccaoReligiosa)]
+    [InlineData("compro do sindicato dos professores", CategoriaSensivel.FiliacaoSindical)]
+    [InlineData("meu médico proibiu cafeína, tenho gastrite", CategoriaSensivel.Saude)]
+    public void Detecta_o_indicio_na_fala(string fala, CategoriaSensivel esperada)
+    {
+        var indicios = DadoSensivel.Detectar(fala);
+
+        Assert.NotEmpty(indicios);
+        Assert.Contains(indicios, i => i.Categoria == esperada);
+    }
+
+    [Theory]
+    [InlineData("me vê um café preto, por favor")]
+    [InlineData("o pote da direita, o de torra escura")]
+    [InlineData("vi voces no marketing digital de voces")]
+    [InlineData("tenho fé em vocês, mandem logo")]
+    [InlineData("qual o valor do kg do bourbon amarelo?")]
+    public void Conversa_comum_de_cafeteria_nao_dispara(string fala)
+    {
+        // Detector que marca metade das conversas nao protege ninguem: ele e
+        // desligado na primeira semana, e ai nao protege mais nada.
+        Assert.Empty(DadoSensivel.Detectar(fala));
+    }
+
+    [Fact]
+    public void Dado_sensivel_nunca_entra_no_indice()
+    {
+        // Indice e o pior destino: o dado deixa de estar numa conversa e passa
+        // a ser RECUPERAVEL por semelhanca, aparecendo na analise de outro
+        // cliente sem ninguem ter pedido (#62).
+        Assert.False(DadoSensivel.PodeIndexar("to com refluxo, posso tomar cafe?"));
+        Assert.True(DadoSensivel.PodeIndexar("me vê 2kg do bourbon amarelo"));
+    }
+
+    [Fact]
+    public void O_trecho_sensivel_nao_chega_ao_modelo_mas_o_pedido_chega()
+    {
+        // Descartar a fala inteira seria perder a venda junto com o dado: o
+        // pedido esta na segunda metade da frase.
+        var paraOModelo = DadoSensivel.ForaDoContextoDeSugestao(
+            "to com refluxo, posso tomar cafe?");
+
+        Assert.DoesNotContain("refluxo", paraOModelo);
+        Assert.Contains("posso tomar cafe?", paraOModelo);
+        Assert.Contains("[SENSIVEL:Saude]", paraOModelo);
+    }
+
+    [Fact]
+    public void A_conviccao_religiosa_nao_calibra_a_sugestao()
+    {
+        // O criterio que mais importa eticamente: usar "nao bebo por questao de
+        // fe" para escolher o angulo da venda e o uso que a lei trata com rigor
+        // — e a garantia nao e o prompt pedir, e o trecho nao estar la.
+        var paraOModelo = DadoSensivel.ForaDoContextoDeSugestao(
+            "não bebo por questão de fé, mas quero presentear meu sócio");
+
+        Assert.DoesNotContain("questão de fé", paraOModelo);
+        Assert.Contains("quero presentear meu sócio", paraOModelo);
+    }
+
+    [Fact]
+    public void Fala_sem_nada_sensivel_atravessa_intacta()
+    {
+        const string fala = "me vê 3kg do bourbon, pra durar";
+
+        Assert.Equal(fala, DadoSensivel.ForaDoContextoDeSugestao(fala));
+    }
+
+    [Fact]
+    public void A_fala_ja_entra_no_contexto_sem_o_trecho_sensivel()
+    {
+        // A moldura e o unico caminho da fala do cliente ate o modelo, entao a
+        // limpeza mora la — nao em quem chama.
+        var (bloco, _) = MolduraDeContexto.Montar("to com refluxo, posso tomar cafe?");
+
+        Assert.DoesNotContain("refluxo", bloco);
+        Assert.Contains("[SENSIVEL:Saude]", bloco);
+        Assert.Contains("posso tomar cafe?", bloco);
+    }
+
+    [Fact]
+    public void A_retencao_e_mais_curta_que_a_da_conversa()
+    {
+        // Dado que ninguem pediu, e que a empresa nao tem finalidade para usar,
+        // nao pode ficar pelo prazo do que ela pediu.
+        Assert.True(DadoSensivel.Retencao < TimeSpan.FromDays(90));
+        Assert.False(DadoSensivel.DeveExpurgar(T0, T0.AddDays(29)));
+        Assert.True(DadoSensivel.DeveExpurgar(T0, T0.AddDays(30)));
+    }
+
+    [Fact]
+    public void Cliente_falante_na_mesma_conversa_nao_vira_alerta()
+    {
+        // Cinco mencoes de uma pessoa so e uma pessoa so.
+        var incidencia = new IncidenciaDeDadoSensivel();
+        var conversa = Guid.NewGuid();
+
+        for (var i = 0; i < 5; i++) incidencia.Registrar(conversa, T0.AddMinutes(i));
+
+        Assert.False(incidencia.DeveAlertarGestor(T0));
+    }
+
+    [Fact]
+    public void Cinco_conversas_na_semana_alertam_o_gestor()
+    {
+        // Aqui nao e coincidencia: e formulario, roteiro ou campanha pedindo
+        // informacao que a empresa nao precisa.
+        var incidencia = new IncidenciaDeDadoSensivel();
+        for (var i = 0; i < 5; i++) incidencia.Registrar(Guid.NewGuid(), T0.AddHours(i));
+
+        Assert.True(incidencia.DeveAlertarGestor(T0.AddHours(5)));
+        Assert.Contains("revisar por onde essa pergunta", incidencia.Alerta(T0.AddHours(5)));
+    }
+
+    [Fact]
+    public void Fora_da_janela_a_contagem_nao_acumula_para_sempre()
+    {
+        var incidencia = new IncidenciaDeDadoSensivel();
+        for (var i = 0; i < 5; i++) incidencia.Registrar(Guid.NewGuid(), T0);
+
+        Assert.False(incidencia.DeveAlertarGestor(T0.AddDays(8)));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `81-direitos-do-titular` (#81) para a #89 poder empilhar em cima das duas.

## O que muda
Deteccao por categoria do art. 11 e remocao do trecho DENTRO da `MolduraDeContexto`, unico caminho da fala do cliente ate o modelo.

## Decisoes
- O trecho sai, a frase fica: em "to com refluxo, posso tomar cafe?" o pedido esta na segunda metade.
- O que NAO detectar esta comentado no codigo: "preto" (cafe preto), "direita" (a prateleira), "digital" (marketing).
- Alerta ao gestor conta CONVERSAS distintas, nao mencoes: cinco mencoes de uma pessoa e um cliente falante.

## Fora deste PR
Exclusao do indice de embeddings: nao existe indice ainda (#62). O que existe e `PodeIndexar()` com teste.

Closes #82