### PR TITLE
Idempotencia com estado fora do processo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ STATE_BACKEND=inmemory
 # inmemory | rabbitmq  — fila de ingestao e trabalho em background
 QUEUE_BACKEND=inmemory
 #
+# Por quantas horas um ProviderMessageId fica marcado como ja processado (#67).
+# O padrao de 24h espelha a janela de atendimento do WhatsApp; o prazo real de
+# reentrega do webhook nao foi verificado na fonte, e por isso isto e variavel.
+IDEMPOTENCIA_JANELA_HORAS=24
+#
 # Com inmemory a aplicacao roda sozinha, sem Redis nem RabbitMQ: e o padrao,
 # usado no desenvolvimento e na demo. Os valores abaixo so importam quando os
 # backends acima apontam para redis/rabbitmq, com `--profile distribuido`.

--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -84,6 +84,26 @@ Cada mensagem entra com um identificador estável da origem; invocações de IA 
 `Idempotency-Key` derivada do estado da conversa. Reprocessar é barato e não cobra duas
 vezes.
 
+**Onde o registro mora, e por quê (#67).** Em `IDistributedState`, não num dicionário do
+processo. Com duas instâncias atrás de um balanceador, cada processo teria seu próprio
+registro: a reentrega cai na outra instância, que nunca viu aquele id, e a mensagem é
+analisada de novo e **cobrada** de novo. Esse buraco não aparece em teste de unidade nem
+em desenvolvimento — ele só existe com réplica, e se manifesta como fatura maior, nunca
+como erro. Há um teste que documenta justamente o comportamento errado (dois estados
+separados ⇒ dois processamentos), para que voltar atrás quebre a suíte.
+
+A dedupe roda **no worker, não no webhook**: marcar antes de enfileirar descartaria a
+reentrega de uma mensagem que se perdeu na fila quando o processo caiu — trocaria custo
+duplicado por fala do cliente sumida, que é o desfecho pior. A decisão é uma operação
+atômica só (`TentarMarcar`), porque entre um `ler` e um `gravar` cabe a outra instância
+lendo "não existe".
+
+A janela padrão é de 24h, espelhando a janela de atendimento (§13.2, verificada), e é
+**configurável** por `IDEMPOTENCIA_JANELA_HORAS`: o prazo real de reentrega do webhook
+não foi conferido na fonte, e fixá-lo como constante seria arquitetar em cima de memória.
+Sobreviver a restart depende do backend — com `inmemory` o registro morre junto com o
+processo; a persistência é do Redis com `appendonly`, na #70.
+
 ---
 
 ## 6. Fila e o webhook

--- a/src/Copiloto.Api/Ingestao/GuardaDeReentrega.cs
+++ b/src/Copiloto.Api/Ingestao/GuardaDeReentrega.cs
@@ -1,0 +1,70 @@
+using Copiloto.Api.Infra;
+
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// Decide se uma mensagem ja foi processada, valendo para TODAS as instancias
+/// (#67).
+///
+/// O webhook do WhatsApp reentrega. Com o registro dentro do processo, a
+/// reentrega cai na outra instancia, que nunca viu aquele id — e a mensagem e
+/// analisada de novo e COBRADA de novo. A garantia de "nao pagar duas vezes
+/// pelo mesmo clique" passa a ter uma restricao de implantacao nao declarada:
+/// so vale em processo unico. E o tipo de premissa que ninguem escreve e que
+/// quebra no primeiro deploy com replica.
+/// </summary>
+public class GuardaDeReentrega
+{
+    /// <summary>
+    /// Por quanto tempo o id fica marcado.
+    ///
+    /// 24h espelha a janela de atendimento do WhatsApp (ARQUITETURA 13.2, essa
+    /// sim verificada na fonte): fora dela a conversa muda de regime, e uma
+    /// reentrega tao tardia interessa menos que o custo de guardar id para
+    /// sempre.
+    ///
+    /// O prazo REAL de reentrega do webhook nao foi verificado, e por isso o
+    /// valor e configuravel em vez de constante — quando alguem conferir na
+    /// fonte, muda a variavel e nao o codigo. Marcar isso como se fosse fato
+    /// conferido seria arquitetar em cima de memoria, que e exatamente o que a
+    /// #26 mostrou custar caro.
+    /// </summary>
+    public static readonly TimeSpan JanelaPadrao = TimeSpan.FromHours(24);
+
+    private readonly IDistributedState _estado;
+    private readonly TimeSpan _janela;
+
+    public GuardaDeReentrega(IDistributedState estado, TimeSpan? janela = null)
+    {
+        ArgumentNullException.ThrowIfNull(estado);
+
+        _estado = estado;
+        _janela = janela ?? JanelaPadrao;
+    }
+
+    /// <summary>
+    /// True quando ESTA chamada foi a que marcou o id — e so ela processa.
+    ///
+    /// A decisao e uma operacao atomica so, e nao ler-decidir-gravar: entre a
+    /// leitura e a gravacao cabe a outra instancia lendo "nao existe", e as
+    /// duas processariam a mesma mensagem. A janela e pequena e o custo dela e
+    /// dinheiro.
+    /// </summary>
+    public Task<bool> EhAPrimeiraVez(string providerMessageId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(providerMessageId))
+            throw new ArgumentException(
+                "Sem ProviderMessageId nao ha o que deduplicar: qualquer chave que "
+                + "eu inventasse aqui marcaria mensagens diferentes como a mesma.",
+                nameof(providerMessageId));
+
+        return _estado.TentarMarcar(Chave(providerMessageId), _janela, ct);
+    }
+
+    /// <summary>
+    /// O prefixo evita colisao com as outras chaves do mesmo Redis — rate
+    /// limit, circuit breaker e cache de analise dividem o espaco (#68, #71).
+    /// </summary>
+    public static string Chave(string providerMessageId) =>
+        $"ingestao:msg:{providerMessageId.Trim()}";
+}

