### PR TITLE
Health check por dependencia e degradacao

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -407,6 +407,28 @@ A suíte é escrita contra o **contrato**, parametrizada pela implementação: `
 que impede a segunda implementação de nascer com garantias mais fracas que a primeira sem
 ninguém notar.
 
+### 12.35 Quando a infraestrutura cai (#72)
+
+`/saude` reporta **cada dependência separadamente** — Postgres, fila e estado
+compartilhado, com o motivo da falha junto. Health check que responde só verde ou vermelho
+manda o plantonista procurar do zero.
+
+**Estado compartilhado fora degrada; não derruba.** O vendedor não pode perder o
+atendimento inteiro por causa de um cache. Mas cair para memória em silêncio esconderia
+que idempotência, rate limit e circuito passaram a valer só naquela instância — então o
+decorator **grita enquanto estiver degradado**, e o risco aparece no `/saude` com essa
+frase. Falha silenciosa aqui reaparece semanas depois como fatura maior, sem ninguém ligar
+uma coisa à outra. A reconexão é automática, mas espaçada: tentar o primário a cada chamada
+transformaria toda operação numa espera de timeout, e o remédio ficaria mais caro que a
+doença. O que foi gravado na memória durante a queda **não é promovido** de volta — são
+chaves de validade curta, e reidratar idempotência vencida reintroduziria decisões que já
+expiraram.
+
+**Fila fora é essencial, e aqui está o ponto contraintuitivo:** com a fila fora, *recusar*
+a mensagem é melhor que aceitar. O webhook devolve 503, que provoca reentrega; aceitar com
+202 e perder é exatamente a falha silenciosa que a fila durável existe para eliminar — o
+WhatsApp reentrega o que deu erro, e não reentrega o que ele acha que entregou.
+
 ### 12.4 Redis também é backplane do SignalR
 
 Com mais de uma instância, o vendedor conectado à instância A não recebe o evento

--- a/src/Copiloto.Api/Infra/ChannelQueue.cs
+++ b/src/Copiloto.Api/Infra/ChannelQueue.cs
@@ -38,6 +38,15 @@ public class ChannelQueue<T> : IQueue<T>
     public int Aguardando => _canal.Reader.Count;
 
     /// <summary>
+    /// Em memoria a fila so para de aceitar no desligamento. Um broker
+    /// responderia pela conexao, e e por isso que isto e do contrato e nao um
+    /// detalhe do Channel.
+    /// </summary>
+    public bool Aceitando => !_fechada;
+
+    private bool _fechada;
+
+    /// <summary>
     /// Enfileira. Devolve false quando a fila esta cheia e a espera estourou o
     /// tempo — o chamador decide o que dizer ao provedor.
     /// </summary>
@@ -66,5 +75,9 @@ public class ChannelQueue<T> : IQueue<T>
     /// Fecha para escrita. O consumidor continua lendo o que ficou — e' o que
     /// faz o desligamento DRENAR em vez de descartar.
     /// </summary>
-    public void PararDeAceitar() => _canal.Writer.TryComplete();
+    public void PararDeAceitar()
+    {
+        _fechada = true;
+        _canal.Writer.TryComplete();
+    }
 }

--- a/src/Copiloto.Api/Infra/EstadoComDegradacao.cs
+++ b/src/Copiloto.Api/Infra/EstadoComDegradacao.cs
@@ -1,0 +1,119 @@
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// Usa o estado distribuido enquanto ele responde, e cai para a memoria quando
+/// ele para — registrando o risco (#72).
+///
+/// Redis fora do ar NAO pode derrubar a aplicacao: o vendedor perde o
+/// atendimento inteiro por causa de um cache. Mas cair para memoria em silencio
+/// tambem nao serve, porque enquanto isso durar a idempotencia vale so por
+/// instancia (#67), o rate limit se multiplica pelas replicas (#71) e o
+/// circuito de cada uma volta a ser o seu (#68).
+///
+/// As duas coisas juntas sao a decisao: degrada, e GRITA enquanto estiver
+/// degradado. Falha silenciosa aqui aparece semanas depois como fatura maior,
+/// e ninguem liga uma coisa a outra.
+/// </summary>
+public class EstadoComDegradacao : IDistributedState
+{
+    /// <summary>
+    /// Quanto tempo esperar antes de tentar o primario de novo.
+    ///
+    /// Tentar a cada chamada transformaria cada operacao em uma espera de
+    /// timeout — o remedio ficaria mais caro que a doenca. Tentar de vez em
+    /// quando e o que faz a reconexao ser automatica sem ser cara.
+    /// </summary>
+    public static readonly TimeSpan EsperaParaTentarDeNovo = TimeSpan.FromSeconds(30);
+
+    private readonly IDistributedState _primario;
+    private readonly IDistributedState _reserva;
+    private readonly ILogger<EstadoComDegradacao> _log;
+    private readonly Func<DateTimeOffset> _agora;
+
+    private DateTimeOffset? _degradadoDesde;
+    private DateTimeOffset _proximaTentativa = DateTimeOffset.MinValue;
+
+    public EstadoComDegradacao(
+        IDistributedState primario, ILogger<EstadoComDegradacao> log,
+        IDistributedState? reserva = null, Func<DateTimeOffset>? agora = null)
+    {
+        ArgumentNullException.ThrowIfNull(primario);
+
+        _primario = primario;
+        _reserva = reserva ?? new InMemoryState();
+        _log = log;
+        _agora = agora ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>Esta rodando na reserva agora?</summary>
+    public bool Degradado => _degradadoDesde is not null;
+
+    public DateTimeOffset? DegradadoDesde => _degradadoDesde;
+
+    /// <summary>O que o `/saude` mostra, e o que o log repete enquanto durar.</summary>
+    public string RiscoAtual => Degradado
+        ? "estado compartilhado indisponivel: idempotencia, rate limit e circuito "
+          + "valem apenas nesta instancia. Com mais de uma replica, mensagem "
+          + "reprocessada, limite multiplicado e provedor caido golpeado por cada uma."
+        : "";
+
+    public Task<bool> TentarMarcar(string chave, TimeSpan validade, CancellationToken ct) =>
+        Tentar(e => e.TentarMarcar(chave, validade, ct));
+
+    public Task<string?> Ler(string chave, CancellationToken ct) =>
+        Tentar(e => e.Ler(chave, ct));
+
+    public Task Gravar(string chave, string valor, TimeSpan validade, CancellationToken ct) =>
+        Tentar<object?>(async e =>
+        {
+            await e.Gravar(chave, valor, validade, ct);
+            return null;
+        });
+
+    public Task<long> Incrementar(string chave, TimeSpan janela, CancellationToken ct) =>
+        Tentar(e => e.Incrementar(chave, janela, ct));
+
+    private async Task<T> Tentar<T>(Func<IDistributedState, Task<T>> operacao)
+    {
+        if (Degradado && _agora() < _proximaTentativa)
+            return await operacao(_reserva);
+
+        try
+        {
+            var resultado = await operacao(_primario);
+            if (Degradado) Recuperou();
+
+            return resultado;
+        }
+        catch (Exception erro)
+        {
+            Degradou(erro);
+            return await operacao(_reserva);
+        }
+    }
+
+    private void Degradou(Exception erro)
+    {
+        _proximaTentativa = _agora() + EsperaParaTentarDeNovo;
+
+        if (Degradado) return;   // ja avisado; nao repetir a cada chamada
+
+        _degradadoDesde = _agora();
+        _log.LogError(erro, "Estado compartilhado caiu; usando memoria. RISCO: {Risco}", RiscoAtual);
+    }
+
+    private void Recuperou()
+    {
+        // O que foi escrito na reserva durante a queda NAO e copiado de volta,
+        // e isso e deliberado: sao chaves com validade curta, e reidratar
+        // idempotencia velha reintroduziria decisoes que ja venceram. O sistema
+        // volta ao normal com a memoria compartilhada limpa, que e o estado
+        // conservador.
+        _log.LogWarning(
+            "Estado compartilhado voltou depois de {Tempo}. O que foi gravado durante a "
+            + "queda ficou na memoria da instancia e nao foi promovido.",
+            _agora() - _degradadoDesde);
+
+        _degradadoDesde = null;
+    }
+}

--- a/src/Copiloto.Api/Infra/IQueue.cs
+++ b/src/Copiloto.Api/Infra/IQueue.cs
@@ -18,6 +18,16 @@ public interface IQueue<T>
     int Aguardando { get; }
 
     /// <summary>
+    /// A fila esta aceitando trabalho agora?
+    ///
+    /// Existe para o `/saude` e para o webhook, e a resposta importa mais do
+    /// que parece: com a fila fora, RECUSAR a mensagem e melhor que aceitar.
+    /// Aceitar com 202 e perder e a falha silenciosa que a fila duravel existe
+    /// para eliminar — e o WhatsApp reentrega o que deu erro (#72).
+    /// </summary>
+    bool Aceitando { get; }
+
+    /// <summary>
     /// Enfileira. Devolve false quando nao deu — fila cheia com espera
     /// estourada, ou desligamento em andamento. Quem chama decide o que
     /// responder ao provedor: o webhook responde 503 para o WhatsApp

--- a/src/Copiloto.Api/Infra/Saude.cs
+++ b/src/Copiloto.Api/Infra/Saude.cs
@@ -1,0 +1,105 @@
+using Copiloto.Api.Persistencia;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Api.Infra;
+
+/// <summary>Como uma dependencia esta agora.</summary>
+public record EstadoDaDependencia(string Nome, bool Ok, string Detalhe, bool Essencial);
+
+/// <summary>
+/// O retrato das dependencias (#72).
+///
+/// Cada uma reportada SEPARADAMENTE, e nao um "ok" agregado: health check que
+/// responde so verde ou vermelho manda o plantonista procurar do zero. O que
+/// ele precisa saber e qual peca caiu.
+/// </summary>
+public record RelatorioDeSaude(IReadOnlyList<EstadoDaDependencia> Dependencias)
+{
+    /// <summary>
+    /// A aplicacao esta apta a receber trafego?
+    ///
+    /// So o que e ESSENCIAL derruba: banco fora e fila fora impedem atender.
+    /// Estado compartilhado fora degrada — a aplicacao continua util, com
+    /// garantias menores, e devolver 503 nesse caso tiraria do ar um sistema
+    /// que ainda atende.
+    /// </summary>
+    public bool Apta => Dependencias.Where(d => d.Essencial).All(d => d.Ok);
+
+    /// <summary>Alguma coisa esta pior do que deveria, mesmo que apta.</summary>
+    public bool Degradada => Dependencias.Any(d => !d.Ok);
+}
+
+/// <summary>Monta o relatorio consultando cada dependencia de verdade.</summary>
+public class Saude
+{
+    private readonly CopilotoDbContext _ctx;
+    private readonly IQueue<Ingestao.MensagemRecebida> _fila;
+    private readonly IDistributedState _estado;
+    private readonly string _backendDeEstado;
+    private readonly string _backendDeFila;
+
+    public Saude(
+        CopilotoDbContext ctx,
+        IQueue<Ingestao.MensagemRecebida> fila,
+        IDistributedState estado,
+        IConfiguration configuracao)
+    {
+        _ctx = ctx;
+        _fila = fila;
+        _estado = estado;
+        _backendDeEstado = configuracao["STATE_BACKEND"] ?? Backends.Padrao;
+        _backendDeFila = configuracao["QUEUE_BACKEND"] ?? Backends.Padrao;
+    }
+
+    public async Task<RelatorioDeSaude> Agora(CancellationToken ct)
+    {
+        return new RelatorioDeSaude(
+        [
+            await Postgres(ct),
+            Fila(),
+            Estado(),
+        ]);
+    }
+
+    private async Task<EstadoDaDependencia> Postgres(CancellationToken ct)
+    {
+        try
+        {
+            var conecta = await _ctx.Database.CanConnectAsync(ct);
+            return new EstadoDaDependencia("postgres", conecta,
+                conecta ? "conectado" : "sem conexao", Essencial: true);
+        }
+        catch (Exception erro)
+        {
+            // A mensagem do provedor entra no detalhe, e nao so "falhou": e a
+            // diferenca entre o plantonista saber que e senha errada e ficar
+            // adivinhando.
+            return new EstadoDaDependencia("postgres", false, erro.Message, Essencial: true);
+        }
+    }
+
+    /// <summary>
+    /// Fila fora e ESSENCIAL, e este e o ponto contraintuitivo da issue: com a
+    /// fila fora, recusar a mensagem e melhor que aceitar. Aceitar e perder e a
+    /// falha silenciosa que a fila existe para eliminar — o WhatsApp reentrega
+    /// o que deu erro, e nao reentrega o que recebeu 202.
+    /// </summary>
+    private EstadoDaDependencia Fila() =>
+        new("fila", _fila.Aceitando,
+            _fila.Aceitando
+                ? $"{_backendDeFila}, {_fila.Aguardando} aguardando"
+                : $"{_backendDeFila}, nao aceita trabalho novo",
+            Essencial: true);
+
+    private EstadoDaDependencia Estado()
+    {
+        if (_estado is not EstadoComDegradacao comDegradacao)
+            return new EstadoDaDependencia("estado", true, _backendDeEstado, Essencial: false);
+
+        return new EstadoDaDependencia("estado", !comDegradacao.Degradado,
+            comDegradacao.Degradado
+                ? $"degradado desde {comDegradacao.DegradadoDesde:O} — {comDegradacao.RiscoAtual}"
+                : _backendDeEstado,
+            Essencial: false);
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -22,8 +22,14 @@ builder.Services.AddSingleton(_ => new RoteadorDeModelo(
 
 // Estado e fila vem da variavel de ambiente, com `inmemory` como padrao (#66).
 // Sem .env, sem Redis e sem RabbitMQ, a aplicacao sobe inteira.
-builder.Services.AddSingleton(_ => Backends.Fila<MensagemRecebida>(builder.Configuration));
-builder.Services.AddSingleton(_ => Backends.Estado(builder.Configuration));
+builder.Services.AddSingleton<IQueue<MensagemRecebida>>(
+    _ => Backends.Fila<MensagemRecebida>(builder.Configuration));
+// O estado distribuido entra embrulhado na degradacao (#72): Redis fora nao
+// pode derrubar o atendimento, mas cair para memoria em silencio esconderia que
+// idempotencia, rate limit e circuito passaram a valer so nesta instancia.
+builder.Services.AddSingleton<IDistributedState>(sp => new EstadoComDegradacao(
+    Backends.Estado(builder.Configuration),
+    sp.GetRequiredService<ILogger<EstadoComDegradacao>>()));
 
 // O circuito por provedor tambem vive no estado compartilhado (#68): com estado
 // local, tres replicas sao tres circuitos e o provedor caido leva 3N chamadas.
@@ -57,9 +63,25 @@ builder.Services.AddSingleton(_ => new ResolvedorDeLead(
     builder.Configuration["WHATSAPP_NUMERO_EMPRESA"] ?? "+55 11 3333-4444"));
 builder.Services.AddHostedService<ProcessadorDeMensagens>();
 
+builder.Services.AddScoped<Saude>();
+
 var app = builder.Build();
 
-app.MapGet("/saude", () => Results.Ok(new { ok = true }));
+// Cada dependencia separada, e nao um "ok" agregado: health check que responde
+// so verde ou vermelho manda o plantonista procurar do zero (#72).
+app.MapGet("/saude", async (Saude saude, CancellationToken ct) =>
+{
+    var relatorio = await saude.Agora(ct);
+
+    // 503 so quando o ESSENCIAL cai. Estado compartilhado fora degrada, e tirar
+    // do ar um sistema que ainda atende seria transformar perda de garantia em
+    // perda de atendimento.
+    return relatorio.Apta
+        ? Results.Ok(new { ok = true, degradada = relatorio.Degradada, relatorio.Dependencias })
+        : Results.Json(
+            new { ok = false, degradada = true, relatorio.Dependencias },
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+});
 
 // O webhook responde na hora e nao processa nada (#40). O 202 e' deliberado: 200
 // diria "processado", e o que aconteceu foi "recebido e enfileirado".

--- a/testes/Copiloto.Testes/SaudeEDegradacaoTeste.cs
+++ b/testes/Copiloto.Testes/SaudeEDegradacaoTeste.cs
@@ -1,0 +1,235 @@
+using Copiloto.Api.Infra;
+using Copiloto.Api.Ingestao;
+using Copiloto.Api.Persistencia;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O que acontece quando a infraestrutura cai (#72).
+///
+/// O criterio mais contraintuitivo da issue: com a fila fora, RECUSAR a
+/// mensagem e melhor que aceitar. Aceitar e perder e a falha silenciosa que a
+/// fila duravel existe para eliminar — o WhatsApp reentrega o que deu erro, e
+/// nao reentrega o que recebeu 202.
+/// </summary>
+public class SaudeEDegradacaoTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public SaudeEDegradacaoTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    /// <summary>Um estado que cai quando mandam cair.</summary>
+    private class EstadoQueCai : IDistributedState
+    {
+        public bool NoChao { get; set; }
+        public int Chamadas { get; private set; }
+
+        private readonly InMemoryState _real = new();
+
+        private T Talvez<T>(Func<InMemoryState, T> operacao)
+        {
+            Chamadas++;
+            if (NoChao) throw new InvalidOperationException("conexao recusada");
+
+            return operacao(_real);
+        }
+
+        public Task<bool> TentarMarcar(string c, TimeSpan v, CancellationToken ct) =>
+            Talvez(e => e.TentarMarcar(c, v, ct));
+        public Task<string?> Ler(string c, CancellationToken ct) => Talvez(e => e.Ler(c, ct));
+        public Task Gravar(string c, string v, TimeSpan t, CancellationToken ct) =>
+            Talvez(e => e.Gravar(c, v, t, ct));
+        public Task<long> Incrementar(string c, TimeSpan j, CancellationToken ct) =>
+            Talvez(e => e.Incrementar(c, j, ct));
+    }
+
+    private static IConfiguration Config() => new ConfigurationBuilder().Build();
+
+    // --- Degradacao do estado ---
+
+    [Fact]
+    public async Task Estado_fora_do_ar_nao_derruba_a_aplicacao()
+    {
+        // O vendedor nao pode perder o atendimento inteiro por causa de um cache.
+        var primario = new EstadoQueCai { NoChao = true };
+        var estado = new EstadoComDegradacao(primario, NullLogger<EstadoComDegradacao>.Instance);
+
+        Assert.True(await estado.TentarMarcar("k", TimeSpan.FromMinutes(1), default));
+        Assert.True(estado.Degradado);
+    }
+
+    [Fact]
+    public async Task Enquanto_degradado_o_risco_fica_dito_e_nao_implicito()
+    {
+        // Cair para memoria em silencio esconde que idempotencia, rate limit e
+        // circuito passaram a valer so nesta instancia — e isso reaparece
+        // semanas depois como fatura maior, sem ninguem ligar uma coisa a outra.
+        var estado = new EstadoComDegradacao(
+            new EstadoQueCai { NoChao = true }, NullLogger<EstadoComDegradacao>.Instance);
+        await estado.Ler("k", default);
+
+        Assert.Contains("idempotencia", estado.RiscoAtual);
+        Assert.Contains("apenas nesta instancia", estado.RiscoAtual);
+    }
+
+    [Fact]
+    public async Task A_reserva_atende_de_verdade_e_nao_so_engole_a_chamada()
+    {
+        var estado = new EstadoComDegradacao(
+            new EstadoQueCai { NoChao = true }, NullLogger<EstadoComDegradacao>.Instance);
+
+        await estado.Gravar("k", "v", TimeSpan.FromMinutes(5), default);
+
+        Assert.Equal("v", await estado.Ler("k", default));
+    }
+
+    [Fact]
+    public async Task Degradado_nao_martela_o_primario_a_cada_chamada()
+    {
+        // Tentar a cada chamada transformaria cada operacao numa espera de
+        // timeout: o remedio ficaria mais caro que a doenca.
+        var agora = T0;
+        var primario = new EstadoQueCai { NoChao = true };
+        var estado = new EstadoComDegradacao(
+            primario, NullLogger<EstadoComDegradacao>.Instance, agora: () => agora);
+
+        await estado.Ler("k", default);
+        var depoisDaPrimeira = primario.Chamadas;
+
+        for (var i = 0; i < 10; i++) await estado.Ler("k", default);
+
+        Assert.Equal(depoisDaPrimeira, primario.Chamadas);
+    }
+
+    [Fact]
+    public async Task Passada_a_espera_ele_tenta_de_novo_e_volta_sozinho()
+    {
+        var agora = T0;
+        var primario = new EstadoQueCai { NoChao = true };
+        var estado = new EstadoComDegradacao(
+            primario, NullLogger<EstadoComDegradacao>.Instance, agora: () => agora);
+        await estado.Ler("k", default);
+
+        primario.NoChao = false;
+        agora += EstadoComDegradacao.EsperaParaTentarDeNovo + TimeSpan.FromSeconds(1);
+
+        await estado.Ler("k", default);
+
+        Assert.False(estado.Degradado);
+        Assert.Equal("", estado.RiscoAtual);
+    }
+
+    [Fact]
+    public async Task Com_o_primario_de_pe_a_reserva_nem_e_tocada()
+    {
+        var primario = new EstadoQueCai();
+        var estado = new EstadoComDegradacao(primario, NullLogger<EstadoComDegradacao>.Instance);
+
+        await estado.Gravar("k", "v", TimeSpan.FromMinutes(1), default);
+
+        Assert.False(estado.Degradado);
+        Assert.Equal(1, primario.Chamadas);
+    }
+
+    // --- O relatorio ---
+
+    [Fact]
+    public async Task O_relatorio_separa_cada_dependencia()
+    {
+        // Health check que responde so verde ou vermelho manda o plantonista
+        // procurar do zero.
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var saude = new Saude(ctx, new ChannelQueue<MensagemRecebida>(), new InMemoryState(), Config());
+
+        var relatorio = await saude.Agora(default);
+
+        Assert.Equal(3, relatorio.Dependencias.Count);
+        Assert.Contains(relatorio.Dependencias, d => d.Nome == "postgres");
+        Assert.Contains(relatorio.Dependencias, d => d.Nome == "fila");
+        Assert.Contains(relatorio.Dependencias, d => d.Nome == "estado");
+        Assert.True(relatorio.Apta);
+        Assert.False(relatorio.Degradada);
+    }
+
+    [Fact]
+    public async Task Fila_que_parou_de_aceitar_derruba_a_aptidao()
+    {
+        // O criterio contraintuitivo: melhor recusar e deixar o WhatsApp
+        // reentregar do que aceitar e perder.
+        var fila = new ChannelQueue<MensagemRecebida>();
+        fila.PararDeAceitar();
+
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var relatorio = await new Saude(ctx, fila, new InMemoryState(), Config()).Agora(default);
+
+        Assert.False(relatorio.Apta);
+        Assert.Contains(relatorio.Dependencias, d => d.Nome == "fila" && !d.Ok);
+    }
+
+    [Fact]
+    public async Task Estado_degradado_aparece_no_relatorio_sem_derrubar_a_aptidao()
+    {
+        // Perda de garantia nao pode virar perda de atendimento: 503 aqui
+        // tiraria do ar um sistema que ainda atende.
+        var estado = new EstadoComDegradacao(
+            new EstadoQueCai { NoChao = true }, NullLogger<EstadoComDegradacao>.Instance);
+        await estado.Ler("k", default);
+
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var relatorio = await new Saude(
+            ctx, new ChannelQueue<MensagemRecebida>(), estado, Config()).Agora(default);
+
+        Assert.True(relatorio.Apta);
+        Assert.True(relatorio.Degradada);
+        Assert.Contains(relatorio.Dependencias,
+            d => d.Nome == "estado" && !d.Ok && d.Detalhe.Contains("degradado"));
+    }
+
+    [Fact]
+    public async Task Banco_fora_aparece_com_o_motivo_e_nao_so_com_falhou()
+    {
+        // A diferenca entre o plantonista saber que e senha errada e ficar
+        // adivinhando.
+        var ctx = new CopilotoDbContext(
+            new DbContextOptionsBuilder<CopilotoDbContext>()
+                .UseNpgsql("Host=nao-existe-mesmo.invalid;Database=x;Username=y;Timeout=1")
+                .Options);
+
+        var relatorio = await new Saude(
+            ctx, new ChannelQueue<MensagemRecebida>(), new InMemoryState(), Config()).Agora(default);
+
+        var postgres = relatorio.Dependencias.Single(d => d.Nome == "postgres");
+        Assert.False(postgres.Ok);
+        Assert.False(relatorio.Apta);
+        Assert.NotEmpty(postgres.Detalhe);
+    }
+
+    [Fact]
+    public async Task A_fila_de_pe_informa_quantos_esperam()
+    {
+        var fila = new ChannelQueue<MensagemRecebida>();
+        await fila.Publicar(
+            new MensagemRecebida("wamid.1", "+5511988887777", "+5511333334444", "oi", T0), default);
+
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var relatorio = await new Saude(ctx, fila, new InMemoryState(), Config()).Agora(default);
+
+        Assert.Contains("1 aguardando", relatorio.Dependencias.Single(d => d.Nome == "fila").Detalhe);
+    }
+}


### PR DESCRIPTION
**Base:** sai de `68-circuito-compartilhado` (#68).

## O que muda
`/saude` reporta Postgres, fila e estado separadamente, com motivo. Estado fora degrada para memoria e registra o risco.

## Decisoes
- Estado fora NAO derruba a aptidao; fila fora derruba. Perda de garantia nao pode virar perda de atendimento, mas aceitar mensagem com a fila fora e a falha silenciosa que a fila existe para eliminar.
- Reconexao espacada: tentar o primario a cada chamada transformaria toda operacao numa espera de timeout.
- O que foi gravado na memoria durante a queda nao e promovido de volta.

Closes #72