### PR TITLE
Rate limit e cache de analise compartilhados

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ QUEUE_BACKEND=inmemory
 # O padrao de 24h espelha a janela de atendimento do WhatsApp; o prazo real de
 # reentrega do webhook nao foi verificado na fonte, e por isso isto e variavel.
 IDEMPOTENCIA_JANELA_HORAS=24
+
+# Chamadas de analise por usuario, por minuto (#41, #71). O contador vive no
+# STATE_BACKEND: com estado local, o limite viraria limite x numero de replicas.
+RATE_LIMIT_POR_USUARIO=60
+# Por quantas horas uma analise ja paga continua valendo (#34).
+CACHE_ANALISE_HORAS=6
 #
 # Com inmemory a aplicacao roda sozinha, sem Redis nem RabbitMQ: e o padrao,
 # usado no desenvolvimento e na demo. Os valores abaixo so importam quando os

--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -319,12 +319,32 @@ da aplicação**:
 |---|---|
 | Idempotência do webhook | Cada instância tem seu próprio registro de mensagens vistas. A reentrega cai na outra instância e é processada de novo — **e cobrada de novo**. |
 | Circuit breaker | Três instâncias, três circuitos independentes. Cada uma precisa falhar N vezes por conta própria antes de proteger. O provedor caído é golpeado 3N vezes. |
-| Rate limit por usuário | O limite vira o limite × número de instâncias. |
-| Cache de análise | Taxa de acerto cai proporcionalmente às instâncias. |
+| Rate limit por usuário | O limite vira o limite × número de instâncias. **Resolvido em #71.** |
+| Cache de análise | Taxa de acerto cai proporcionalmente às instâncias. **Resolvido em #71.** |
 
 Isso não é um problema de volume — é um problema de **corretude**. Um sistema cuja
 proteção contra gasto duplicado depende de rodar em processo único tem uma restrição
 de implantação não declarada.