--- a/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
+++ b/src/Copiloto.Api/Ingestao/ProcessadorDeMensagens.cs
@@ -18,13 +18,16 @@ public class ProcessadorDeMensagens : BackgroundService
 {
     private readonly IQueue<MensagemRecebida> _fila;
     private readonly ResolvedorDeLead _resolvedor;
+    private readonly GuardaDeReentrega _guarda;
     private readonly ILogger<ProcessadorDeMensagens> _log;
 
     public ProcessadorDeMensagens(
-        IQueue<MensagemRecebida> fila, ResolvedorDeLead resolvedor, ILogger<ProcessadorDeMensagens> log)
+        IQueue<MensagemRecebida> fila, ResolvedorDeLead resolvedor,
+        GuardaDeReentrega guarda, ILogger<ProcessadorDeMensagens> log)
     {
         _fila = fila;
         _resolvedor = resolvedor;
+        _guarda = guarda;
         _log = log;
     }
 
@@ -48,8 +51,19 @@ public class ProcessadorDeMensagens : BackgroundService
         }
     }
 
-    private Task Processar(MensagemRecebida bruta)
+    private async Task Processar(MensagemRecebida bruta)
     {
+        // A dedupe fica AQUI, e nao no webhook, de proposito: marcar antes de
+        // enfileirar descartaria a reentrega de uma mensagem que se perdeu na
+        // fila quando o processo caiu — trocaria custo duplicado por fala do
+        // cliente sumida, que e' o desfecho pior.
+        if (!await _guarda.EhAPrimeiraVez(bruta.ProviderMessageId, CancellationToken.None))
+        {
+            _log.LogInformation(
+                "Mensagem {Id} ja processada: reentrega ignorada", bruta.ProviderMessageId);
+            return;
+        }
+
         var doCliente = _resolvedor.TelefoneDoCliente(bruta);
         if (doCliente is null)
         {
@@ -58,7 +72,7 @@ public class ProcessadorDeMensagens : BackgroundService
             _log.LogWarning(
                 "Mensagem {Id} descartada: nem De ({De}) nem Para ({Para}) e telefone valido",
                 bruta.ProviderMessageId, bruta.De, bruta.Para);
-            return Task.CompletedTask;
+            return;
         }
 
         var lead = _resolvedor.Resolver(doCliente, bruta.EnviadaEm);
@@ -70,7 +84,6 @@ public class ProcessadorDeMensagens : BackgroundService
         _log.LogInformation(
             "Mensagem {Id} de {Autor} no lead {Lead} processada fora do webhook",
             bruta.ProviderMessageId, autor, lead.Id);
-        return Task.CompletedTask;
     }
 
     public override async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -25,6 +25,14 @@ builder.Services.AddSingleton(_ => new RoteadorDeModelo(
 builder.Services.AddSingleton(_ => Backends.Fila<MensagemRecebida>(builder.Configuration));
 builder.Services.AddSingleton(_ => Backends.Estado(builder.Configuration));
 
+// A janela de dedupe e configuravel porque o prazo real de reentrega do webhook
+// nao foi verificado na fonte (#67): conferir muda a variavel, nao o codigo.
+builder.Services.AddSingleton(sp => new GuardaDeReentrega(
+    sp.GetRequiredService<IDistributedState>(),
+    double.TryParse(builder.Configuration["IDEMPOTENCIA_JANELA_HORAS"], out var horas)
+        ? TimeSpan.FromHours(horas)
+        : GuardaDeReentrega.JanelaPadrao));
+
 // O numero da empresa e o que decide quem falou em cada mensagem, entao ele e
 // configuracao e nao constante: cada instalacao tem o seu.
 builder.Services.AddSingleton(_ => new ResolvedorDeLead(

--- a/testes/Copiloto.Testes/IdempotenciaDistribuidaTeste.cs
+++ b/testes/Copiloto.Testes/IdempotenciaDistribuidaTeste.cs
@@ -1,0 +1,170 @@
+using Copiloto.Api.Infra;
+using Copiloto.Api.Ingestao;
+using Microsoft.Extensions.Logging;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Idempotencia que sobrevive a duas instancias (#67).
+///
+/// A #18 resolveu a reentrega dentro de um processo. O buraco que sobrou nao
+/// aparece em teste de unidade nenhum e nem em ambiente de desenvolvimento: ele
+/// so existe quando ha replica, e se manifesta como fatura maior — nunca como
+/// erro.
+/// </summary>
+public class IdempotenciaDistribuidaTeste
+{
+    private const string Id = "wamid.HBgNNTUxMTk4ODg4MTExMRUCABIYFjNBMD";
+
+    [Fact]
+    public async Task A_mesma_mensagem_entregue_as_duas_instancias_processa_uma_vez()
+    {
+        // Estado compartilhado e o que Redis sera: as duas instancias olham o
+        // mesmo registro, e so uma delas ganha a marcacao.
+        var compartilhado = new InMemoryState();
+        var instanciaA = new GuardaDeReentrega(compartilhado);
+        var instanciaB = new GuardaDeReentrega(compartilhado);
+
+        var naA = await instanciaA.EhAPrimeiraVez(Id, default);
+        var naB = await instanciaB.EhAPrimeiraVez(Id, default);
+
+        Assert.True(naA);
+        Assert.False(naB);
+    }
+
+    [Fact]
+    public async Task Com_estado_por_processo_a_reentrega_e_cobrada_de_novo()
+    {
+        // Este teste documenta o BUG que a issue existe para fechar, e falharia
+        // se alguem "simplificasse" a guarda de volta para um dicionario local:
+        // duas instancias, dois registros, dois processamentos, duas cobrancas.
+        var instanciaA = new GuardaDeReentrega(new InMemoryState());
+        var instanciaB = new GuardaDeReentrega(new InMemoryState());
+
+        Assert.True(await instanciaA.EhAPrimeiraVez(Id, default));
+        Assert.True(await instanciaB.EhAPrimeiraVez(Id, default));
+    }
+
+    [Fact]
+    public async Task Instancia_unica_com_inmemory_continua_funcionando()
+    {
+        // O criterio que protege a demo: sem Redis, tudo de pe.
+        var guarda = new GuardaDeReentrega(new InMemoryState());
+
+        Assert.True(await guarda.EhAPrimeiraVez(Id, default));
+        Assert.False(await guarda.EhAPrimeiraVez(Id, default));
+        Assert.False(await guarda.EhAPrimeiraVez(Id, default));
+    }
+
+    [Fact]
+    public async Task Mensagens_diferentes_nao_se_atrapalham()
+    {
+        var guarda = new GuardaDeReentrega(new InMemoryState());
+
+        Assert.True(await guarda.EhAPrimeiraVez("wamid.1", default));
+        Assert.True(await guarda.EhAPrimeiraVez("wamid.2", default));
+    }
+
+    [Fact]
+    public async Task Depois_da_janela_o_id_deixa_de_ocupar_espaco()
+    {
+        // Guardar id para sempre e um vazamento lento: a chave nunca mais e
+        // consultada e continua paga em memoria (ou em Redis, que custa mais).
+        var agora = new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+        var guarda = new GuardaDeReentrega(new InMemoryState(() => agora), TimeSpan.FromHours(24));
+
+        Assert.True(await guarda.EhAPrimeiraVez(Id, default));
+
+        agora = agora.AddHours(25);
+
+        Assert.True(await guarda.EhAPrimeiraVez(Id, default));
+    }
+
+    [Fact]
+    public async Task Dentro_da_janela_a_reentrega_tardia_ainda_e_barrada()
+    {
+        var agora = new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+        var guarda = new GuardaDeReentrega(new InMemoryState(() => agora), TimeSpan.FromHours(24));
+        await guarda.EhAPrimeiraVez(Id, default);
+
+        agora = agora.AddHours(23);
+
+        Assert.False(await guarda.EhAPrimeiraVez(Id, default));
+    }
+
+    [Fact]
+    public async Task Cinquenta_entregas_simultaneas_processam_uma_vez_so()
+    {
+        // O balanceador nao entrega em ordem nem espacado: a corrida e real.
+        var compartilhado = new InMemoryState();
+        var instancias = Enumerable.Range(0, 50)
+            .Select(_ => new GuardaDeReentrega(compartilhado)).ToList();
+
+        var resultados = await Task.WhenAll(
+            instancias.Select(i => Task.Run(() => i.EhAPrimeiraVez(Id, default))));
+
+        Assert.Single(resultados, primeira => primeira);
+    }
+
+    [Fact]
+    public async Task Sem_id_do_provedor_a_guarda_recusa_em_vez_de_inventar_chave()
+    {
+        var guarda = new GuardaDeReentrega(new InMemoryState());
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => guarda.EhAPrimeiraVez("  ", default));
+    }
+
+    // --- Com a fila e o worker de verdade ---
+
+    /// <summary>Conta quantas vezes o worker disse que PROCESSOU.</summary>
+    private class LogEspiao : ILogger<ProcessadorDeMensagens>
+    {
+        public int Processadas { get; private set; }
+        public int Ignoradas { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel nivel) => true;
+
+        public void Log<TState>(
+            LogLevel nivel, EventId id, TState estado, Exception? erro,
+            Func<TState, Exception?, string> formatar)
+        {
+            var linha = formatar(estado, erro);
+            if (linha.Contains("processada fora do webhook")) Processadas++;
+            if (linha.Contains("reentrega ignorada")) Ignoradas++;
+        }
+    }
+
+    private static MensagemRecebida Fala() => new(
+        Id, "+55 11 98765-4321", "+55 11 3333-4444", "qual o valor do kg?",
+        new DateTimeOffset(2026, 9, 3, 10, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task Reentrega_na_fila_nao_vira_segundo_processamento()
+    {
+        // O caminho inteiro: webhook enfileira duas vezes o mesmo wamid — o que
+        // acontece quando o provedor nao recebe o 202 a tempo — e o worker
+        // trabalha uma vez so.
+        var log = new LogEspiao();
+        var fila = new ChannelQueue<MensagemRecebida>();
+        var worker = new ProcessadorDeMensagens(
+            fila, new ResolvedorDeLead("+55 11 3333-4444"),
+            new GuardaDeReentrega(new InMemoryState()), log);
+
+        await worker.StartAsync(default);
+        await fila.Publicar(Fala(), default);
+        await fila.Publicar(Fala(), default);
+        await worker.StopAsync(default);
+
+        Assert.Equal(1, log.Processadas);
+        Assert.Equal(1, log.Ignoradas);
+    }
+
+    [Fact]
+    public void A_chave_e_prefixada_para_nao_colidir_com_os_outros_usos()
+    {
+        // Rate limit, circuit breaker e cache de analise dividem o mesmo Redis.
+        Assert.StartsWith("ingestao:msg:", GuardaDeReentrega.Chave("wamid.1"));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `66-state-e-queue` (#66).

## O que muda
O registro de reentrega saiu do processo. Com replica, a reentrega caia na outra instancia e era cobrada de novo.

## Decisoes
- A dedupe roda no WORKER, nao no webhook: marcar antes de enfileirar trocaria custo duplicado por fala do cliente sumida.
- Uma operacao atomica so — entre um ler e um gravar cabe a outra instancia lendo "nao existe".
- Janela configuravel: o prazo real de reentrega do webhook nao foi verificado na fonte.

Ha teste que documenta o comportamento ERRADO (dois estados locais, dois processamentos), para que voltar atras quebre o build.

## Fora deste PR
Sobreviver a restart depende do Redis com appendonly (#70).

Closes #67