### PR TITLE
Circuit breaker com estado compartilhado

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -318,13 +318,31 @@ da aplicação**:
 | Mecanismo | O que quebra com duas instâncias |
 |---|---|
 | Idempotência do webhook | Cada instância tem seu próprio registro de mensagens vistas. A reentrega cai na outra instância e é processada de novo — **e cobrada de novo**. |
-| Circuit breaker | Três instâncias, três circuitos independentes. Cada uma precisa falhar N vezes por conta própria antes de proteger. O provedor caído é golpeado 3N vezes. |
+| Circuit breaker | Três instâncias, três circuitos independentes. Cada uma precisa falhar N vezes por conta própria antes de proteger. O provedor caído é golpeado 3N vezes. **Resolvido em #68.** |
 | Rate limit por usuário | O limite vira o limite × número de instâncias. **Resolvido em #71.** |
 | Cache de análise | Taxa de acerto cai proporcionalmente às instâncias. **Resolvido em #71.** |
 
 Isso não é um problema de volume — é um problema de **corretude**. Um sistema cuja
 proteção contra gasto duplicado depende de rodar em processo único tem uma restrição
 de implantação não declarada.
+
+**O circuito, um só para todas as instâncias (#68).** A instância que abre protege as
+demais na mesma hora, em vez de cada uma descobrir a queda por conta própria.
+
+O detalhe que decide a implementação está no **meio-aberto**: quando a espera passa, o
+estado não volta a "fechado" para todo mundo ao mesmo tempo — isso faria a avalanche
+acontecer por expiração de chave, no pior momento possível, que é o provedor tentando se
+recuperar. A sonda é **disputada**: quem marca primeiro faz a requisição de teste, e as
+demais seguem barradas até haver resposta. A reserva da sonda é curta de propósito, para
+que a instância que morrer no meio do teste não prenda o circuito em meio-aberto.
+
+O contador de falhas tem **janela**: sem ela, três falhas espalhadas por uma semana
+abririam o circuito de um provedor que está de pé, e o sintoma seria "às vezes o sistema
+escolhe o modelo caro". Sucesso zera a contagem pelo mesmo motivo.
+
+O `RoteadorDeModelo` continua sendo regra de domínio e recebe uma função síncrona: quem
+vai chamar o modelo carrega o retrato dos provedores fora do ar — uma leitura por provedor
+da tabela — e entrega ao router. O router decide; ele não consulta infraestrutura.
 
 **Rate limit e cache, agora no estado compartilhado (#71).** O contador do limite vive em
 `IDistributedState`, então três réplicas dividem o mesmo teto em vez de multiplicá-lo —

--- a/src/Copiloto.Api/Ia/CircuitoDoProvedor.cs
+++ b/src/Copiloto.Api/Ia/CircuitoDoProvedor.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using Copiloto.Api.Infra;
+
+namespace Copiloto.Api.Ia;
+
+/// <summary>Em que ponto o circuito de um provedor esta.</summary>
+public enum EstadoDoCircuito
+{
+    /// <summary>Chamando normalmente.</summary>
+    Fechado = 0,
+
+    /// <summary>Provedor fora do ar: ninguem chama.</summary>
+    Aberto = 1,
+
+    /// <summary>Hora de testar — e UMA instancia testa, nao todas.</summary>
+    MeioAberto = 2,
+}
+
+/// <summary>
+/// O circuit breaker por provedor, com o estado fora do processo (#38, #68).
+///
+/// Com o estado em memoria e tres instancias existem TRES circuitos
+/// independentes: cada uma precisa falhar N vezes por conta propria antes de
+/// proteger. Um provedor fora do ar leva 3N requisicoes em vez de N — e cada
+/// uma delas e tempo de espera na frente do vendedor.
+///
+/// O detalhe que separa quem ja implementou disso de quem leu sobre esta no
+/// meio-aberto: se todas as instancias testarem o provedor em recuperacao ao
+/// mesmo tempo, o teste vira exatamente a avalanche que o breaker existe para
+/// evitar. Aqui a sonda e disputada — quem marca primeiro testa, e os demais
+/// seguem barrados ate haver resposta.
+/// </summary>
+public class CircuitoDoProvedor
+{
+    /// <summary>O que o estado compartilhado guarda sobre um provedor.</summary>
+    private record Registro(DateTimeOffset? AbertoAte);
+
+    private static readonly JsonSerializerOptions Json = new();
+
+    public const int FalhasQueAbrem = 3;
+
+    /// <summary>Quanto tempo ninguem chama antes de valer a pena testar.</summary>
+    public static readonly TimeSpan EsperaAntesDeTestar = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Falhas contam dentro de uma JANELA. Sem ela, tres falhas espalhadas por
+    /// uma semana abririam o circuito de um provedor que esta de pe.
+    /// </summary>
+    public static readonly TimeSpan JanelaDeContagem = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Quanto tempo a sonda fica reservada. Curto de proposito: se a instancia
+    /// que ganhou morrer antes de responder, o circuito nao pode ficar preso em
+    /// meio-aberto para sempre — outra tenta logo depois.
+    /// </summary>
+    public static readonly TimeSpan ReservaDaSonda = TimeSpan.FromSeconds(10);
+
+    private readonly IDistributedState _estado;
+    private readonly Func<DateTimeOffset> _agora;
+
+    public CircuitoDoProvedor(IDistributedState estado, Func<DateTimeOffset>? agora = null)
+    {
+        ArgumentNullException.ThrowIfNull(estado);
+
+        _estado = estado;
+        _agora = agora ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    public async Task<EstadoDoCircuito> Estado(string provedor, CancellationToken ct)
+    {
+        var registro = await Registrado(provedor, ct);
+
+        if (registro?.AbertoAte is null) return EstadoDoCircuito.Fechado;
+
+        return registro.AbertoAte > _agora()
+            ? EstadoDoCircuito.Aberto
+            : EstadoDoCircuito.MeioAberto;
+    }
+
+    /// <summary>
+    /// Se ESTA chamada pode seguir para o provedor.
+    ///
+    /// No meio-aberto a resposta e verdadeira para UMA instancia so — a que
+    /// ganhar a sonda. As outras continuam barradas ate o resultado, senao o
+    /// momento da recuperacao seria o momento de maior carga.
+    /// </summary>
+    public async Task<bool> PodeChamar(string provedor, CancellationToken ct) =>
+        await Estado(provedor, ct) switch
+        {
+            EstadoDoCircuito.Fechado => true,
+            EstadoDoCircuito.Aberto => false,
+            _ => await _estado.TentarMarcar(Sonda(provedor), ReservaDaSonda, ct),
+        };
+
+    public async Task RegistrarFalha(string provedor, CancellationToken ct)
+    {
+        var falhas = await _estado.Incrementar(Contador(provedor), JanelaDeContagem, ct);
+        if (falhas < FalhasQueAbrem) return;
+
+        var abertoAte = _agora() + EsperaAntesDeTestar;
+
+        // A validade da chave passa do fim da espera: enquanto ela existir com
+        // AbertoAte vencido, o circuito esta em MEIO-ABERTO. Se ela sumisse
+        // junto com a espera, o estado voltaria a "fechado" para todo mundo ao
+        // mesmo tempo — e a avalanche aconteceria por expiracao de chave.
+        await Gravar(provedor, new Registro(abertoAte), EsperaAntesDeTestar * 4, ct);
+    }
+
+    /// <summary>
+    /// Provedor respondeu: fecha o circuito e zera a contagem.
+    ///
+    /// Zerar importa mais do que parece — sem isso, tres falhas espalhadas com
+    /// sucessos no meio abririam o circuito de um provedor saudavel, e o
+    /// sintoma seria "o sistema escolhe o modelo caro as vezes".
+    /// </summary>
+    public async Task RegistrarSucesso(string provedor, CancellationToken ct)
+    {
+        await _estado.Gravar(Contador(provedor), "0", JanelaDeContagem, ct);
+        await Gravar(provedor, new Registro(AbertoAte: null), JanelaDeContagem, ct);
+    }
+
+    /// <summary>
+    /// Os provedores que o router deve descartar agora.
+    ///
+    /// Existe porque o <c>RoteadorDeModelo</c> e regra de dominio e recebe uma
+    /// funcao SINCRONA: quem vai chamar o modelo carrega este retrato — uma
+    /// leitura por provedor da tabela — e entrega ao router. O router decide;
+    /// ele nao consulta infraestrutura.
+    /// </summary>
+    public async Task<IReadOnlySet<string>> Indisponiveis(
+        IEnumerable<string> provedores, CancellationToken ct)
+    {
+        var fora = new HashSet<string>();
+        foreach (var provedor in provedores.Distinct())
+            if (await Estado(provedor, ct) == EstadoDoCircuito.Aberto)
+                fora.Add(provedor);
+
+        return fora;
+    }
+
+    private async Task<Registro?> Registrado(string provedor, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(provedor))
+            throw new ArgumentException(
+                "Circuito sem provedor: a unidade do breaker e o provedor, e uma "
+                + "chave comum derrubaria todos juntos quando um caisse.",
+                nameof(provedor));
+
+        var cru = await _estado.Ler(Chave(provedor), ct);
+        return cru is null ? null : JsonSerializer.Deserialize<Registro>(cru, Json);
+    }
+
+    private Task Gravar(string provedor, Registro registro, TimeSpan validade, CancellationToken ct) =>
+        _estado.Gravar(Chave(provedor), JsonSerializer.Serialize(registro, Json), validade, ct);
+
+    private static string Chave(string provedor) => $"breaker:{provedor.Trim()}";
+    private static string Contador(string provedor) => $"breaker:{provedor.Trim()}:falhas";
+    private static string Sonda(string provedor) => $"breaker:{provedor.Trim()}:sonda";
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -25,6 +25,11 @@ builder.Services.AddSingleton(_ => new RoteadorDeModelo(
 builder.Services.AddSingleton(_ => Backends.Fila<MensagemRecebida>(builder.Configuration));
 builder.Services.AddSingleton(_ => Backends.Estado(builder.Configuration));
 
+// O circuito por provedor tambem vive no estado compartilhado (#68): com estado
+// local, tres replicas sao tres circuitos e o provedor caido leva 3N chamadas.
+builder.Services.AddSingleton(sp => new CircuitoDoProvedor(
+    sp.GetRequiredService<IDistributedState>()));
+
 // Rate limit e cache de analise dividem o mesmo estado compartilhado (#71): com
 // contador local, o limite viraria limite vezes o numero de replicas.
 builder.Services.AddSingleton(sp => new LimitadorDeTaxa(

--- a/testes/Copiloto.Testes/CircuitoCompartilhadoTeste.cs
+++ b/testes/Copiloto.Testes/CircuitoCompartilhadoTeste.cs
@@ -1,0 +1,226 @@
+using Copiloto.Api.Ia;
+using Copiloto.Api.Infra;
+using Copiloto.Dominio.Ia;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O circuito valendo para todas as instancias (#68).
+///
+/// Com estado em memoria e tres replicas existem tres circuitos independentes:
+/// um provedor fora do ar leva 3N requisicoes em vez de N, e cada uma e tempo
+/// de espera na frente do vendedor.
+/// </summary>
+public class CircuitoCompartilhadoTeste
+{
+    private const string Provedor = "openai";
+    private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
+
+    private static async Task Derrubar(CircuitoDoProvedor circuito)
+    {
+        for (var i = 0; i < CircuitoDoProvedor.FalhasQueAbrem; i++)
+            await circuito.RegistrarFalha(Provedor, default);
+    }
+
+    [Fact]
+    public async Task Circuito_comeca_fechado()
+    {
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+
+        Assert.Equal(EstadoDoCircuito.Fechado, await circuito.Estado(Provedor, default));
+        Assert.True(await circuito.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Falhas_abaixo_do_limiar_nao_abrem()
+    {
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+
+        await circuito.RegistrarFalha(Provedor, default);
+        await circuito.RegistrarFalha(Provedor, default);
+
+        Assert.True(await circuito.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task A_instancia_que_abre_protege_as_demais_na_hora()
+    {
+        // O criterio da issue: sem estado compartilhado, a instancia B ainda
+        // teria de falhar tres vezes por conta propria.
+        var compartilhado = new InMemoryState();
+        var instanciaA = new CircuitoDoProvedor(compartilhado);
+        var instanciaB = new CircuitoDoProvedor(compartilhado);
+
+        await Derrubar(instanciaA);
+
+        Assert.Equal(EstadoDoCircuito.Aberto, await instanciaB.Estado(Provedor, default));
+        Assert.False(await instanciaB.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Com_estado_por_processo_cada_instancia_apanha_sozinha()
+    {
+        // Documenta o bug que a issue fecha: se alguem trocar o estado
+        // compartilhado por um local, este teste passa a ser a realidade.
+        var instanciaA = new CircuitoDoProvedor(new InMemoryState());
+        var instanciaB = new CircuitoDoProvedor(new InMemoryState());
+
+        await Derrubar(instanciaA);
+
+        Assert.True(await instanciaB.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Um_provedor_caido_nao_derruba_o_outro()
+    {
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+
+        await Derrubar(circuito);
+
+        Assert.True(await circuito.PodeChamar("anthropic", default));
+    }
+
+    [Fact]
+    public async Task Passada_a_espera_o_circuito_fica_meio_aberto()
+    {
+        var agora = T0;
+        var circuito = new CircuitoDoProvedor(new InMemoryState(() => agora), () => agora);
+        await Derrubar(circuito);
+
+        agora += CircuitoDoProvedor.EsperaAntesDeTestar + TimeSpan.FromSeconds(1);
+
+        Assert.Equal(EstadoDoCircuito.MeioAberto, await circuito.Estado(Provedor, default));
+    }
+
+    [Fact]
+    public async Task No_meio_aberto_so_UMA_instancia_faz_a_requisicao_de_teste()
+    {
+        // O detalhe que separa quem implementou de quem leu sobre: se todas
+        // testarem juntas, o teste vira a avalanche que o breaker evita.
+        var agora = T0;
+        var compartilhado = new InMemoryState(() => agora);
+        var instancias = Enumerable.Range(0, 10)
+            .Select(_ => new CircuitoDoProvedor(compartilhado, () => agora)).ToList();
+
+        await Derrubar(instancias[0]);
+        agora += CircuitoDoProvedor.EsperaAntesDeTestar + TimeSpan.FromSeconds(1);
+
+        var podem = await Task.WhenAll(instancias.Select(i => i.PodeChamar(Provedor, default)));
+
+        Assert.Single(podem, pode => pode);
+    }
+
+    [Fact]
+    public async Task Sonda_que_da_certo_libera_todo_mundo()
+    {
+        var agora = T0;
+        var compartilhado = new InMemoryState(() => agora);
+        var sonda = new CircuitoDoProvedor(compartilhado, () => agora);
+        var outra = new CircuitoDoProvedor(compartilhado, () => agora);
+        await Derrubar(sonda);
+        agora += CircuitoDoProvedor.EsperaAntesDeTestar + TimeSpan.FromSeconds(1);
+
+        Assert.True(await sonda.PodeChamar(Provedor, default));
+        await sonda.RegistrarSucesso(Provedor, default);
+
+        Assert.Equal(EstadoDoCircuito.Fechado, await outra.Estado(Provedor, default));
+        Assert.True(await outra.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Sonda_que_falha_fecha_a_porta_de_novo()
+    {
+        var agora = T0;
+        var compartilhado = new InMemoryState(() => agora);
+        var sonda = new CircuitoDoProvedor(compartilhado, () => agora);
+        var outra = new CircuitoDoProvedor(compartilhado, () => agora);
+        await Derrubar(sonda);
+        agora += CircuitoDoProvedor.EsperaAntesDeTestar + TimeSpan.FromSeconds(1);
+
+        await sonda.PodeChamar(Provedor, default);
+        await sonda.RegistrarFalha(Provedor, default);
+
+        Assert.Equal(EstadoDoCircuito.Aberto, await outra.Estado(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Sucesso_zera_a_contagem_de_falhas()
+    {
+        // Sem zerar, tres falhas espalhadas com sucessos no meio abririam o
+        // circuito de um provedor saudavel — e o sintoma seria "as vezes o
+        // sistema escolhe o modelo caro".
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+
+        await circuito.RegistrarFalha(Provedor, default);
+        await circuito.RegistrarFalha(Provedor, default);
+        await circuito.RegistrarSucesso(Provedor, default);
+        await circuito.RegistrarFalha(Provedor, default);
+
+        Assert.True(await circuito.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Falha_velha_nao_conta_para_abrir_hoje()
+    {
+        var agora = T0;
+        var circuito = new CircuitoDoProvedor(new InMemoryState(() => agora), () => agora);
+
+        await circuito.RegistrarFalha(Provedor, default);
+        await circuito.RegistrarFalha(Provedor, default);
+
+        agora += CircuitoDoProvedor.JanelaDeContagem + TimeSpan.FromSeconds(1);
+        await circuito.RegistrarFalha(Provedor, default);
+
+        Assert.True(await circuito.PodeChamar(Provedor, default));
+    }
+
+    [Fact]
+    public async Task Provedor_vazio_e_erro_e_nao_circuito_comum()
+    {
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+
+        await Assert.ThrowsAsync<ArgumentException>(() => circuito.Estado("  ", default));
+    }
+
+    // --- O encontro com o router (#29) ---
+
+    [Fact]
+    public async Task O_router_descarta_o_provedor_com_circuito_aberto()
+    {
+        // O router recebe o retrato pronto: ele decide, nao consulta
+        // infraestrutura.
+        var compartilhado = new InMemoryState();
+        var circuito = new CircuitoDoProvedor(compartilhado);
+        await Derrubar(circuito);
+
+        var tabela = new[]
+        {
+            new ModeloDisponivel("barato", Provedor, 0.5m, 400, [Tarefa.Triagem]),
+            new ModeloDisponivel("caro", "anthropic", 4m, 900, [Tarefa.Triagem]),
+        };
+
+        var fora = await circuito.Indisponiveis(tabela.Select(m => m.Provedor), default);
+        var decisao = new RoteadorDeModelo(tabela, p => fora.Contains(p)).Escolher(Tarefa.Triagem);
+
+        Assert.NotNull(decisao);
+        Assert.Equal("caro", decisao!.Modelo);
+        Assert.Contains(decisao.Descartados, d => d.Contains("circuito aberto"));
+    }
+
+    [Fact]
+    public async Task Com_todos_de_pe_o_router_nao_muda_de_ideia()
+    {
+        var circuito = new CircuitoDoProvedor(new InMemoryState());
+        var tabela = new[]
+        {
+            new ModeloDisponivel("barato", Provedor, 0.5m, 400, [Tarefa.Triagem]),
+            new ModeloDisponivel("caro", "anthropic", 4m, 900, [Tarefa.Triagem]),
+        };
+
+        var fora = await circuito.Indisponiveis(tabela.Select(m => m.Provedor), default);
+
+        Assert.Empty(fora);
+        Assert.Equal("barato",
+            new RoteadorDeModelo(tabela, p => fora.Contains(p)).Escolher(Tarefa.Triagem)!.Modelo);
+    }
+}


### PR DESCRIPTION
**Base:** sai de `71-limite-e-cache` (#71).

## O que muda
Um circuito por provedor, valendo para todas as instancias.

## Decisoes (o meio-aberto decidiu o desenho)
- A chave vive MAIS que a espera: se expirasse junto, o estado voltaria a fechado para todos ao mesmo tempo e a avalanche aconteceria por expiracao de chave.
- A sonda e DISPUTADA: quem marca primeiro testa; a reserva e curta para a instancia que morrer nao prender o circuito.
- Contador com janela e sucesso zerando: sem isso, tres falhas espalhadas abririam o circuito de um provedor de pe.

Closes #68