+
+**Rate limit e cache, agora no estado compartilhado (#71).** O contador do limite vive em
+`IDistributedState`, então três réplicas dividem o mesmo teto em vez de multiplicá-lo —
+limite que se multiplica sozinho não é limite, é sugestão. O contador **continua subindo
+depois do teto**, de propósito: quem insiste além do limite é exatamente quem se quer
+enxergar, e um contador que trava apaga o único sinal de que houve insistência.
+
+O cache de análise é chaveado pelo **estado da conversa** (lead + id da última mensagem +
+versão do prompt), e não pelo texto: guardar por texto faria cada mensagem nova virar uma
+entrada inteira, e guardar só por lead serviria análise velha depois de o cliente falar de
+novo — que é o erro pior, porque a resposta *parece* certa. Trocar a versão do prompt
+também muda a chave, senão a mudança que alguém acabou de fazer ficaria escondida atrás
+de respostas antigas.
+
+E a parte que quebra alto: **o dono é gravado dentro do valor e conferido na leitura**, não
+só embutido na chave. Cache distribuído mal chaveado serve o dossiê de um cliente para
+outro em silêncio — sem erro, sem log, com a tela mostrando um texto plausível sobre a
+pessoa errada. Com a conferência, uma chave colidida vira *miss*, não vazamento. O prefixo
+`analise:<leadId>:` existe para o expurgo por titular (#46) achar o que é dele sem varrer
+o Redis inteiro.
 
 ### 12.2 A fila em memória perde mensagem
 

--- a/src/Copiloto.Api/Ia/CacheDeAnalise.cs
+++ b/src/Copiloto.Api/Ia/CacheDeAnalise.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Copiloto.Api.Infra;
+
+namespace Copiloto.Api.Ia;
+
+/// <summary>
+/// O que foi analisado e ainda vale, compartilhado entre instancias (#34, #71).
+///
+/// Com cache local, a taxa de acerto cai proporcionalmente ao numero de
+/// replicas: a segunda instancia nao sabe que a primeira ja pagou por aquela
+/// analise, e paga de novo.
+///
+/// O risco desta classe nao e perder acerto, e VAZAR: cache mal chaveado serve
+/// o dossie de um cliente para outro, e faz isso em silencio — sem erro, sem
+/// log, com a tela mostrando um texto plausivel sobre a pessoa errada. Por isso
+/// o dono e gravado DENTRO do valor e conferido na leitura, e nao so embutido
+/// na chave.
+/// </summary>
+public class CacheDeAnalise
+{
+    private record Guardado(Guid LeadId, string Conteudo);
+
+    private static readonly JsonSerializerOptions Json = new();
+
+    private readonly IDistributedState _estado;
+    private readonly TimeSpan _validade;
+
+    public CacheDeAnalise(IDistributedState estado, TimeSpan? validade = null)
+    {
+        ArgumentNullException.ThrowIfNull(estado);
+
+        _estado = estado;
+        _validade = validade ?? TimeSpan.FromHours(6);
+    }
+
+    /// <summary>Acertos e erros, para a metrica do painel.</summary>
+    public int Acertos { get; private set; }
+
+    public int Erros { get; private set; }
+
+    public double TaxaDeAcerto => Acertos + Erros == 0 ? 0 : (double)Acertos / (Acertos + Erros);
+
+    /// <summary>
+    /// A chave e o ESTADO da conversa, nao o texto dela.
+    ///
+    /// Guardar por texto faria a mesma conversa com uma mensagem a mais virar
+    /// outra entrada inteira; guardar so por lead serviria analise velha depois
+    /// de o cliente falar de novo — que e o erro pior, porque a resposta parece
+    /// certa. O id da ultima mensagem resolve os dois: ele muda exatamente
+    /// quando a conversa anda.
+    /// </summary>
+    public static string Chave(Guid leadId, Guid ultimaMensagemId, string versaoDoPrompt)
+    {
+        var cru = $"{leadId}|{ultimaMensagemId}|{versaoDoPrompt}";
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cru)))[..16];
+
+        // O lead vai no prefixo E entra no hash: o prefixo deixa a chave
+        // legivel no Redis para depurar e expurgar por titular (#46), e o hash
+        // e o que de fato identifica o estado.
+        return $"analise:{leadId}:{hash}";
+    }
+
+    /// <summary>
+    /// Le a analise guardada. Devolve null quando nao ha — e tambem quando o
+    /// que ha pertence a OUTRO lead, que e a defesa contra o vazamento
+    /// silencioso.
+    /// </summary>
+    public async Task<string?> Ler(Guid leadId, string chave, CancellationToken ct)
+    {
+        var cru = await _estado.Ler(chave, ct);
+        if (cru is null)
+        {
+            Erros++;
+            return null;
+        }
+
+        var guardado = JsonSerializer.Deserialize<Guardado>(cru, Json);
+        if (guardado is null || guardado.LeadId != leadId)
+        {
+            // Conta como erro e nao serve nada. Chegar aqui significa colisao
+            // de chave ou chave montada errado — e nos dois casos entregar o
+            // conteudo seria mostrar o dossie de um cliente para outro.
+            Erros++;
+            return null;
+        }
+
+        Acertos++;
+        return guardado.Conteudo;
+    }
+
+    public Task Guardar(Guid leadId, string chave, string conteudo, CancellationToken ct) =>
+        _estado.Gravar(chave, JsonSerializer.Serialize(new Guardado(leadId, conteudo), Json),
+                       _validade, ct);
+}

