### PR TITLE
Papeis de controlador e operador, e a cadeia de suboperadores

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Isto não é um wrapper de LLM. As peças que importam:
 | **Circuit breaker** | Por provedor, com teste que abre e fecha o circuito. |
 | **Idempotência** | Webhook de WhatsApp reentrega mensagem. Sem isso, você paga duas vezes pela mesma análise. |
 | **PII Shield** | CPF, telefone e e-mail são mascarados antes de sair da rede. Teste falha se vazar. É **pseudonimização, não anonimização**: o texto mascarado continua sendo dado pessoal ([LGPD.md](docs/LGPD.md)). |
+| **Papéis sob a LGPD** | A empresa cliente é **controladora**; o Copiloto é **operador**. Mandar conversa a um provedor de IA é subcontratar tratamento, e o controlador precisa autorizar ([LGPD.md](docs/LGPD.md#25-quem-responde-pelo-quê)). |
 | **Ledger + ROI** | Custo por invocação, ligado ao Deal. Responde quanto gastou **e quanto rendeu**. |
 
 ### A parte que quase ninguém faz: a conta fechada

--- a/docs/CONTRATO-TRATAMENTO.md
+++ b/docs/CONTRATO-TRATAMENTO.md
@@ -1,0 +1,88 @@
+# Minuta de cláusulas de tratamento de dados
+
+**Isto é uma minuta técnica, escrita por quem conhece o sistema — não é parecer
+jurídico.** Ela existe para que a conversa com o advogado comece do que o software
+realmente faz, em vez de um modelo genérico baixado da internet que descreve um produto
+que não é este. Cada cláusula abaixo tem o comportamento correspondente no código, e é por
+isso que ela pode ser cobrada.
+
+Papéis, e o porquê deles, estão em [LGPD.md](LGPD.md#25-quem-responde-pelo-quê): a empresa
+cliente é **controladora**, o Copiloto é **operador**.
+
+---
+
+## 1. Objeto e finalidade
+
+O operador trata dados pessoais **exclusivamente** para a finalidade de ler as conversas
+comerciais do controlador e produzir, para os vendedores dele, contexto sobre cada
+negociação.
+
+O operador **não** envia mensagem ao cliente final. Quem escreve é o vendedor.
+
+> Esta cláusula não é redacional: é a tese do produto, e sustenta que a única saída do
+> sistema é uma tela interna.
+
+## 2. Instruções do controlador
+
+O operador trata os dados apenas conforme as instruções documentadas do controlador, e
+comunica a ele se entender que uma instrução viola a legislação.
+
+Uso dos dados do controlador para **finalidade própria do operador** — incluindo treinar
+ou ajustar modelos, medir qualidade de produto ou compor base de exemplos — exige
+autorização específica e por escrito. Sem ela, não acontece.
+
+## 3. Confidencialidade e acesso
+
+Acesso limitado a quem precisa, com registro. O acesso vale também para o dado
+**pseudonimizado**: marcador é reversível pelo mapa que fica do lado do operador, e por
+isso texto mascarado não é dado "liberado".
+
+## 4. Segurança
+
+O operador mantém, no mínimo:
+
+- mascaramento de dado pessoal antes de qualquer saída para terceiro;
+- isolamento entre titulares no que for indexado para recuperação;
+- controle de acesso por perfil;
+- registro das operações relevantes.
+
+## 5. Suboperadores
+
+O operador **só subcontrata com autorização** do controlador, e mantém a lista atualizada
+em [LGPD.md](LGPD.md#a-cadeia-de-suboperadores), com o que cada um trata e onde processa.
+
+Enviar conversa a um provedor de modelo **é** subcontratação. A autorização precisa ser
+dada antes de a chave do provedor ser configurada — não depois do primeiro envio.
+
+## 6. Direitos do titular
+
+O titular exerce seus direitos perante o **controlador**. O operador fornece os meios
+técnicos para atendê-los — confirmação, acesso, correção, portabilidade em formato legível
+por máquina, oposição e exclusão —, incluindo **as inferências geradas pelo sistema**
+("sensível a preço", "esfriando"), que são dado pessoal criado sobre o titular.
+
+Prazo de apoio do operador ao controlador: a definir junto do prazo legal de resposta
+(#81).
+
+## 7. Incidentes
+
+O operador comunica o controlador **sem demora injustificada** ao tomar conhecimento de
+incidente com dado pessoal, com o que se sabe até então, o que ainda se investiga e as
+medidas já tomadas. Rito e prazo: #84.
+
+## 8. Término
+
+Encerrado o contrato, o operador **elimina ou devolve** os dados, à escolha do
+controlador, incluindo cópias em índice de recuperação, cache e log — guardando apenas o
+que a lei obrigue a guardar, pelo prazo em que obrigue.
+
+> Cache e índice nesta cláusula não são detalhe: são as duas cópias que costumam
+> sobreviver a um "apagamos tudo" feito só no banco principal.
+
+---
+
+## O que esta minuta não cobre
+
+Base legal por finalidade (#77), registro das operações de tratamento (#76), transferência
+internacional (#79) e o aviso de transparência ao titular (#80). Cada um tem issue própria
+— e nenhum deles cabe numa cláusula escrita por analogia.

--- a/docs/LGPD.md
+++ b/docs/LGPD.md
@@ -52,6 +52,56 @@ pedir exclusão.
 
 ---
 
+## 2.5 Quem responde pelo quê
+
+Quando uma empresa usa o Copiloto, os papéis não são negociáveis — eles decorrem de
+quem decide **finalidade e meios**:
+
+| Papel | Quem | Por quê |
+|---|---|---|
+| **Controlador** | A empresa cliente | É ela quem decide vender café por WhatsApp, quem contata, com que finalidade, e que dado pede ao cliente |
+| **Operador** | O Copiloto | Trata em nome dela, seguindo as instruções dela, e não para finalidade própria |
+| **Titulares** | Clientes da empresa, vendedores, e terceiros citados na conversa | Os três grupos, não só o primeiro |
+
+Isso decide **quem responde pelo quê** perante o titular e a ANPD, e é o que precisa
+estar no contrato antes do primeiro dado real entrar.
+
+### Obrigações do operador, que são nossas
+
+- **Seguir as instruções do controlador**, e só elas. Tratar para finalidade própria — por
+  exemplo, usar conversa de um cliente para melhorar o produto — nos tornaria controlador
+  *daquele* tratamento, com todas as obrigações que vêm junto.
+- **Segurança**, incluindo o que já é código: PII Shield, controle de acesso, isolamento
+  entre titulares no que for indexado.
+- **Apoiar o controlador nos pedidos de titular** — acesso, correção, portabilidade,
+  oposição e exclusão. O operador não responde direto ao titular; ele dá ao controlador o
+  meio de responder. É por isso que a exportação (#81) é ferramenta, e não um canal
+  público.
+- **Avisar incidente** ao controlador, sem demora. O prazo e o rito são a #84.
+- **Não subcontratar sem autorização** — o item abaixo, que é o que costuma ser
+  descoberto tarde.
+
+### A cadeia de suboperadores
+
+**Mandar a conversa para um provedor de IA é subcontratar tratamento.** O controlador
+precisa saber que esse terceiro existe e autorizá-lo; sem isso, a empresa cliente está
+compartilhando dado dos clientes dela com alguém que ela não sabe que existe.
+
+| Suboperador | O que trata | Estado hoje |
+|---|---|---|
+| Provedor de modelo | Conversa pseudonimizada, para análise | **Nenhum**: `MODEL_PROVIDER=fake` é o padrão, e nada sai da máquina. Ao trocar, entra aqui com nome e país |
+| Hospedagem / banco | Todo o dado do CRM | A definir com o controlador; hoje roda em Postgres local |
+| Servidor MCP | Depende de quem é o servidor | O nosso (#56) **não** é subcontratação — é o próprio operador. Ferramenta MCP de terceiro (ERP, tabela de frete) seria, e entra nesta tabela quando existir |
+
+A coluna de estado não é enfeite: hoje, com os padrões do repositório, **não há
+transferência a terceiro nenhum**. É o que torna a demo honesta — e é também o que muda no
+dia em que uma chave de provedor real for configurada, que é o momento de o controlador
+autorizar, não depois.
+
+Onde o provedor processa fisicamente é transferência internacional, e isso é a #79.
+
+---
+
 ## 3. O que decorre, na prática
 
 - **Retenção tem prazo, e prazo tem finalidade.** "Pseudonimizado, então guardo para
@@ -81,7 +131,6 @@ vocabulário jurídico. Convenção que depende de alguém lembrar tem prazo de 
 
 | Assunto | Issue |
 |---|---|
-| Papéis de controlador e operador, e subcontratação | #78 |
 | Base legal por finalidade, e legítimo interesse | #77 |
 | Registro das operações de tratamento | #76 |
 | Onde o provedor de IA processa (transferência internacional) | #79 |

--- a/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
+++ b/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
@@ -32,6 +32,7 @@ public class LinguagemDaLgpdTeste
         "README.md",
         Path.Combine("docs", "ARQUITETURA.md"),
         Path.Combine("docs", "LGPD.md"),
+        Path.Combine("docs", "CONTRATO-TRATAMENTO.md"),
     };
 
     [Theory]
@@ -110,6 +111,31 @@ public class LinguagemDaLgpdTeste
         }
 
         if (atual.Count > 0) yield return (inicio, string.Join(" ", atual));
+    }
+
+    [Fact]
+    public void Os_papeis_estao_definidos_com_quem_e_cada_um()
+    {
+        // Papel nao e formalidade: e quem responde perante o titular e a ANPD
+        // (#78). Documento que fala de LGPD sem dizer quem e controlador
+        // descreve obrigacoes sem dono.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "LGPD.md"));
+
+        Assert.Contains("Controlador", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Operador", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("empresa cliente", texto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void O_provedor_de_modelo_esta_mapeado_como_suboperador()
+    {
+        // E o item descoberto tarde: mandar a conversa para um provedor de IA e
+        // subcontratar tratamento, e sem isso a empresa cliente compartilha
+        // dado dos clientes dela com um terceiro que ela nao sabe que existe.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "LGPD.md"));
+
+        Assert.Contains("suboperador", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Provedor de modelo", texto, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string RaizDoRepositorio()


### PR DESCRIPTION
**Base:** sai de `83-pseudonimizacao` (#83), mesmo arquivo.

## O que muda
Papeis definidos, obrigacoes do operador, tabela de suboperadores e minuta de clausulas em `docs/CONTRATO-TRATAMENTO.md`.

## Decisoes
- Mandar conversa ao provedor de IA E subcontratacao: a autorizacao vem antes de a chave ser configurada.
- O servidor MCP da #56 NAO e subcontratacao (e o proprio operador); ferramenta MCP de terceiro seria.
- A tabela tem coluna de estado, e hoje ela diz "nenhum": com MODEL_PROVIDER=fake nada sai da maquina.

Closes #78