### PR TITLE
Base legal por finalidade e avaliacao de legitimo interesse

### DIFF
--- a/docs/BASE-LEGAL.md
+++ b/docs/BASE-LEGAL.md
@@ -1,0 +1,125 @@
+# Base legal por finalidade
+
+**Minuta técnica, escrita por quem conhece o sistema — precisa de revisão jurídica antes
+do primeiro dado real** (#77). Ela existe para que essa revisão comece do que o software
+faz, e não de um modelo genérico.
+
+Base legal não é formalidade: **ela determina o que o produto pode fazer**. Se fosse
+consentimento, o sistema precisaria de revogação que parasse o tratamento na hora; sendo
+legítimo interesse, precisa de canal de oposição funcionando. São funcionalidades
+diferentes, e descobrir isso depois de construir custa retrabalho — por isso a decisão
+vem antes.
+
+---
+
+## 1. A escolha, por finalidade
+
+| Finalidade | Base legal | Por quê |
+|---|---|---|
+| Receber e guardar a conversa | Execução de contrato ou procedimentos preliminares (art. 7, V) | O cliente mandou mensagem **para comprar**. Guardar o que ele disse é o próprio atendimento |
+| Cadastrar e identificar o Lead | Art. 7, V | Sem saber de quem é a conversa não há atendimento |
+| **Analisar a conversa por IA** (dossiê, sinais, lacunas) | **Legítimo interesse (art. 7, IX)** | Não é necessário para atender o pedido — é para atender *melhor*. Exige a avaliação da seção 2 |
+| Sugerir abordagem ao vendedor | Legítimo interesse (art. 7, IX) | Mesma análise, mesmo balanceamento |
+| Ficha do Cliente (dado de terceiro B2B) | Legítimo interesse (art. 7, IX) | Contato profissional em contexto de negócio, com as salvaguardas da #89 |
+| Ledger de custo e medição | Legítimo interesse (art. 7, IX) | Do controlador, sobre a própria operação; usa o vínculo, não o conteúdo |
+| Indexar precedentes (RAG) | Legítimo interesse (art. 7, IX), **com a salvaguarda mais forte** | É onde a expectativa do titular é mais frágil: a conversa dele ajuda a vender para outra pessoa |
+| Atender pedidos de titular | Cumprimento de obrigação legal (art. 7, II) | O pedido obriga a resposta |
+| **Dado sensível** (saúde, fé, política…) | **Nenhuma — por isso não é tratado** | O art. 11 exigiria consentimento específico e destacado, que ninguém deu. A decisão foi **remover** o trecho antes da análise (#82), e não achar uma base para ele |
+
+A última linha é a mais importante da tabela: quando não há base legal, a saída correta
+não é procurar uma justificativa melhor — é **não tratar**.
+
+## Por que não consentimento
+
+Consentimento é revogável a qualquer momento, e um produto cujo funcionamento depende dele
+para de funcionar sem aviso. Pior: o consentimento pedido no meio de uma conversa de venda
+— "aceita que a IA leia isto?" — não é livre de verdade, porque quem quer comprar clica em
+qualquer coisa para seguir. Consentimento coletado assim é **frágil na forma e frágil no
+mérito**.
+
+Consentimento continua sendo a base certa para o que estiver fora do atendimento — por
+exemplo, usar a conversa para marketing, ou para treinar modelo. Nada disso está no
+escopo, e o [contrato](CONTRATO-TRATAMENTO.md) proíbe o segundo sem autorização específica.
+
+---
+
+## 2. Avaliação de legítimo interesse
+
+Três etapas, na ordem em que a lei pede. Só passa quem passa nas três.
+
+### 2.1 A finalidade é legítima?
+
+Sim: ajudar um vendedor a entender a conversa que **ele mesmo está tendo** com o cliente
+dele, e a não esquecer negócio em aberto. É atividade comercial ordinária, e o titular é
+parte dela — ele iniciou o contato para comprar.
+
+### 2.2 O tratamento é necessário?
+
+Necessário para a finalidade, e limitado a ela:
+
+- a análise usa **a conversa daquele cliente com aquela empresa**, não dados comprados,
+  não enriquecimento externo, não rede social;
+- o produto **não envia mensagem ao cliente**, então não há tratamento para influenciar
+  diretamente o titular sem intermediação humana;
+- o dado sensível é **removido** do contexto, e não usado com cuidado redobrado — o que
+  não está lá não influencia nada.
+
+Onde o tratamento **não** era necessário, ele foi cortado: o Vigia varre datas sem chamar
+modelo, e o catálogo vai inteiro no contexto em vez de virar índice (#63).
+
+### 2.3 O balanceamento, com a pergunta desconfortável
+
+> **O cliente que manda mensagem para uma torrefação espera que aquilo seja analisado por
+> IA para traçar o perfil dele?**
+
+A resposta honesta é **provavelmente não**. Ele espera ser atendido por uma pessoa.
+
+Isso não impede o legítimo interesse — impede que ele seja assumido de graça. A expectativa
+frustrada é o que exige salvaguarda proporcionalmente mais forte, e é o que justifica cada
+uma das decisões abaixo, que existem **no código**, não só neste documento:
+
+| Salvaguarda | Onde está |
+|---|---|
+| A IA nunca escreve ao cliente; quem fala é o vendedor | Tese do produto, e o escopo inteiro depende dela |
+| Dado sensível sai da fala antes de qualquer análise | #82, na moldura de contexto |
+| PII mascarada antes de sair da rede, com teste que falha o build | #43 |
+| Toda conclusão cita a fala que a originou — o titular pode contestar o dado *e* a leitura | Regra de ancoragem |
+| Fato e impressão separados, com procedência | #88 |
+| Categoria sensível recusada na Ficha, e aviso ao vendedor de que o titular pode ler | #89 |
+| **Canal de oposição que suspende a análise sem apagar o histórico** | #81 |
+| Exportação inclui o que o sistema *produziu*, não só o que entrou | #81 |
+| Retenção por finalidade, com prazo declarado | seção 3 |
+| Escopo por vendedor: cada um enxerga os próprios leads | #49, #58 |
+| Sem uso para treinar modelo sem autorização específica | Cláusula 2 do contrato |
+
+**A oposição é a que sustenta a base.** Legítimo interesse sem canal de oposição real é
+legítimo interesse no papel; por isso ela é código, e por isso opor-se **não** custa o
+histórico comercial do cliente — se custasse, ninguém se oporia, e o canal seria decorativo.
+
+E a expectativa frustrada é também o que torna a transparência (#80) obrigatória, e não
+cortesia: o titular precisa **saber** que existe análise para poder se opor a ela.
+
+---
+
+## 3. Prazos de retenção, por finalidade
+
+Propostos aqui, para o controlador confirmar em contrato. Prazo que ninguém escreve vira
+"guardamos desde 2019 porque ninguém definiu".
+
+| Dado | Prazo | Por quê |
+|---|---|---|
+| Conversa e Lead | 24 meses após o último contato | Cobre a recompra e a retomada; além disso é arquivo morto com dado pessoal dentro |
+| Ficha do Cliente | Enquanto o negócio estiver ativo; 12 meses após perdido | #89 |
+| Dado sensível detectado | 30 dias | Regime próprio, mais curto que tudo (#82) |
+| Log da aplicação | 6 meses | Prazo de depuração real; além disso ninguém abre |
+| Ledger de custo | Prazo fiscal do controlador | É documento contábil, não histórico de conversa |
+| Índice de embeddings | Igual à conversa de origem, com expurgo em cascata | Apagar o Lead sem apagar o vetor deixa o dado vivo (#46, #62) |
+
+---
+
+## 4. O que falta antes do primeiro dado real
+
+- **Revisão jurídica** desta minuta, com o controlador.
+- Onde o provedor de modelo processa fisicamente (#79) — muda o balanceamento se houver
+  transferência internacional.
+- Aviso de transparência ao titular (#80), que a seção 2.3 torna obrigatório.

--- a/docs/LGPD.md
+++ b/docs/LGPD.md
@@ -102,6 +102,22 @@ Onde o provedor processa fisicamente é transferência internacional, e isso é 
 
 ---
 
+## 2.8 A base legal, e o que ela obriga
+
+Está em [BASE-LEGAL.md](BASE-LEGAL.md), por finalidade. Em resumo: receber e guardar a
+conversa é **execução de contrato** (o cliente escreveu para comprar); analisar por IA é
+**legítimo interesse**, com a avaliação escrita; atender pedido de titular é **obrigação
+legal**; e dado sensível **não tem base** — por isso é removido, em vez de tratado com
+cuidado extra.
+
+A escolha não é etiqueta: legítimo interesse **obriga** canal de oposição funcionando, e é
+por isso que a oposição é código (#81) e não política. A avaliação também encara a
+pergunta que decide o balanceamento — *o cliente que manda mensagem para uma torrefação
+espera ser analisado por IA?* —, e a resposta honesta, "provavelmente não", é o que exige
+salvaguarda proporcionalmente mais forte.
+
+---
+
 ## 2.9 O registro das operações
 
 Cada tratamento — ingestão, cadastro, ficha, análise, ledger, log, varredura, índice e
@@ -145,7 +161,6 @@ vocabulário jurídico. Convenção que depende de alguém lembrar tem prazo de 
 
 | Assunto | Issue |
 |---|---|
-| Base legal por finalidade, e legítimo interesse | #77 |
 | Onde o provedor de IA processa (transferência internacional) | #79 |
 | Direitos do titular além da exclusão | #81 |
 | Dado sensível em regime próprio | #82 |

--- a/docs/REGISTRO-DE-TRATAMENTO.md
+++ b/docs/REGISTRO-DE-TRATAMENTO.md
@@ -8,9 +8,8 @@ que está rodando, é pior que registro nenhum — ele passa em auditoria e ment
 decide.
 
 Papéis (controlador é a empresa cliente; operador é o Copiloto) estão em
-[LGPD.md](LGPD.md#25-quem-responde-pelo-quê). **A base legal de cada operação é a #77** e
-está marcada como pendente onde ainda não foi decidida — preencher por analogia seria
-inventar a parte que mais importa.
+[LGPD.md](LGPD.md#25-quem-responde-pelo-quê). A base legal de cada operação está em
+[BASE-LEGAL.md](BASE-LEGAL.md), com a avaliação de legítimo interesse onde ela é a base.
 
 Cada operação abaixo declara, obrigatoriamente: **Finalidade**, **Titulares**, **Dados**,
 **Base legal**, **Compartilhamento**, **Retenção**, **Segurança** e **Estado**. Há teste
@@ -24,11 +23,12 @@ que reprova o build se algum desses rótulos faltar.
   matéria-prima de todo o resto.
 - **Titulares:** clientes da empresa; vendedores; terceiros citados na conversa.
 - **Dados:** telefone, nome quando aparece, conteúdo livre das mensagens, data e hora.
-- **Base legal:** pendente (#77) — provável execução de contrato/legítimo interesse do
-  controlador na relação comercial.
+- **Base legal:** execução de contrato ou procedimentos preliminares (art. 7, V) — o
+  cliente mandou mensagem para comprar ([BASE-LEGAL.md](BASE-LEGAL.md)).
 - **Compartilhamento:** nenhum nesta etapa. O webhook grava e enfileira.
-- **Retenção:** a definir por finalidade com o controlador (#77). Hoje não há expurgo
-  automático — e isso está declarado, não escondido.
+- **Retenção:** 24 meses após o último contato, proposto em
+  [BASE-LEGAL.md](BASE-LEGAL.md#3-prazos-de-retenção-por-finalidade) para o controlador
+  confirmar. Hoje não há expurgo automático (#46) — e isso está declarado, não escondido.
 - **Segurança:** webhook exige identificador do provedor; conteúdo do cliente entra
   delimitado como dado não confiável; dado sensível é retirado antes de qualquer análise
   (#82).
@@ -39,9 +39,9 @@ que reprova o build se algum desses rótulos faltar.
 - **Finalidade:** saber de quem é cada conversa, e ligar mensagens ao mesmo cliente.
 - **Titulares:** clientes da empresa.
 - **Dados:** telefone normalizado, nome quando informado, data de criação.
-- **Base legal:** pendente (#77).
+- **Base legal:** art. 7, V — sem saber de quem é a conversa não há atendimento.
 - **Compartilhamento:** nenhum.
-- **Retenção:** enquanto durar a relação comercial; exclusão a pedido do titular (#46).
+- **Retenção:** 24 meses após o último contato; exclusão a pedido do titular (#46).
 - **Segurança:** telefone normalizado antes de casar, para não criar dois cadastros da
   mesma pessoa; acesso por perfil (#49).
 - **Estado:** existe.
@@ -54,7 +54,8 @@ que reprova o build se algum desses rótulos faltar.
   há registro sobre ela. É o ponto sensível desta operação (#89).
 - **Dados:** ramo, porte, cargo, papel na decisão, necessidade, orçamento estimado, e
   impressões do vendedor, cada linha marcada como fato ou impressão, com fonte.
-- **Base legal:** pendente (#77) — provável legítimo interesse comercial em contexto B2B.
+- **Base legal:** legítimo interesse (art. 7, IX), com as salvaguardas da #89 — contato
+  profissional em contexto de negócio.
 - **Compartilhamento:** vai ao provedor de modelo junto do contexto, quando houver um
   configurado.
 - **Retenção:** enquanto o negócio estiver ativo; **12 meses** após negócio perdido (#89).
@@ -69,8 +70,9 @@ que reprova o build se algum desses rótulos faltar.
 - **Titulares:** clientes; terceiros citados.
 - **Dados:** conversa pseudonimizada, ficha, playbook. **E as inferências geradas**, que
   são dado pessoal novo, criado por nós, sobre o titular.
-- **Base legal:** pendente (#77). Se for legítimo interesse, depende do canal de oposição
-  funcionando (#81) — e ele existe.
+- **Base legal:** legítimo interesse (art. 7, IX), com a avaliação da
+  [BASE-LEGAL.md](BASE-LEGAL.md#2-avaliação-de-legítimo-interesse). Depende do canal de
+  oposição funcionando (#81) — e ele existe.
 - **Compartilhamento:** provedor de modelo, quando configurado. Hoje `MODEL_PROVIDER=fake`
   e **nada sai da máquina**. Onde o provedor processa é a #79.
 - **Retenção:** o dossiê é recalculado, não guardado. O que persiste é o custo (operação 5).
@@ -83,8 +85,8 @@ que reprova o build se algum desses rótulos faltar.
 - **Finalidade:** saber quanto cada negócio custou em IA, e se o produto se paga.
 - **Titulares:** clientes (indiretamente, pelo vínculo com o negócio).
 - **Dados:** modelo, custo, data, `deal_id` — que aponta para uma pessoa.
-- **Base legal:** pendente (#77) — provável legítimo interesse do controlador em controle
-  de custos.
+- **Base legal:** legítimo interesse do controlador (art. 7, IX) sobre a própria operação:
+  usa o vínculo, não o conteúdo.
 - **Compartilhamento:** nenhum.
 - **Retenção:** prazo contábil/fiscal do controlador; não segue o prazo da conversa.
 - **Segurança:** não guarda conteúdo de mensagem, apenas o vínculo e o valor.
@@ -96,10 +98,10 @@ que reprova o build se algum desses rótulos faltar.
 - **Titulares:** clientes; vendedores.
 - **Dados:** identificadores, marcadores de PII (`[TEL_1]`) e metadados. **Mesmo mascarado é
   dado pessoal**: o marcador é reversível pelo mapa, e o `deal_id` ao lado identifica.
-- **Base legal:** pendente (#77).
+- **Base legal:** legítimo interesse (art. 7, IX) na operação e depuração do sistema.
 - **Compartilhamento:** nenhum hoje; ferramenta de observabilidade externa entraria como
   suboperador.
-- **Retenção:** a definir; menor que a da conversa.
+- **Retenção:** 6 meses — prazo de depuração real; além disso ninguém abre.
 - **Segurança:** teste que **falha o build** se PII vazar em log ou payload (#43).
 - **Estado:** existe.
 
@@ -109,8 +111,9 @@ que reprova o build se algum desses rótulos faltar.
   esfriando.
 - **Titulares:** clientes.
 - **Dados:** datas de mensagem e de estágio; a última fala do cliente é citada no alerta.
-- **Base legal:** pendente (#77).
-- **Compartilhamento:** nenhum — a varredura é determinística e **não chama modelo**.
+- **Base legal:** legítimo interesse (art. 7, IX), o mesmo da análise, com tratamento
+  menor: a varredura é determinística e não chama modelo.
+- **Compartilhamento:** nenhum.
 - **Retenção:** não cria registro novo além do alerta em log.
 - **Segurança:** só varre negócios abertos; não repete o mesmo alerta.
 - **Estado:** issue #53.
@@ -121,7 +124,8 @@ que reprova o build se algum desses rótulos faltar.
 - **Titulares:** clientes; terceiros citados nas conversas indexadas.
 - **Dados:** trechos de conversa vetorizados. **Vetor é dado pessoal** — derivado do texto,
   recuperável por semelhança, apontando para o mesmo titular.
-- **Base legal:** pendente (#77).
+- **Base legal:** legítimo interesse (art. 7, IX), com a salvaguarda mais forte — é onde a
+  expectativa do titular é mais frágil: a conversa dele ajuda a vender para outra pessoa.
 - **Compartilhamento:** provedor de embeddings, quando houver.
 - **Retenção:** igual à da conversa de origem, e **expurgo em cascata** com o Lead — apagar
   o Lead sem apagar o vetor deixa o dado vivo depois de o titular pedir exclusão.
@@ -148,8 +152,7 @@ que reprova o build se algum desses rótulos faltar.
 
 | Assunto | Issue |
 |---|---|
-| Base legal por finalidade, e o teste de legítimo interesse | #77 |
 | Onde o provedor de IA processa fisicamente | #79 |
-| Prazos de retenção acordados com o controlador | #77 |
+| Confirmação dos prazos de retenção pelo controlador, em contrato | #77 |
 | Aviso de transparência ao titular | #80 |
 | Exclusão em cascata, incluindo índice e cache | #46 |

--- a/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
+++ b/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
@@ -34,6 +34,7 @@ public class LinguagemDaLgpdTeste
         Path.Combine("docs", "LGPD.md"),
         Path.Combine("docs", "CONTRATO-TRATAMENTO.md"),
         Path.Combine("docs", "REGISTRO-DE-TRATAMENTO.md"),
+        Path.Combine("docs", "BASE-LEGAL.md"),
     };
 
     [Theory]
@@ -188,6 +189,33 @@ public class LinguagemDaLgpdTeste
 
         Assert.Contains("**Estado:** existe", texto);
         Assert.Contains("issue #", texto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Nenhuma_operacao_ficou_sem_base_legal_definida()
+    {
+        // Base legal determina o que o produto PODE fazer — consentimento pede
+        // revogação que para na hora, legitimo interesse pede canal de
+        // oposicao. Sao funcionalidades diferentes, e descobrir depois de
+        // construir custa retrabalho (#77).
+        var texto = File.ReadAllText(
+            Path.Combine(RaizDoRepositorio(), "docs", "REGISTRO-DE-TRATAMENTO.md"));
+
+        Assert.DoesNotContain("Base legal:** pendente", texto);
+    }
+
+    [Fact]
+    public void A_avaliacao_de_legitimo_interesse_encara_a_pergunta_desconfortavel()
+    {
+        // O cliente que manda mensagem para uma torrefacao espera ser analisado
+        // por IA? A resposta honesta e "provavelmente nao", e e ela que obriga
+        // a salvaguarda mais forte. Uma LIA que so lista beneficios nao e
+        // avaliacao, e folheto.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "BASE-LEGAL.md"));
+
+        Assert.Contains("provavelmente não", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("oposição", texto, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("revisão jurídica", texto, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string RaizDoRepositorio()


### PR DESCRIPTION
**Base:** sai de `76-registro-de-tratamento` (#76).

## O que muda
Base legal por finalidade, LIA escrita, salvaguardas apontando para o codigo, e os prazos de retencao propostos.

## Decisoes
- Guardar a conversa e execucao de contrato; ANALISAR e legitimo interesse — analisar nao e necessario para atender o pedido, e para atender melhor.
- A LIA encara a pergunta desconfortavel: o cliente espera ser analisado por IA? Provavelmente nao — e e isso que exige salvaguarda mais forte.
- Dado sensivel: NENHUMA base. Quando nao ha base, a saida e nao tratar.

## Pendente
Revisao juridica antes do primeiro dado real, escrita no topo do documento.

Closes #77