### PR TITLE
O escudo pseudonimiza, e o build passa a cobrar o termo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Isto não é um wrapper de LLM. As peças que importam:
 | **Contrato por agente** | Saída validada contra JSON Schema. Não validou, reprompt com o erro; 2 falhas, próximo modelo da cascata. |
 | **Circuit breaker** | Por provedor, com teste que abre e fecha o circuito. |
 | **Idempotência** | Webhook de WhatsApp reentrega mensagem. Sem isso, você paga duas vezes pela mesma análise. |
-| **PII Shield** | CPF, telefone e e-mail são mascarados antes de sair da rede. Teste falha se vazar. |
+| **PII Shield** | CPF, telefone e e-mail são mascarados antes de sair da rede. Teste falha se vazar. É **pseudonimização, não anonimização**: o texto mascarado continua sendo dado pessoal ([LGPD.md](docs/LGPD.md)). |
 | **Ledger + ROI** | Custo por invocação, ligado ao Deal. Responde quanto gastou **e quanto rendeu**. |
 
 ### A parte que quase ninguém faz: a conta fechada

--- a/docs/LGPD.md
+++ b/docs/LGPD.md
@@ -1,0 +1,92 @@
+# LGPD: o que é dado pessoal aqui, e o que decorre disso
+
+Este documento existe por causa de **uma confusão específica** (#83), e ela gera decisão
+errada em cascata: quem acredita ter anonimizado conclui que pode reter para sempre,
+indexar à vontade e dispensar controle de acesso — porque "não é mais dado pessoal". E é.
+
+O que **não** está decidido aqui está nomeado no fim, com a issue que decide. Documento de
+conformidade que preenche lacuna com suposição é pior que documento incompleto: ele
+parece resposta.
+
+---
+
+## 1. O PII Shield pseudonimiza. Não anonimiza.
+
+O escudo troca `João Silva, 11 98765-4321` por `[NOME_1], [TEL_1]` **mantendo o vínculo
+com o Lead** — o mapa que remonta fica do nosso lado, por construção, porque a resposta do
+modelo precisa voltar legível para o vendedor.
+
+Isso é **pseudonimização**: reversível por quem tem a tabela.
+
+> Anonimização de verdade é **irreversível**, inclusive com informação adicional. Só o
+> dado anonimizado sai do escopo da LGPD. O nosso não sai.
+
+Consequência direta, e é o ponto inteiro do documento: **texto mascarado continua sendo
+dado pessoal**, e carrega junto todas as obrigações — base legal, prazo de retenção,
+controle de acesso, direito de acesso e exclusão do titular.
+
+Chamar o escudo de anonimização não seria imprecisão de vocabulário: seria **a base legal
+errada**, escrita por engano num documento que alguém vai ler para decidir.
+
+---
+
+## 2. Onde há dado pessoal
+
+Todo item desta lista é base de dado pessoal, com os mesmos controles. A coluna de estado
+diz o que **existe hoje** — não o que se pretende.
+
+| Onde | O que tem | Estado |
+|---|---|---|
+| Postgres (`leads`, `conversas`, `fichas_cliente`) | Nome, telefone, o que o cliente disse, o que o vendedor anotou | existe |
+| Payload que sai para o provedor de IA | Conversa mascarada pelo escudo — **pseudonimizada, não anônima** | existe |
+| Log da aplicação | Mesmo mascarado, é dado pessoal: o marcador é reversível pelo mapa, e o `deal_id` ao lado identifica | existe |
+| Ficha do cliente | Inclui **dado de terceiro** (o que o vendedor ouviu falar), que tem regime próprio | existe · regime em #89 |
+| Índice de embeddings (RAG) | Trechos de conversa vetorizados | não existe · #60, #62 |
+| Ledger (`ai_invocations`) | Custo ligado ao `deal_id`, que aponta para uma pessoa | existe |
+
+**O índice do RAG é a linha que mais escapa.** Vetor não parece dado pessoal — parece
+número. Mas ele é derivado do texto, é recuperável por semelhança e aponta para o mesmo
+titular: é base de dado pessoal como qualquer outra, com o mesmo controle de acesso e o
+mesmo expurgo. Apagar o Lead sem apagar o vetor deixa o dado vivo depois de o titular
+pedir exclusão.
+
+---
+
+## 3. O que decorre, na prática
+
+- **Retenção tem prazo, e prazo tem finalidade.** "Pseudonimizado, então guardo para
+  sempre" é a conclusão errada mais comum.
+- **Expurgo em cascata.** Exclusão do titular alcança conversa, ficha, log e índice —
+  qualquer um deles sozinho mantém o dado vivo.
+- **Controle de acesso vale para a base mascarada** tanto quanto para a original.
+- **A inferência também é dado pessoal.** "Sensível a preço", "esfriando" e "provável
+  necessidade" são dado novo, criado por nós, sobre alguém que nunca nos forneceu aquilo
+  — e o titular pode acessar e contestar. Protege-se o que entrou e esquece-se o que o
+  sistema produziu.
+
+---
+
+## 4. O gate que mantém isto verdadeiro
+
+Há teste que lê `README.md` e `docs/` e **reprova o build** se a palavra "anonimização"
+aparecer descrevendo o que fazemos, em vez de dizendo o que **não** fazemos.
+
+O motivo de ser teste, e não convenção: o termo errado é confortável — é mais curto, soa
+mais forte, e ninguém revisando um PR de código vai reler o README para conferir
+vocabulário jurídico. Convenção que depende de alguém lembrar tem prazo de validade.
+
+---
+
+## 5. O que este documento NÃO decide
+
+| Assunto | Issue |
+|---|---|
+| Papéis de controlador e operador, e subcontratação | #78 |
+| Base legal por finalidade, e legítimo interesse | #77 |
+| Registro das operações de tratamento | #76 |
+| Onde o provedor de IA processa (transferência internacional) | #79 |
+| Direitos do titular além da exclusão | #81 |
+| Dado sensível em regime próprio | #82 |
+| Aviso de transparência ao titular | #80 |
+| Resposta a incidente e log de auditoria | #84 |
+| Dado de terceiro na Ficha do Cliente | #89 |

--- a/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
+++ b/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O termo certo para o que o PII Shield faz, cobrado pelo build (#83).
+///
+/// Pseudonimizacao e anonimizacao nao sao sinonimos: a primeira e reversivel
+/// por quem tem a tabela e continua sob a LGPD; a segunda e irreversivel e sai
+/// do escopo da lei. O escudo faz a primeira, porque o mapa que remonta fica do
+/// nosso lado por construcao.
+///
+/// Isto e teste e nao convencao porque o termo errado e CONFORTAVEL: e mais
+/// curto, soa mais forte, e ninguem revisando um PR de codigo vai reler o
+/// README para conferir vocabulario juridico. A confusao gera decisao errada em
+/// cascata — quem acredita ter anonimizado conclui que pode reter para sempre,
+/// indexar a vontade e dispensar controle de acesso.
+/// </summary>
+public class LinguagemDaLgpdTeste
+{
+    /// <summary>
+    /// Palavras que TRANSFORMAM a mencao em correcao, e nao em afirmacao.
+    ///
+    /// So se fala de anonimizacao aqui para dizer que NAO e isso — entao a
+    /// mencao precisa vir com negacao ou com a explicacao do que a distingue.
+    /// </summary>
+    private static readonly string[] Ressalvas =
+        ["não", "nao", "nunca", "irrevers", "sai do escopo", "≠", "acredita"];
+
+    public static TheoryData<string> Documentos => new()
+    {
+        "README.md",
+        Path.Combine("docs", "ARQUITETURA.md"),
+        Path.Combine("docs", "LGPD.md"),
+    };
+
+    [Theory]
+    [MemberData(nameof(Documentos))]
+    public void Nenhum_documento_chama_o_escudo_de_anonimizacao(string relativo)
+    {
+        var caminho = Path.Combine(RaizDoRepositorio(), relativo);
+        Assert.True(File.Exists(caminho), $"documento nao encontrado: {caminho}");
+
+        // A checagem e por PARAGRAFO, e nao por linha: markdown quebra a frase
+        // no meio, e a ressalva costuma cair na linha seguinte da que tem o
+        // termo. Por linha, o gate acusaria o proprio texto que explica a
+        // distincao — e gate que acusa o certo e desligado no mesmo dia.
+        var afirmacoes = Paragrafos(File.ReadAllLines(caminho))
+            .Where(p => p.Texto.Contains("anonimiz", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !Ressalvas.Any(r => p.Texto.Contains(r, StringComparison.OrdinalIgnoreCase)))
+            .Select(p => $"{relativo}:{p.Linha}: {p.Texto.Trim()}")
+            .ToList();
+
+        Assert.True(afirmacoes.Count == 0,
+            "Mencao a anonimizacao sem a ressalva de que NAO e o que fazemos. "
+            + "O escudo pseudonimiza: o mapa que remonta fica do nosso lado, entao o "
+            + "texto mascarado continua sendo dado pessoal sob a LGPD.\n"
+            + string.Join("\n", afirmacoes));
+    }
+
+    [Fact]
+    public void O_documento_de_LGPD_diz_que_dado_pseudonimizado_continua_sob_a_lei()
+    {
+        // A ausencia dessa frase e o modo silencioso de o documento perder o
+        // ponto: ele continuaria falando de mascaramento, sem dizer o que isso
+        // NAO resolve.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "LGPD.md"));
+
+        Assert.Contains("continua sendo\ndado pessoal", texto.Replace("**", ""),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void O_indice_do_RAG_esta_registrado_como_base_de_dado_pessoal()
+    {
+        // E a linha que mais escapa: vetor nao PARECE dado pessoal, parece
+        // numero. Apagar o Lead sem apagar o vetor deixa o dado vivo depois de
+        // o titular pedir exclusao.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "LGPD.md"));
+
+        Assert.Contains("índice de embeddings", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("base de dado pessoal", texto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void O_log_mascarado_esta_registrado_como_dado_pessoal()
+    {
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "LGPD.md"));
+
+        Assert.Contains("Log da aplicação", texto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Blocos separados por linha em branco, com a linha de inicio.</summary>
+    private static IEnumerable<(int Linha, string Texto)> Paragrafos(string[] linhas)
+    {
+        var atual = new List<string>();
+        var inicio = 1;
+
+        for (var i = 0; i < linhas.Length; i++)
+        {
+            if (string.IsNullOrWhiteSpace(linhas[i]))
+            {
+                if (atual.Count > 0) yield return (inicio, string.Join(" ", atual));
+                atual.Clear();
+                continue;
+            }
+
+            if (atual.Count == 0) inicio = i + 1;
+            atual.Add(linhas[i]);
+        }
+
+        if (atual.Count > 0) yield return (inicio, string.Join(" ", atual));
+    }
+
+    private static string RaizDoRepositorio()
+    {
+        var raiz = typeof(LinguagemDaLgpdTeste).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "RaizDoRepositorio")
+            ?.Value;
+
+        Assert.False(string.IsNullOrWhiteSpace(raiz),
+            "Metadado RaizDoRepositorio ausente — ele e escrito pelo "
+            + "Copiloto.Testes.csproj em tempo de compilacao.");
+
+        return raiz!;
+    }
+}


### PR DESCRIPTION
## O que muda
`docs/LGPD.md` com a distincao e o inventario de onde ha dado pessoal, e um gate que reprova o build quando "anonimizacao" aparece descrevendo o que fazemos.

## Decisoes
- A checagem e por PARAGRAFO, nao por linha: o markdown quebra a frase e a ressalva cai na linha seguinte. Gate que acusa o certo e desligado no mesmo dia.
- Conferido a mao que ele reprova a frase errada.
- Duas linhas do inventario sao as que escapam: o indice de embeddings (vetor nao parece dado pessoal) e o log mascarado.

Closes #83