### PR TITLE
Ficha do Cliente sob a LGPD: dado de terceiro e categoria sensivel

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -185,6 +185,35 @@ do vencimento — prazo que ninguém mede só aparece depois de vencido, e o que
 disso não é um lembrete, é uma notificação da ANPD. Pedido atendido não vence depois:
 alarme falso esconde os que ainda importam.
 
+### 7.36 A Ficha do Cliente é dado de um terceiro que não sabe que existe
+
+O vendedor pesquisa o João no LinkedIn, no site da empresa, pergunta a um conhecido, e
+escreve. **O titular da ficha não está na conversa** e não sabe que há um registro sobre
+ele. Isso é legítimo em B2B — é o que todo CRM faz — mas tem consequências que precisam
+estar tratadas, e não ignoradas (#89).
+
+**Categoria sensível não entra, e o bloqueio é do domínio.** Religião, saúde, orientação
+sexual, opinião política e origem racial são exatamente o que alguém "pesca" sem procurar
+ao abrir um perfil de rede social — e anotar isso é problema de outra magnitude: exige
+consentimento específico, que ninguém pediu ao titular antes de pesquisá-lo. Por isso a
+regra do que é dado sensível **mora no domínio** e é cobrada no único método que altera a
+ficha, em vez de depender de alguém validar antes de gravar.
+
+**O bloco da empresa fica de fora do bloqueio, e a diferença é jurídica, não de rigor:**
+dado sensível é sobre *pessoa natural*. "Ramo: igreja" ou "Como chegou: indicação do
+sindicato" descreve o cliente PJ — bloquear isso impediria o vendedor de registrar quem
+ele atende, e é o tipo de bloqueio que faz a informação ir para outro campo, onde o
+controle deixa de existir sem deixar de incomodar.
+
+**O aviso na tela vale mais que a política escrita.** "O cliente pode pedir para ler o que
+está escrito aqui" faz o vendedor escrever *"prefere objetividade"* em vez de *"chato pra
+caramba"* — e o primeiro continua útil para vender, só para de ser passivo.
+
+**Retenção própria:** ficha de negócio ativo não expira (a finalidade está viva); ficha de
+lead perdido sai depois de 12 meses, que é o horizonte em que o cliente que disse "agora
+não" costuma voltar. Menos que isso jogaria fora exatamente o caso que a ficha resolve;
+mais que isso é dado de terceiro guardado sem finalidade.
+
 ### 7.4 Controles de engenharia
 
 - **PII Shield** mascarando antes da saída da rede, com teste que **falha o build** se

--- a/src/Copiloto.Api/Seguranca/MolduraDeContexto.cs
+++ b/src/Copiloto.Api/Seguranca/MolduraDeContexto.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Copiloto.Dominio.Seguranca;
 
 namespace Copiloto.Api.Seguranca;
 

--- a/src/Copiloto.Dominio/Fichas/FichaCliente.cs
+++ b/src/Copiloto.Dominio/Fichas/FichaCliente.cs
@@ -1,3 +1,5 @@
+using Copiloto.Dominio.Seguranca;
+
 namespace Copiloto.Dominio.Fichas;
 
 /// <summary>O que o vendedor descobriu sobre a empresa. Tudo opcional.</summary>
@@ -79,10 +81,46 @@ public class FichaCliente
     public bool EstaVazia => Preenchidos.Count == 0;
 
     /// <summary>
+    /// Quanto tempo a ficha sobrevive ao negocio perdido (#89).
+    ///
+    /// Doze meses porque e' o horizonte em que o cliente que disse "agora nao"
+    /// costuma voltar — e a ficha existe exatamente para a segunda conversa nao
+    /// comecar do zero. Passado isso, ela deixa de ser memoria comercial util e
+    /// vira dado de terceiro guardado sem finalidade, que e' o que a lei nao
+    /// admite.
+    ///
+    /// Ficha de negocio ATIVO nao expira por tempo: enquanto ha negociacao, a
+    /// finalidade esta viva.
+    /// </summary>
+    public static readonly TimeSpan RetencaoAposPerder = TimeSpan.FromDays(365);
+
+    /// <summary>
+    /// Passou o prazo desde que o negocio foi perdido.
+    ///
+    /// Recebe a data da perda em vez de consultar o Deal porque a ficha nao
+    /// conhece o funil — e quem chama e' quem sabe se ainda ha negocio de pe.
+    /// </summary>
+    public bool DeveExpurgar(DateTimeOffset? negocioPerdidoEm, DateTimeOffset agora) =>
+        negocioPerdidoEm is not null && agora - negocioPerdidoEm >= RetencaoAposPerder;
+
+    /// <summary>
     /// Atualiza, guardando a versao anterior. Passar null em um bloco mantem o
     /// que ja estava — a ficha e PROGRESSIVA, cresce de tres linhas para quinze
     /// sem exigir que alguem redigite o que ja sabia.
     /// </summary>
+    /// <summary>
+    /// O que a tela de edicao precisa dizer ao vendedor, antes de ele escrever
+    /// (#89).
+    ///
+    /// E o item que muda o comportamento mais que qualquer politica: saber que
+    /// o titular pode pedir para ler faz escrever "prefere objetividade" em vez
+    /// de "chato pra caramba" — e o primeiro continua util para vender, so para
+    /// de ser passivo.
+    /// </summary>
+    public const string AvisoAoVendedor =
+        "O cliente pode pedir para ler o que está escrito aqui, e a empresa é "
+        + "obrigada a mostrar. Escreva o que você mostraria a ele.";
+
     public void Atualizar(
         DateTimeOffset quando,
         SobreAEmpresa? empresa = null,
@@ -90,6 +128,16 @@ public class FichaCliente
         SobreONegocio? negocio = null)
     {
         if (empresa is null && pessoa is null && negocio is null) return;
+
+        // Categoria sensivel nao entra na ficha (#82, #89). O vetor e realista:
+        // quem pesquisa alguem em rede social esbarra em posicionamento
+        // politico e religioso sem procurar, e anotar isso e um problema de
+        // outra magnitude — dado sensivel exige consentimento especifico, que
+        // ninguem pediu ao Joao antes de olhar o LinkedIn dele.
+        RecusarSensivel(pessoa?.Cargo, pessoa?.PapelNaDecisao,
+                        pessoa?.QuemMaisDecide, pessoa?.EstiloObservado,
+                        negocio?.ProvavelNecessidade, negocio?.UsaHoje,
+                        negocio?.OrcamentoEstimado, negocio?.RiscoConhecido);
 
         _historico.Insert(0, new VersaoDaFicha(AtualizadaEm, Empresa, Pessoa, Negocio));
 
@@ -151,6 +199,34 @@ public class FichaCliente
     /// </summary>
     public IReadOnlyDictionary<string, Anotacao> Impressoes =>
         Preenchidos.Where(p => !p.Value.EhFato).ToDictionary(p => p.Key, p => p.Value);
+
+    /// <summary>
+    /// Recusa anotacao com indicio de dado sensivel sobre a PESSOA.
+    ///
+    /// O bloco da EMPRESA fica de fora de proposito, e a diferenca e juridica e
+    /// nao de rigor: dado sensivel e sobre pessoa natural. "Ramo: igreja" ou
+    /// "Como chegou: indicacao do sindicato" descreve o CLIENTE PJ, e bloquear
+    /// isso impediria o vendedor de registrar quem ele atende — que e o tipo de
+    /// bloqueio que faz alguem escrever a informacao noutro campo, e ai o
+    /// controle deixa de existir sem deixar de incomodar.
+    /// </summary>
+    private static void RecusarSensivel(params Anotacao?[] anotacoes)
+    {
+        foreach (var anotacao in anotacoes)
+        {
+            if (anotacao is null) continue;
+
+            var indicios = DadoSensivel.Detectar(anotacao.Valor);
+            if (indicios.Count == 0) continue;
+
+            throw new ArgumentException(
+                $"\"{anotacao.Valor}\" tem indicio de {indicios[0].Categoria}, que e "
+                + "categoria sensivel (art. 11) e exige consentimento especifico — "
+                + "ninguem pediu isso ao titular antes de pesquisar sobre ele. "
+                + "Anote o que interessa a venda: o que ele precisa, quando decide, "
+                + "quem mais decide.");
+        }
+    }
 
     private static readonly string[] TodosOsRotulos =
     [

--- a/src/Copiloto.Dominio/Seguranca/DadoSensivel.cs
+++ b/src/Copiloto.Dominio/Seguranca/DadoSensivel.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace Copiloto.Api.Seguranca;
+namespace Copiloto.Dominio.Seguranca;
 
 /// <summary>As categorias do art. 11 que aparecem em conversa de venda.</summary>
 public enum CategoriaSensivel
@@ -35,6 +35,11 @@ public record IndicioSensivel(CategoriaSensivel Categoria, string Trecho);
 /// A garantia nao e uma instrucao no prompt: o trecho sensivel nao chega ao
 /// modelo (<see cref="ForaDoContextoDeSugestao"/>) e nao entra no indice
 /// (<see cref="PodeIndexar"/>). O que nao esta la nao calibra nada.
+///
+/// Mora no DOMINIO, e nao na borda, desde a #89: o que faz um texto ser dado
+/// sensivel e regra da LGPD, nao detalhe de infraestrutura — e a Ficha do
+/// Cliente precisa dessa regra no proprio construtor para o bloqueio ser
+/// estrutural, em vez de depender de alguem lembrar de validar antes de gravar.
 /// </summary>
 public static class DadoSensivel
 {

--- a/testes/Copiloto.Testes/DadoSensivelTeste.cs
+++ b/testes/Copiloto.Testes/DadoSensivelTeste.cs
@@ -1,4 +1,5 @@
 using Copiloto.Api.Seguranca;
+using Copiloto.Dominio.Seguranca;
 
 namespace Copiloto.Testes;
 

--- a/testes/Copiloto.Testes/FichaSobLgpdTeste.cs
+++ b/testes/Copiloto.Testes/FichaSobLgpdTeste.cs
@@ -1,0 +1,130 @@
+using Copiloto.Dominio.Fichas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A Ficha do Cliente como coleta de dado de terceiro (#89).
+///
+/// O titular da ficha NAO esta na conversa e nao sabe que existe um registro
+/// sobre ele: o vendedor pesquisou no LinkedIn, no site, perguntou a um
+/// conhecido, e escreveu. E legitimo em B2B — e o que todo CRM faz — mas tem
+/// consequencias que precisam estar tratadas, e nao ignoradas.
+/// </summary>
+public class FichaSobLgpdTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+
+    private static FichaCliente Nova() => new(Guid.NewGuid(), Guid.NewGuid(), T0);
+
+    [Theory]
+    [InlineData("faz tratamento para ansiedade")]
+    [InlineData("é evangélico, não bebe")]
+    [InlineData("votei diferente dele, melhor não falar de eleição")]
+    [InlineData("é sindicalizado")]
+    public void Categoria_sensivel_nao_entra_na_ficha(string anotado)
+    {
+        // O vetor e realista: quem pesquisa alguem em rede social esbarra em
+        // posicionamento politico e religioso sem procurar. Anotar isso e um
+        // problema de outra magnitude — exige consentimento especifico, que
+        // ninguem pediu ao titular antes de olhar o perfil dele.
+        var ficha = Nova();
+
+        var erro = Assert.Throws<ArgumentException>(() => ficha.Atualizar(T0,
+            pessoa: new SobreAPessoa(EstiloObservado: Anotacao.Impressao(anotado))));
+
+        Assert.Contains("categoria sensivel", erro.Message);
+    }
+
+    [Fact]
+    public void O_bloqueio_vale_para_fato_e_para_impressao()
+    {
+        // Marcar como "fato" nao torna o dado sensivel anotavel: a natureza diz
+        // se sustenta afirmacao, nao se pode ser coletado.
+        var ficha = Nova();
+
+        Assert.Throws<ArgumentException>(() => ficha.Atualizar(T0,
+            negocio: new SobreONegocio(
+                RiscoConhecido: Anotacao.Fato("tem gastrite, evita café forte", "ele contou"))));
+    }
+
+    [Fact]
+    public void A_ficha_nao_fica_pela_metade_quando_o_bloqueio_dispara()
+    {
+        // A recusa vem antes de qualquer gravacao: meia atualizacao deixaria a
+        // ficha num estado que ninguem pediu.
+        var ficha = Nova();
+
+        Assert.Throws<ArgumentException>(() => ficha.Atualizar(T0,
+            empresa: new SobreAEmpresa(Ramo: Anotacao.Fato("cafeteria")),
+            pessoa: new SobreAPessoa(EstiloObservado: Anotacao.Impressao("é espírita"))));
+
+        Assert.True(ficha.EstaVazia);
+        Assert.Empty(ficha.Historico);
+    }
+
+    [Fact]
+    public void O_ramo_do_cliente_PJ_continua_anotavel()
+    {
+        // A diferenca e juridica, nao de rigor: dado sensivel e sobre pessoa
+        // natural. "Ramo: igreja" descreve o cliente, e bloquear isso impediria
+        // o vendedor de registrar quem ele atende — o tipo de bloqueio que faz
+        // a informacao ir para outro campo, e ai o controle so incomoda.
+        var ficha = Nova();
+
+        ficha.Atualizar(T0, empresa: new SobreAEmpresa(
+            Ramo: Anotacao.Fato("igreja, compra para o café da comunidade"),
+            ComoChegou: Anotacao.Fato("indicação do sindicato dos padeiros")));
+
+        Assert.Equal(2, ficha.Fatos.Count);
+    }
+
+    [Fact]
+    public void Anotacao_comercial_normal_passa_sem_atrito()
+    {
+        var ficha = Nova();
+
+        ficha.Atualizar(T0, pessoa: new SobreAPessoa(
+            Cargo: Anotacao.Fato("gerente de compras", "LinkedIn"),
+            EstiloObservado: Anotacao.Impressao("prefere objetividade")));
+
+        Assert.Equal(2, ficha.Preenchidos.Count);
+    }
+
+    [Fact]
+    public void A_tela_de_edicao_tem_o_que_dizer_ao_vendedor()
+    {
+        // O criterio que muda o comportamento mais que qualquer politica:
+        // saber que o titular pode ler faz escrever "prefere objetividade" em
+        // vez de "chato pra caramba".
+        Assert.Contains("pedir para ler", FichaCliente.AvisoAoVendedor);
+        Assert.Contains("mostraria a ele", FichaCliente.AvisoAoVendedor);
+    }
+
+    // --- Retencao ---
+
+    [Fact]
+    public void Ficha_de_negocio_ativo_nao_expira_por_tempo()
+    {
+        // Enquanto ha negociacao, a finalidade esta viva.
+        var ficha = Nova();
+
+        Assert.False(ficha.DeveExpurgar(negocioPerdidoEm: null, T0.AddYears(5)));
+    }
+
+    [Fact]
+    public void Ficha_de_lead_perdido_nao_fica_para_sempre()
+    {
+        var ficha = Nova();
+
+        Assert.False(ficha.DeveExpurgar(T0, T0.AddDays(364)));
+        Assert.True(ficha.DeveExpurgar(T0, T0.AddDays(365)));
+    }
+
+    [Fact]
+    public void O_prazo_cobre_a_volta_do_cliente_que_disse_agora_nao()
+    {
+        // A ficha existe para a segunda conversa nao comecar do zero: expurgar
+        // em trinta dias jogaria fora exatamente o caso que ela resolve.
+        Assert.True(FichaCliente.RetencaoAposPerder >= TimeSpan.FromDays(180));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `82-dado-sensivel` (#82), que ja carrega a trilha da ficha.

## O que muda
Categoria sensivel recusada na escrita da ficha, aviso ao vendedor de que o titular pode ler, e retencao propria (12 meses apos negocio perdido).

## Decisoes
- `DadoSensivel` mudou de camada (Api -> Dominio): o que faz um texto ser sensivel e regra da LGPD, e a ficha precisa dela no proprio metodo para o bloqueio ser estrutural.
- O bloco da EMPRESA fica fora do bloqueio: dado sensivel e sobre pessoa natural. "Ramo: igreja" descreve o cliente PJ, e bloquear isso empurraria a informacao para outro campo.
- A recusa vale para fato tambem: natureza diz se sustenta afirmacao, nao se pode ser coletado.

Closes #89