--- a/src/Copiloto.Api/Ia/LimitadorDeTaxa.cs
+++ b/src/Copiloto.Api/Ia/LimitadorDeTaxa.cs
@@ -1,0 +1,50 @@
+using Copiloto.Api.Infra;
+
+namespace Copiloto.Api.Ia;
+
+/// <summary>
+/// Rate limit por usuario, valendo para todas as instancias (#41, #71).
+///
+/// Com o contador dentro do processo, o limite vira "limite x numero de
+/// replicas" — e limite que se multiplica sozinho nao e limite, e sugestao.
+/// Aqui ele protege dinheiro, nao CPU: cada chamada que passa e uma invocacao
+/// de modelo paga.
+/// </summary>
+public class LimitadorDeTaxa
+{
+    private readonly IDistributedState _estado;
+    private readonly int _limite;
+    private readonly TimeSpan _janela;
+
+    public LimitadorDeTaxa(IDistributedState estado, int limite, TimeSpan janela)
+    {
+        ArgumentNullException.ThrowIfNull(estado);
+        if (limite <= 0)
+            throw new ArgumentOutOfRangeException(nameof(limite),
+                "Limite zero bloquearia tudo, e limite negativo nao quer dizer nada. "
+                + "Para desligar o limitador, nao o registre.");
+
+        _estado = estado;
+        _limite = limite;
+        _janela = janela;
+    }
+
+    /// <summary>
+    /// Consome uma unidade e diz se a chamada pode seguir.
+    ///
+    /// Contar SEMPRE, inclusive quando ja passou do limite, e deliberado: quem
+    /// insiste alem do teto e exatamente quem se quer enxergar, e um contador
+    /// que para de subir apaga o unico sinal de que houve insistencia.
+    /// </summary>
+    public async Task<bool> Permite(Guid usuarioId, CancellationToken ct)
+    {
+        if (usuarioId == Guid.Empty)
+            throw new ArgumentException(
+                "Rate limit sem usuario cairia todo mundo no mesmo balde, e o "
+                + "primeiro vendedor movimentado bloquearia a empresa inteira.",
+                nameof(usuarioId));
+
+        var usadas = await _estado.Incrementar($"rate:usuario:{usuarioId}", _janela, ct);
+        return usadas <= _limite;
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -25,6 +25,19 @@ builder.Services.AddSingleton(_ => new RoteadorDeModelo(
 builder.Services.AddSingleton(_ => Backends.Fila<MensagemRecebida>(builder.Configuration));
 builder.Services.AddSingleton(_ => Backends.Estado(builder.Configuration));
 
+// Rate limit e cache de analise dividem o mesmo estado compartilhado (#71): com
+// contador local, o limite viraria limite vezes o numero de replicas.
+builder.Services.AddSingleton(sp => new LimitadorDeTaxa(
+    sp.GetRequiredService<IDistributedState>(),
+    int.TryParse(builder.Configuration["RATE_LIMIT_POR_USUARIO"], out var teto) ? teto : 60,
+    TimeSpan.FromMinutes(1)));
+
+builder.Services.AddSingleton(sp => new CacheDeAnalise(
+    sp.GetRequiredService<IDistributedState>(),
+    double.TryParse(builder.Configuration["CACHE_ANALISE_HORAS"], out var validade)
+        ? TimeSpan.FromHours(validade)
+        : null));
+
 // A janela de dedupe e configuravel porque o prazo real de reentrega do webhook
 // nao foi verificado na fonte (#67): conferir muda a variavel, nao o codigo.
 builder.Services.AddSingleton(sp => new GuardaDeReentrega(

--- a/testes/Copiloto.Testes/LimiteECacheTeste.cs
+++ b/testes/Copiloto.Testes/LimiteECacheTeste.cs
@@ -1,0 +1,215 @@
+using Copiloto.Api.Ia;
+using Copiloto.Api.Infra;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Rate limit e cache de analise valendo entre instancias (#71).
+///
+/// Os dois assumiam processo unico, e os dois quebram calados: o limite vira
+/// limite vezes replicas, e o cache perde acerto na mesma proporcao. O terceiro
+/// criterio da issue e o unico que quebra ALTO — cache mal chaveado serve o
+/// dossie de um cliente para outro.
+/// </summary>
+public class LimiteECacheTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Minuto = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// As implementacoes de estado cobradas por estes testes. RedisState (#70)
+    /// entra com uma linha, e o teste de isolamento do cache passa a rodar nos
+    /// dois backends, como o criterio pede.
+    /// </summary>
+    public static TheoryData<string, Func<IDistributedState>> Backends => new()
+    {
+        { "inmemory", () => new InMemoryState() },
+    };
+
+    // --- Rate limit ---
+
+    [Theory]
+    [MemberData(nameof(Backends))]
+    public async Task O_limite_vale_para_as_duas_instancias_juntas(
+        string nome, Func<IDistributedState> criar)
+    {
+        // O ponto da issue: limite que se multiplica pelo numero de replicas
+        // nao e limite, e sugestao.
+        var compartilhado = criar();
+        var usuario = Guid.NewGuid();
+        var instanciaA = new LimitadorDeTaxa(compartilhado, limite: 3, Minuto);
+        var instanciaB = new LimitadorDeTaxa(compartilhado, limite: 3, Minuto);
+
+        Assert.True(await instanciaA.Permite(usuario, default));
+        Assert.True(await instanciaB.Permite(usuario, default));
+        Assert.True(await instanciaA.Permite(usuario, default));
+        Assert.False(await instanciaB.Permite(usuario, default));
+        Assert.NotNull(nome);
+    }
+
+    [Fact]
+    public async Task Cada_usuario_tem_o_proprio_balde()
+    {
+        // Sem a chave por usuario, o primeiro vendedor movimentado bloquearia
+        // a empresa inteira.
+        var limitador = new LimitadorDeTaxa(new InMemoryState(), limite: 1, Minuto);
+
+        Assert.True(await limitador.Permite(Guid.NewGuid(), default));
+        Assert.True(await limitador.Permite(Guid.NewGuid(), default));
+    }
+
+    [Fact]
+    public async Task A_janela_vira_e_o_usuario_volta_a_poder()
+    {
+        var agora = T0;
+        var limitador = new LimitadorDeTaxa(new InMemoryState(() => agora), limite: 1, Minuto);
+        var usuario = Guid.NewGuid();
+
+        Assert.True(await limitador.Permite(usuario, default));
+        Assert.False(await limitador.Permite(usuario, default));
+
+        agora = agora.AddMinutes(2);
+
+        Assert.True(await limitador.Permite(usuario, default));
+    }
+
+    [Fact]
+    public async Task Quem_insiste_alem_do_teto_continua_sendo_contado()
+    {
+        // Contador que para de subir apaga o unico sinal de que houve
+        // insistencia — e insistencia e o que se quer enxergar.
+        var estado = new InMemoryState();
+        var limitador = new LimitadorDeTaxa(estado, limite: 1, Minuto);
+        var usuario = Guid.NewGuid();
+
+        for (var i = 0; i < 5; i++) await limitador.Permite(usuario, default);
+
+        Assert.Equal(6, await estado.Incrementar($"rate:usuario:{usuario}", Minuto, default));
+    }
+
+    [Fact]
+    public void Limite_zero_e_recusado_na_construcao()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new LimitadorDeTaxa(new InMemoryState(), limite: 0, Minuto));
+    }
+
+    [Fact]
+    public async Task Rate_limit_sem_usuario_e_erro_e_nao_balde_comum()
+    {
+        var limitador = new LimitadorDeTaxa(new InMemoryState(), limite: 1, Minuto);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => limitador.Permite(Guid.Empty, default));
+    }
+
+    // --- Cache de analise ---
+
+    [Theory]
+    [MemberData(nameof(Backends))]
+    public async Task O_cache_nunca_serve_dossie_de_outro_lead(
+        string nome, Func<IDistributedState> criar)
+    {
+        // O criterio que quebra alto: sem a conferencia do dono, uma chave
+        // colidida mostraria um texto plausivel sobre a pessoa errada — sem
+        // erro, sem log, com a tela parecendo certa.
+        var compartilhado = criar();
+        var cache = new CacheDeAnalise(compartilhado);
+        var marina = Guid.NewGuid();
+        var lucas = Guid.NewGuid();
+        var chave = CacheDeAnalise.Chave(marina, Guid.NewGuid(), "v1");
+
+        await cache.Guardar(marina, chave, "Marina está pronta para fechar", default);
+
+        Assert.Null(await cache.Ler(lucas, chave, default));
+        Assert.Equal("Marina está pronta para fechar", await cache.Ler(marina, chave, default));
+        Assert.NotNull(nome);
+    }
+
+    [Theory]
+    [MemberData(nameof(Backends))]
+    public async Task A_segunda_instancia_aproveita_o_que_a_primeira_pagou(
+        string nome, Func<IDistributedState> criar)
+    {
+        var compartilhado = criar();
+        var lead = Guid.NewGuid();
+        var chave = CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1");
+
+        await new CacheDeAnalise(compartilhado).Guardar(lead, chave, "dossiê", default);
+
+        Assert.Equal("dossiê", await new CacheDeAnalise(compartilhado).Ler(lead, chave, default));
+        Assert.NotNull(nome);
+    }
+
+    [Fact]
+    public void A_chave_muda_quando_a_conversa_anda()
+    {
+        // Servir analise velha depois de o cliente falar de novo e o erro pior
+        // do cache: a resposta PARECE certa.
+        var lead = Guid.NewGuid();
+
+        var antes = CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1");
+        var depois = CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1");
+
+        Assert.NotEqual(antes, depois);
+    }
+
+    [Fact]
+    public void A_chave_muda_quando_o_prompt_muda_de_versao()
+    {
+        // Prompt novo com resposta velha esconde justamente o efeito da
+        // mudanca que alguem acabou de fazer.
+        var lead = Guid.NewGuid();
+        var mensagem = Guid.NewGuid();
+
+        Assert.NotEqual(
+            CacheDeAnalise.Chave(lead, mensagem, "v1"),
+            CacheDeAnalise.Chave(lead, mensagem, "v2"));
+    }
+
+    [Fact]
+    public void A_chave_leva_o_lead_no_prefixo_para_expurgo_por_titular()
+    {
+        // O titular pede exclusao e alguem precisa achar o que e dele no Redis
+        // sem varrer tudo (#46).
+        var lead = Guid.NewGuid();
+
+        Assert.StartsWith($"analise:{lead}:", CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1"));
+    }
+
+    [Fact]
+    public async Task A_metrica_de_acerto_conta_o_que_pagou_e_o_que_nao_pagou()
+    {
+        var cache = new CacheDeAnalise(new InMemoryState());
+        var lead = Guid.NewGuid();
+        var chave = CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1");
+
+        Assert.Null(await cache.Ler(lead, chave, default));
+        await cache.Guardar(lead, chave, "dossiê", default);
+        await cache.Ler(lead, chave, default);
+
+        Assert.Equal(1, cache.Acertos);
+        Assert.Equal(1, cache.Erros);
+        Assert.Equal(0.5, cache.TaxaDeAcerto);
+    }
+
+    [Fact]
+    public async Task Analise_vencida_nao_e_servida()
+    {
+        var agora = T0;
+        var cache = new CacheDeAnalise(new InMemoryState(() => agora), TimeSpan.FromHours(6));
+        var lead = Guid.NewGuid();
+        var chave = CacheDeAnalise.Chave(lead, Guid.NewGuid(), "v1");
+        await cache.Guardar(lead, chave, "dossiê", default);
+
+        agora = agora.AddHours(7);
+
+        Assert.Null(await cache.Ler(lead, chave, default));
+    }
+
+    [Fact]
+    public void Sem_leitura_nenhuma_a_taxa_nao_inventa_numero()
+    {
+        // Zero leitura com taxa "100%" viraria um painel que mente para cima.
+        Assert.Equal(0, new CacheDeAnalise(new InMemoryState()).TaxaDeAcerto);
+    }
+}


### PR DESCRIPTION
**Base:** sai de `67-idempotencia-distribuida` (#67).

## O que muda
Contador de limite e cache de analise no estado compartilhado.

## Decisoes
- O DONO e gravado dentro do valor e conferido na leitura: cache mal chaveado serve o dossie de um cliente para outro em silencio. Com a conferencia, chave colidida vira miss.
- O contador continua subindo depois do teto: quem insiste e quem se quer enxergar.
- A chave e o ESTADO da conversa (lead + ultima mensagem + versao do prompt), nao o texto.

Closes #71