### PR TITLE
IQueue e IDistributedState, com in-memory como padrao

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -337,6 +337,18 @@ Consequência prática, que é o ponto: **a demo continua rodando com um único
 distribuído em produção. Uma demonstração que depende de cinco contêineres no ar tem
 cinco maneiras de falhar ao vivo.
 
+**O que já existe (#66):** as duas interfaces, `ChannelQueue` e `InMemoryState`, e a
+escolha por variável de ambiente com `inmemory` como padrão — sem `.env`, a aplicação
+sobe inteira. As implementações distribuídas ficam para #69 e #70, e até lá pedir
+`STATE_BACKEND=redis` **derruba a subida** com o número da issue no erro. É deliberado:
+cair para memória em silêncio daria uma aplicação que *parece* distribuída, roda com duas
+réplicas e perde idempotência sem nenhum sinal.
+
+A suíte é escrita contra o **contrato**, parametrizada pela implementação: `RedisState` e
+`RabbitMqQueue` entram com uma linha cada e passam a responder pelos mesmos testes. É o
+que impede a segunda implementação de nascer com garantias mais fracas que a primeira sem
+ninguém notar.
+
 ### 12.4 Redis também é backplane do SignalR
 
 Com mais de uma instância, o vendedor conectado à instância A não recebe o evento

--- a/src/Copiloto.Api/Infra/Backends.cs
+++ b/src/Copiloto.Api/Infra/Backends.cs
@@ -1,0 +1,49 @@
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// Escolhe a implementacao pela variavel de ambiente (#66).
+///
+/// `STATE_BACKEND` e `QUEUE_BACKEND`, com `inmemory` como padrao: sem .env, sem
+/// broker e sem cache, a aplicacao sobe inteira. E o mesmo principio do
+/// `CONVERSATION_SOURCE=fake` — demonstracao que depende de cinco conteineres
+/// no ar tem cinco maneiras de falhar ao vivo.
+/// </summary>
+public static class Backends
+{
+    public const string Padrao = "inmemory";
+
+    public static IQueue<T> Fila<T>(IConfiguration configuracao) =>
+        Escolhido(configuracao, "QUEUE_BACKEND") switch
+        {
+            Padrao => new ChannelQueue<T>(),
+            "rabbitmq" => throw NaoImplementado("QUEUE_BACKEND", "rabbitmq", 69),
+            var outro => throw Desconhecido("QUEUE_BACKEND", outro, "inmemory, rabbitmq"),
+        };
+
+    public static IDistributedState Estado(IConfiguration configuracao) =>
+        Escolhido(configuracao, "STATE_BACKEND") switch
+        {
+            Padrao => new InMemoryState(),
+            "redis" => throw NaoImplementado("STATE_BACKEND", "redis", 70),
+            var outro => throw Desconhecido("STATE_BACKEND", outro, "inmemory, redis"),
+        };
+
+    private static string Escolhido(IConfiguration configuracao, string variavel) =>
+        (configuracao[variavel] ?? Padrao).Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Backend previsto que ainda nao tem corpo. Falhar na SUBIDA e a escolha
+    /// certa: cair para memoria em silencio daria uma aplicacao que parece
+    /// distribuida, roda com duas replicas e perde idempotencia sem nenhum
+    /// sinal — o modo de falhar mais caro que existe aqui.
+    /// </summary>
+    private static NotSupportedException NaoImplementado(
+        string variavel, string valor, int issue) =>
+        new($"{variavel}={valor} ainda nao tem implementacao (issue #{issue}). "
+            + $"Use {variavel}={Padrao} ou implemente o backend — cair para memoria "
+            + "em silencio esconderia justamente a perda de garantia.");
+
+    private static ArgumentException Desconhecido(
+        string variavel, string valor, string aceitos) =>
+        new($"{variavel}={valor} nao existe. Valores aceitos: {aceitos}.");
+}

--- a/src/Copiloto.Api/Infra/ChannelQueue.cs
+++ b/src/Copiloto.Api/Infra/ChannelQueue.cs
@@ -1,19 +1,19 @@
 using System.Threading.Channels;
 
-namespace Copiloto.Api.Ingestao;
+namespace Copiloto.Api.Infra;
 
 /// <summary>
-/// A fila entre o webhook e o processamento (#40).
+/// A fila em processo, com `Channel<T>` — o padrao (#40, #66).
 ///
-/// `Channel<T>` em memoria, e nao RabbitMQ: o volume nao justifica (YAGNI). A
-/// troca fica barata porque quem publica so enxerga `Publicar` e quem consome
-/// so enxerga `Ler` — o dia em que doer, o corpo muda e as duas pontas nao.
+/// E o padrao pelo mesmo motivo do `FakeSource`: a aplicacao sobe inteira sem
+/// broker, e a demo nao tem cinco conteineres para falhar ao vivo. RabbitMQ
+/// entra atras da mesma interface na #69, por variavel de ambiente.
 ///
 /// PERDE MENSAGEM SE O PROCESSO CAIR, e isso e' aceito enquanto a fila e' de
-/// memoria. A durabilidade e a #69, e ate' la' o webhook responder 200 e' uma
+/// memoria. A durabilidade e a #69, e ate' la' o webhook responder 202 e' uma
 /// promessa de que a mensagem foi RECEBIDA, nao de que sera processada.
 /// </summary>
-public class FilaDeMensagens
+public class ChannelQueue<T> : IQueue<T>
 {
     /// <summary>
     /// Teto de itens esperando. Existe porque fila sem limite nao para de
@@ -23,8 +23,8 @@ public class FilaDeMensagens
     /// </summary>
     public const int Capacidade = 1_000;
 
-    private readonly Channel<MensagemRecebida> _canal =
-        Channel.CreateBounded<MensagemRecebida>(new BoundedChannelOptions(Capacidade)
+    private readonly Channel<T> _canal =
+        Channel.CreateBounded<T>(new BoundedChannelOptions(Capacidade)
         {
             // Contrapressao: o produtor ESPERA em vez de a fila descartar. O
             // webhook prefere demorar a responder do que perder a fala do
@@ -41,11 +41,11 @@ public class FilaDeMensagens
     /// Enfileira. Devolve false quando a fila esta cheia e a espera estourou o
     /// tempo — o chamador decide o que dizer ao provedor.
     /// </summary>
-    public async Task<bool> Publicar(MensagemRecebida mensagem, CancellationToken ct)
+    public async Task<bool> Publicar(T item, CancellationToken ct)
     {
         try
         {
-            await _canal.Writer.WriteAsync(mensagem, ct);
+            await _canal.Writer.WriteAsync(item, ct);
             return true;
         }
         catch (OperationCanceledException)
@@ -59,7 +59,7 @@ public class FilaDeMensagens
         }
     }
 
-    public IAsyncEnumerable<MensagemRecebida> Ler(CancellationToken ct) =>
+    public IAsyncEnumerable<T> Ler(CancellationToken ct) =>
         _canal.Reader.ReadAllAsync(ct);
 
     /// <summary>

--- a/src/Copiloto.Api/Infra/IDistributedState.cs
+++ b/src/Copiloto.Api/Infra/IDistributedState.cs
@@ -1,0 +1,37 @@
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// Estado que precisa valer para TODAS as instancias, nao so para esta (#66).
+///
+/// Sao tres usos, cada um com issue propria, e os tres quebram do mesmo jeito
+/// com duas replicas atras de um balanceador: idempotencia de webhook (#67),
+/// estado do circuit breaker (#68) e rate limit com cache de analise (#71). Com
+/// o estado no processo, a segunda instancia nao sabe que a primeira ja pagou
+/// pela analise, ja abriu o circuito ou ja atendeu aquela mensagem.
+///
+/// O contrato tem quatro operacoes porque sao essas que os tres usos pedem.
+/// Redis sabe fazer muito mais, e o resto ficaria sem equivalente em memoria.
+/// </summary>
+public interface IDistributedState
+{
+    /// <summary>
+    /// Marca a chave se ela ainda nao existir, e diz se a marcacao foi SUA.
+    ///
+    /// E a operacao da idempotencia (#67), e ela precisa ser atomica: ler,
+    /// decidir e gravar em tres passos deixa a janela em que duas instancias
+    /// leem "nao existe" e as duas processam a mesma mensagem — que e
+    /// exatamente o que a idempotencia existe para impedir.
+    /// </summary>
+    Task<bool> TentarMarcar(string chave, TimeSpan validade, CancellationToken ct);
+
+    Task<string?> Ler(string chave, CancellationToken ct);
+
+    Task Gravar(string chave, string valor, TimeSpan validade, CancellationToken ct);
+
+    /// <summary>
+    /// Soma um a um contador que expira sozinho, e devolve o total. E o rate
+    /// limit (#71): sem a janela, o contador so cresce e o limite vira um teto
+    /// permanente em vez de uma taxa.
+    /// </summary>
+    Task<long> Incrementar(string chave, TimeSpan janela, CancellationToken ct);
+}

--- a/src/Copiloto.Api/Infra/IQueue.cs
+++ b/src/Copiloto.Api/Infra/IQueue.cs
@@ -1,0 +1,36 @@
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// A fila de trabalho, sem dizer quem esta atras dela (#66).
+///
+/// Nasce com duas implementacoes reais previstas — `ChannelQueue` em processo
+/// e RabbitMQ na #69 —, entao nao e abstracao prematura: e a excecao que o
+/// CLAUDE.md ja registrou.
+///
+/// O contrato e deliberadamente pequeno. Tudo que um broker sabe fazer e que
+/// nao cabe aqui (roteamento, prioridade, reentrega com atraso) ficaria sem
+/// equivalente em processo, e uma interface que so a metade das implementacoes
+/// honra nao abstrai nada.
+/// </summary>
+public interface IQueue<T>
+{
+    /// <summary>Itens esperando. Aproximado num broker; exato em memoria.</summary>
+    int Aguardando { get; }
+
+    /// <summary>
+    /// Enfileira. Devolve false quando nao deu — fila cheia com espera
+    /// estourada, ou desligamento em andamento. Quem chama decide o que
+    /// responder ao provedor: o webhook responde 503 para o WhatsApp
+    /// REENTREGAR, porque 200 com a fila cheia perderia a fala do cliente em
+    /// silencio.
+    /// </summary>
+    Task<bool> Publicar(T item, CancellationToken ct);
+
+    IAsyncEnumerable<T> Ler(CancellationToken ct);
+
+    /// <summary>
+    /// Fecha para escrita, mantendo a leitura do que ficou. E o que faz o
+    /// desligamento DRENAR em vez de descartar.
+    /// </summary>
+    void PararDeAceitar();
+}

--- a/src/Copiloto.Api/Infra/InMemoryState.cs
+++ b/src/Copiloto.Api/Infra/InMemoryState.cs
@@ -1,0 +1,84 @@
+using System.Collections.Concurrent;
+
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// O estado compartilhado quando ha um processo so — o padrao (#66).
+///
+/// Vale enquanto a aplicacao roda em uma instancia, que e o caso do
+/// desenvolvimento e da demo. Com duas replicas ele passa a MENTIR: cada
+/// processo tem o seu, e a idempotencia deixa de valer sem nenhum erro
+/// aparecer. E por isso que a interface existe antes de o Redis existir — a
+/// troca precisa ser de configuracao, nao de refatoracao com pressa.
+/// </summary>
+public class InMemoryState : IDistributedState
+{
+    private record Valor(string Conteudo, DateTimeOffset ExpiraEm);
+
+    private readonly ConcurrentDictionary<string, Valor> _itens = new();
+    private readonly Func<DateTimeOffset> _agora;
+
+    /// <param name="agora">
+    /// O relogio entra por parametro para o teste poder envelhecer a chave sem
+    /// dormir. Suite que espera o TTL passar e suite que fica lenta e depois
+    /// fica intermitente.
+    /// </param>
+    public InMemoryState(Func<DateTimeOffset>? agora = null) =>
+        _agora = agora ?? (() => DateTimeOffset.UtcNow);
+
+    public Task<bool> TentarMarcar(string chave, TimeSpan validade, CancellationToken ct)
+    {
+        var agora = _agora();
+        var novo = new Valor("1", agora + validade);
+
+        // AddOrUpdate resolve o vencido e o inexistente no mesmo passo atomico:
+        // testar `ContainsKey` antes abriria a janela que a operacao fecha.
+        var marcouAgora = false;
+        _itens.AddOrUpdate(chave,
+            _ => { marcouAgora = true; return novo; },
+            (_, antigo) =>
+            {
+                if (antigo.ExpiraEm > agora) return antigo;
+
+                marcouAgora = true;
+                return novo;
+            });
+
+        return Task.FromResult(marcouAgora);
+    }
+
+    public Task<string?> Ler(string chave, CancellationToken ct)
+    {
+        if (!_itens.TryGetValue(chave, out var valor)) return Task.FromResult<string?>(null);
+
+        if (valor.ExpiraEm <= _agora())
+        {
+            _itens.TryRemove(chave, out _);
+            return Task.FromResult<string?>(null);
+        }
+
+        return Task.FromResult<string?>(valor.Conteudo);
+    }
+
+    public Task Gravar(string chave, string valor, TimeSpan validade, CancellationToken ct)
+    {
+        _itens[chave] = new Valor(valor, _agora() + validade);
+        return Task.CompletedTask;
+    }
+
+    public Task<long> Incrementar(string chave, TimeSpan janela, CancellationToken ct)
+    {
+        var agora = _agora();
+
+        var atualizado = _itens.AddOrUpdate(chave,
+            _ => new Valor("1", agora + janela),
+            (_, antigo) => antigo.ExpiraEm <= agora
+                // Janela vencida recomeca do 1 E renova o prazo: manter o
+                // vencimento antigo faria o contador expirar no meio da janela
+                // nova, e o limite deixaria de significar uma taxa.
+                ? new Valor("1", agora + janela)
+                : antigo with { Conteudo = (long.Parse(antigo.Conteudo) + 1).ToString() });
+
+        return Task.FromResult(long.Parse(atualizado.Conteudo));
+    }
+}

--- a/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
+++ b/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
@@ -1,5 +1,6 @@
 using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Vendas;
+using Copiloto.Api.Infra;
 
 namespace Copiloto.Api.Ingestao;
 
@@ -15,12 +16,12 @@ namespace Copiloto.Api.Ingestao;
 /// </summary>
 public class ProcessadorDeMensagens : BackgroundService
 {
-    private readonly FilaDeMensagens _fila;
+    private readonly IQueue<MensagemRecebida> _fila;
     private readonly ResolvedorDeLead _resolvedor;
     private readonly ILogger<ProcessadorDeMensagens> _log;
 
     public ProcessadorDeMensagens(
-        FilaDeMensagens fila, ResolvedorDeLead resolvedor, ILogger<ProcessadorDeMensagens> log)
+        IQueue<MensagemRecebida> fila, ResolvedorDeLead resolvedor, ILogger<ProcessadorDeMensagens> log)
     {
         _fila = fila;
         _resolvedor = resolvedor;

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,4 +1,5 @@
 using Copiloto.Api.Ia;
+using Copiloto.Api.Infra;
 using Copiloto.Api.Ingestao;
 using Copiloto.Api.Persistencia;
 using Copiloto.Dominio.Ia;
@@ -19,7 +20,10 @@ builder.Services.AddScoped<IRepositorioDeLeads, LeadsNoBanco>();
 builder.Services.AddSingleton(_ => new RoteadorDeModelo(
     TabelaDeModelos.Carregar(builder.Configuration)));
 
-builder.Services.AddSingleton<FilaDeMensagens>();
+// Estado e fila vem da variavel de ambiente, com `inmemory` como padrao (#66).
+// Sem .env, sem Redis e sem RabbitMQ, a aplicacao sobe inteira.
+builder.Services.AddSingleton(_ => Backends.Fila<MensagemRecebida>(builder.Configuration));
+builder.Services.AddSingleton(_ => Backends.Estado(builder.Configuration));
 
 // O numero da empresa e o que decide quem falou em cada mensagem, entao ele e
 // configuracao e nao constante: cada instalacao tem o seu.
@@ -34,7 +38,7 @@ app.MapGet("/saude", () => Results.Ok(new { ok = true }));
 // O webhook responde na hora e nao processa nada (#40). O 202 e' deliberado: 200
 // diria "processado", e o que aconteceu foi "recebido e enfileirado".
 app.MapPost("/webhook/whatsapp", async (
-    MensagemRecebida mensagem, FilaDeMensagens fila, CancellationToken ct) =>
+    MensagemRecebida mensagem, IQueue<MensagemRecebida> fila, CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(mensagem.ProviderMessageId))
         return Results.BadRequest(new { erro = "sem ProviderMessageId: a reentrega nao teria como ser reconhecida" });

--- a/testes/Copiloto.Testes/ChannelQueueTeste.cs
+++ b/testes/Copiloto.Testes/ChannelQueueTeste.cs
@@ -1,4 +1,5 @@
 using Copiloto.Api.Ingestao;
+using Copiloto.Api.Infra;
 
 namespace Copiloto.Testes;
 
@@ -9,16 +10,56 @@ namespace Copiloto.Testes;
 /// na origem, timeout vira reentrega, reentrega vira custo DUPLICADO — e o custo
 /// aqui e de dinheiro, nao de CPU.
 /// </summary>
-public class FilaDeMensagensTeste
+public class ChannelQueueTeste
 {
     private static MensagemRecebida Fala(string id = "wamid.1") =>
         new(id, "+5511987654321", "+5511333334444", "qual o valor do kg?",
             DateTimeOffset.UtcNow);
 
+    /// <summary>
+    /// As implementacoes de <see cref="IQueue{T}"/> cobradas pelo contrato.
+    /// RabbitMqQueue (#69) entra aqui com UMA linha e passa a responder pelos
+    /// mesmos testes — e o que impede a segunda implementacao de nascer com
+    /// garantias mais fracas que a primeira sem ninguem notar.
+    /// </summary>
+    public static TheoryData<string, Func<IQueue<MensagemRecebida>>> Implementacoes => new()
+    {
+        { "inmemory", () => new ChannelQueue<MensagemRecebida>() },
+    };
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task Contrato_entrega_na_ordem_em_que_publicou(
+        string nome, Func<IQueue<MensagemRecebida>> criar)
+    {
+        var fila = criar();
+        await fila.Publicar(Fala("um"), default);
+        await fila.Publicar(Fala("dois"), default);
+        fila.PararDeAceitar();
+
+        var lidas = new List<string>();
+        await foreach (var m in fila.Ler(default)) lidas.Add(m.ProviderMessageId);
+
+        Assert.Equal(["um", "dois"], lidas);
+        Assert.NotNull(nome);
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task Contrato_depois_de_parar_recusa_trabalho_novo(
+        string nome, Func<IQueue<MensagemRecebida>> criar)
+    {
+        var fila = criar();
+        fila.PararDeAceitar();
+
+        Assert.False(await fila.Publicar(Fala("tarde demais"), default));
+        Assert.NotNull(nome);
+    }
+
     [Fact]
     public async Task Publicar_entrega_para_quem_le()
     {
-        var fila = new FilaDeMensagens();
+        var fila = new ChannelQueue<MensagemRecebida>();
 
         Assert.True(await fila.Publicar(Fala(), CancellationToken.None));
 
@@ -34,12 +75,12 @@ public class FilaDeMensagensTeste
     {
         // Fila sem teto nao para de crescer: consumo mais lento que a chegada faz
         // a memoria subir ate o processo morrer, e ai a perda e de TUDO.
-        var fila = new FilaDeMensagens();
+        var fila = new ChannelQueue<MensagemRecebida>();
 
-        for (var i = 0; i < FilaDeMensagens.Capacidade; i++)
+        for (var i = 0; i < ChannelQueue<MensagemRecebida>.Capacidade; i++)
             await fila.Publicar(Fala($"wamid.{i}"), CancellationToken.None);
 
-        Assert.Equal(FilaDeMensagens.Capacidade, fila.Aguardando);
+        Assert.Equal(ChannelQueue<MensagemRecebida>.Capacidade, fila.Aguardando);
     }
 
     [Fact]
@@ -47,22 +88,22 @@ public class FilaDeMensagensTeste
     {
         // O produtor ESPERA. Descartar em silencio perderia a fala do cliente
         // sem aparecer em lugar nenhum; a espera aparece como latencia.
-        var fila = new FilaDeMensagens();
-        for (var i = 0; i < FilaDeMensagens.Capacidade; i++)
+        var fila = new ChannelQueue<MensagemRecebida>();
+        for (var i = 0; i < ChannelQueue<MensagemRecebida>.Capacidade; i++)
             await fila.Publicar(Fala($"wamid.{i}"), CancellationToken.None);
 
         using var prazo = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
         var publicou = await fila.Publicar(Fala("estoura"), prazo.Token);
 
         Assert.False(publicou);
-        Assert.Equal(FilaDeMensagens.Capacidade, fila.Aguardando);
+        Assert.Equal(ChannelQueue<MensagemRecebida>.Capacidade, fila.Aguardando);
     }
 
     [Fact]
     public async Task Desligamento_drena_o_que_ja_estava_na_fila()
     {
         // O criterio de aceite: parar de aceitar nao pode descartar o que entrou.
-        var fila = new FilaDeMensagens();
+        var fila = new ChannelQueue<MensagemRecebida>();
         await fila.Publicar(Fala("a"), CancellationToken.None);
         await fila.Publicar(Fala("b"), CancellationToken.None);
 
@@ -78,7 +119,7 @@ public class FilaDeMensagensTeste
     [Fact]
     public async Task Depois_de_parar_nao_aceita_trabalho_novo()
     {
-        var fila = new FilaDeMensagens();
+        var fila = new ChannelQueue<MensagemRecebida>();
         fila.PararDeAceitar();
 
         Assert.False(await fila.Publicar(Fala(), CancellationToken.None));
@@ -89,7 +130,7 @@ public class FilaDeMensagensTeste
     {
         // Sem isto, o desligamento dependeria do timeout do host: o laco ficaria
         // esperando trabalho que nunca chega.
-        var fila = new FilaDeMensagens();
+        var fila = new ChannelQueue<MensagemRecebida>();
         await fila.Publicar(Fala(), CancellationToken.None);
         fila.PararDeAceitar();
 

--- a/testes/Copiloto.Testes/EstadoCompartilhadoTeste.cs
+++ b/testes/Copiloto.Testes/EstadoCompartilhadoTeste.cs
@@ -1,0 +1,171 @@
+using Copiloto.Api.Infra;
+using Microsoft.Extensions.Configuration;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O contrato de <see cref="IDistributedState"/>, rodado contra CADA
+/// implementacao (#66).
+///
+/// A lista `Implementacoes` e o ponto da suite: quando o RedisState existir
+/// (#70), ele entra com UMA linha aqui e passa a ser cobrado pelos mesmos
+/// testes. Suite escrita contra a implementacao, e nao contra o contrato,
+/// precisaria ser reescrita — e reescrita sob pressao de "so falta o Redis"
+/// vira suite mais fraca.
+/// </summary>
+public class EstadoCompartilhadoTeste
+{
+    public static TheoryData<string, Func<IDistributedState>> Implementacoes => new()
+    {
+        { "inmemory", () => new InMemoryState() },
+    };
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task Quem_marca_primeiro_ganha(string nome, Func<IDistributedState> criar)
+    {
+        // A operacao da idempotencia (#67): a segunda instancia precisa
+        // descobrir que a primeira ja pegou aquela mensagem.
+        var estado = criar();
+        var chave = $"webhook:{Guid.NewGuid()}";
+
+        Assert.True(await estado.TentarMarcar(chave, TimeSpan.FromMinutes(5), default));
+        Assert.False(await estado.TentarMarcar(chave, TimeSpan.FromMinutes(5), default));
+        Assert.NotNull(nome);
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task So_um_entre_muitos_concorrentes_marca(string nome, Func<IDistributedState> criar)
+    {
+        // Ler-decidir-gravar em tres passos deixaria a janela em que dois leem
+        // "nao existe" e os dois processam a mesma mensagem.
+        var estado = criar();
+        var chave = $"corrida:{Guid.NewGuid()}";
+
+        var tentativas = await Task.WhenAll(Enumerable.Range(0, 50)
+            .Select(_ => Task.Run(() => estado.TentarMarcar(chave, TimeSpan.FromMinutes(5), default))));
+
+        Assert.Single(tentativas, ganhou => ganhou);
+        Assert.NotNull(nome);
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task Le_de_volta_o_que_gravou(string nome, Func<IDistributedState> criar)
+    {
+        var estado = criar();
+
+        await estado.Gravar("analise:42", "resultado", TimeSpan.FromMinutes(5), default);
+
+        Assert.Equal("resultado", await estado.Ler("analise:42", default));
+        Assert.Null(await estado.Ler("analise:inexistente", default));
+        Assert.NotNull(nome);
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementacoes))]
+    public async Task O_contador_soma_e_devolve_o_total(string nome, Func<IDistributedState> criar)
+    {
+        var estado = criar();
+        var chave = $"rate:{Guid.NewGuid()}";
+
+        Assert.Equal(1, await estado.Incrementar(chave, TimeSpan.FromMinutes(1), default));
+        Assert.Equal(2, await estado.Incrementar(chave, TimeSpan.FromMinutes(1), default));
+        Assert.NotNull(nome);
+    }
+
+    // --- Expiracao: so no InMemoryState, com o relogio na mao ---
+
+    [Fact]
+    public async Task A_marca_vencida_libera_a_chave()
+    {
+        // Relogio injetado: suite que espera o TTL passar fica lenta e depois
+        // fica intermitente, que e' o jeito de um teste deixar de ser lido.
+        var agora = new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+        var estado = new InMemoryState(() => agora);
+
+        Assert.True(await estado.TentarMarcar("k", TimeSpan.FromMinutes(5), default));
+
+        agora = agora.AddMinutes(6);
+
+        Assert.True(await estado.TentarMarcar("k", TimeSpan.FromMinutes(5), default));
+    }
+
+    [Fact]
+    public async Task O_valor_vencido_some_da_leitura()
+    {
+        var agora = new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+        var estado = new InMemoryState(() => agora);
+        await estado.Gravar("k", "v", TimeSpan.FromMinutes(1), default);
+
+        agora = agora.AddMinutes(2);
+
+        Assert.Null(await estado.Ler("k", default));
+    }
+
+    [Fact]
+    public async Task A_janela_vencida_recomeca_do_um_e_renova_o_prazo()
+    {
+        // Manter o vencimento antigo faria o contador expirar no meio da janela
+        // nova, e o limite deixaria de significar uma taxa.
+        var agora = new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+        var estado = new InMemoryState(() => agora);
+        var janela = TimeSpan.FromMinutes(1);
+
+        await estado.Incrementar("r", janela, default);
+        await estado.Incrementar("r", janela, default);
+
+        agora = agora.AddMinutes(2);
+        Assert.Equal(1, await estado.Incrementar("r", janela, default));
+
+        agora = agora.AddSeconds(30);
+        Assert.Equal(2, await estado.Incrementar("r", janela, default));
+    }
+
+    // --- A escolha por variavel de ambiente ---
+
+    private static IConfiguration Com(params (string Chave, string Valor)[] valores) =>
+        new ConfigurationBuilder().AddInMemoryCollection(
+            valores.Select(v => new KeyValuePair<string, string?>(v.Chave, v.Valor))).Build();
+
+    [Fact]
+    public void Sem_variavel_nenhuma_a_aplicacao_sobe_em_memoria()
+    {
+        // O criterio que protege a demo: sem broker e sem cache, tudo de pe.
+        var vazia = Com();
+
+        Assert.IsType<InMemoryState>(Backends.Estado(vazia));
+        Assert.IsType<ChannelQueue<string>>(Backends.Fila<string>(vazia));
+    }
+
+    [Fact]
+    public void Backend_previsto_e_sem_corpo_derruba_a_subida()
+    {
+        // Cair para memoria em silencio daria uma aplicacao que PARECE
+        // distribuida, roda com duas replicas e perde idempotencia sem sinal.
+        var erro = Assert.Throws<NotSupportedException>(
+            () => Backends.Estado(Com(("STATE_BACKEND", "redis"))));
+
+        Assert.Contains("#70", erro.Message);
+        Assert.Throws<NotSupportedException>(
+            () => Backends.Fila<string>(Com(("QUEUE_BACKEND", "rabbitmq"))));
+    }
+
+    [Fact]
+    public void Valor_escrito_errado_diz_quais_existem()
+    {
+        var erro = Assert.Throws<ArgumentException>(
+            () => Backends.Estado(Com(("STATE_BACKEND", "reddis"))));
+
+        Assert.Contains("inmemory, redis", erro.Message);
+    }
+
+    [Fact]
+    public void A_variavel_nao_e_sensivel_a_caixa_nem_a_espaco()
+    {
+        // Valor de .env chega com espaco e com maiuscula mais vezes do que se
+        // imagina, e derrubar a subida por isso seria pedantismo caro.
+        Assert.IsType<InMemoryState>(Backends.Estado(Com(("STATE_BACKEND", " InMemory "))));
+    }
+}


### PR DESCRIPTION
## O que muda
As duas interfaces, `ChannelQueue`, `InMemoryState` e a escolha por `STATE_BACKEND`/`QUEUE_BACKEND`. Sem .env, a aplicacao sobe inteira.

## Decisoes
- Backend previsto e sem corpo DERRUBA A SUBIDA com o numero da issue no erro: cair para memoria em silencio daria uma aplicacao que parece distribuida e perde idempotencia sem sinal.
- As quatro operacoes do estado sao as que os tres usos pedem (#67, #68, #71), nao as que o Redis sabe fazer.
- A suite e escrita contra o CONTRATO: RedisState e RabbitMqQueue entram com uma linha cada.

Nenhum pacote novo.

Closes #66