### PR TITLE
Aviso de transparencia ao titular

### DIFF
--- a/docs/LGPD.md
+++ b/docs/LGPD.md
@@ -118,6 +118,33 @@ salvaguarda proporcionalmente mais forte.
 
 ---
 
+## 2.85 O aviso ao titular, no tamanho que ele lê
+
+Transparência é princípio expresso (art. 6) e, aqui, **condição da base legal**: o titular
+só pode se opor à análise se souber que ela existe (#80).
+
+O desafio não é jurídico, é de formato — ninguém lê termo de quatro parágrafos no WhatsApp.
+Aviso que o cliente pula cumpre a formalidade e falha na finalidade. Por isso o aviso curto
+é o principal, com teto de 220 caracteres, e o completo mora atrás de um link:
+
+> Oi! Esta conversa fica registrada na *[empresa]* e usamos IA para organizar o
+> atendimento. **Quem responde aqui é uma pessoa.** Detalhes e seus direitos: *[link]*
+
+A ordem da frase é decidida: primeiro o que acontece com a conversa, depois a
+tranquilização que só este produto pode dar, e por último o link. Começar pelo link faria o
+resto não ser lido; terminar pela pessoa deixaria o aviso soando como robô se desculpando.
+Se o nome da empresa e o link não couberem, a construção **falha** — o erro aparece para
+quem instala, e não para quem compra.
+
+Uma decisão que precisa estar dita: **o aviso não é a IA falando com o cliente.** É texto
+fixo da empresa, escrito uma vez e revisado por gente; nenhum modelo o gera nem o altera. A
+tese continua inteira.
+
+E ele é enviado **uma vez por pessoa**, não por conversa: repetir a cada retomada
+transforma transparência em ruído, que é a forma mais eficiente de não ser lido.
+
+---
+
 ## 2.9 O registro das operações
 
 Cada tratamento — ingestão, cadastro, ficha, análise, ledger, log, varredura, índice e
@@ -164,6 +191,5 @@ vocabulário jurídico. Convenção que depende de alguém lembrar tem prazo de 
 | Onde o provedor de IA processa (transferência internacional) | #79 |
 | Direitos do titular além da exclusão | #81 |
 | Dado sensível em regime próprio | #82 |
-| Aviso de transparência ao titular | #80 |
 | Resposta a incidente e log de auditoria | #84 |
 | Dado de terceiro na Ficha do Cliente | #89 |

--- a/src/Copiloto.Dominio/Titulares/AvisoDeTransparencia.cs
+++ b/src/Copiloto.Dominio/Titulares/AvisoDeTransparencia.cs
@@ -1,0 +1,113 @@
+namespace Copiloto.Dominio.Titulares;
+
+/// <summary>
+/// O que o cliente precisa saber, no tamanho que ele vai ler (#80).
+///
+/// Transparencia e principio expresso (art. 6), e a base de legitimo interesse
+/// depende dela: o titular so pode se opor a analise se souber que ela existe.
+///
+/// O desafio real nao e juridico, e de formato — ninguem le termo de quatro
+/// paragrafos no WhatsApp. Um aviso que o cliente pula cumpre a formalidade e
+/// falha na finalidade, entao aqui a versao curta e a principal, e a completa
+/// mora atras de um link.
+///
+/// ISTO NAO E A IA FALANDO COM O CLIENTE. E texto fixo da empresa, escrito uma
+/// vez e revisado por gente — nenhum modelo o gera e nenhum modelo o altera. A
+/// tese do produto continua inteira: quem conversa e o vendedor.
+/// </summary>
+public static class AvisoDeTransparencia
+{
+    /// <summary>
+    /// Teto do aviso curto.
+    ///
+    /// E escolha de produto, nao limite de plataforma: acima disso o texto vira
+    /// bloco na tela do celular, e bloco em conversa de venda e o que se pula.
+    /// Preferir cortar conteudo a perder o leitor e a decisao — o que nao cabe
+    /// aqui esta no link, que continua sendo o documento completo.
+    /// </summary>
+    public const int TetoDoAvisoCurto = 220;
+
+    /// <summary>
+    /// A frase que vai na primeira resposta ao cliente.
+    ///
+    /// A ordem e deliberada: primeiro o que acontece com a conversa, depois a
+    /// tranquilizacao que so este produto pode dar — "quem responde e uma
+    /// pessoa" —, e por ultimo o link. Comecar pelo link faria o resto nao ser
+    /// lido; terminar pela pessoa deixaria o aviso soando como robo se
+    /// desculpando.
+    /// </summary>
+    public static string Curto(string empresa, string linkDaPolitica)
+    {
+        Exigir(empresa, nameof(empresa));
+        Exigir(linkDaPolitica, nameof(linkDaPolitica));
+
+        var aviso =
+            $"Oi! Esta conversa fica registrada na {empresa.Trim()} e usamos IA para "
+            + "organizar o atendimento. Quem responde aqui é uma pessoa. "
+            + $"Detalhes e seus direitos: {linkDaPolitica.Trim()}";
+
+        if (aviso.Length > TetoDoAvisoCurto)
+            throw new InvalidOperationException(
+                $"O aviso ficou com {aviso.Length} caracteres, acima de "
+                + $"{TetoDoAvisoCurto}: nome de empresa ou link comprido demais. "
+                + "Encurte o link — o texto do aviso ja esta no minimo que informa.");
+
+        return aviso;
+    }
+
+    /// <summary>
+    /// A versao completa, que mora na politica de privacidade.
+    ///
+    /// Cinco coisas, na linguagem de quem compra cafe e nao de quem escreve
+    /// contrato: o que e registrado, que ha analise por IA, para que, com quem
+    /// e compartilhado, e como exercer direitos.
+    /// </summary>
+    public static string Completo(string empresa, string canalDeContato)
+    {
+        Exigir(empresa, nameof(empresa));
+        Exigir(canalDeContato, nameof(canalDeContato));
+
+        var nome = empresa.Trim();
+
+        return string.Join("\n\n",
+            $"**O que registramos.** As mensagens que você troca com a {nome} pelo "
+            + "WhatsApp ficam guardadas, junto com seu telefone e o que você nos contou "
+            + "sobre o que procura.",
+
+            "**O que a IA faz — e o que ela não faz.** Um sistema de inteligência "
+            + "artificial lê essas mensagens e monta, para o vendedor, um resumo do que "
+            + "você pediu e do que ficou em aberto. **A IA não conversa com você**: toda "
+            + "mensagem que chega até aqui foi escrita por uma pessoa da equipe.",
+
+            "**Para quê.** Para atender melhor: não perder o que você pediu, não repetir "
+            + "pergunta que você já respondeu, e não esquecer de voltar quando você pede "
+            + "para pensar.",
+
+            "**Com quem compartilhamos.** Com o provedor de tecnologia que roda a "
+            + "análise, e apenas com ele. Antes de sair daqui, dados como telefone, "
+            + "e-mail e documento são substituídos por marcadores. Não vendemos e não "
+            + "cedemos seus dados para publicidade.",
+
+            "**Seus direitos.** Você pode pedir para ver tudo o que temos sobre você, "
+            + "corrigir o que estiver errado, levar seus dados embora, pedir exclusão, e "
+            + "**pedir que a análise por IA pare** — sem perder o atendimento. É só falar "
+            + $"com a gente: {canalDeContato.Trim()}.");
+    }
+
+    /// <summary>
+    /// Se este cliente ainda precisa receber o aviso.
+    ///
+    /// Uma vez por pessoa, e nao uma vez por conversa: repetir o aviso a cada
+    /// retomada transforma transparencia em ruido, e ruido e a forma mais
+    /// eficiente de nao ser lido.
+    /// </summary>
+    public static bool PrecisaAvisar(DateTimeOffset? avisadoEm) => avisadoEm is null;
+
+    private static void Exigir(string valor, string nome)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+            throw new ArgumentException(
+                $"Aviso sem {nome} nao informa nada: um texto generico deixaria o "
+                + "cliente sem saber com quem esta falando nem onde reclamar.", nome);
+    }
+}

--- a/testes/Copiloto.Testes/AvisoDeTransparenciaTeste.cs
+++ b/testes/Copiloto.Testes/AvisoDeTransparenciaTeste.cs
@@ -1,0 +1,123 @@
+using Copiloto.Dominio.Titulares;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O aviso ao titular (#80), cujo desafio e de formato e nao de conteudo.
+///
+/// Ninguem le termo de quatro paragrafos no WhatsApp. Aviso que o cliente pula
+/// cumpre a formalidade e falha na finalidade — e a finalidade importa porque a
+/// base de legitimo interesse depende dela: so se opoe a analise quem sabe que
+/// ela existe.
+/// </summary>
+public class AvisoDeTransparenciaTeste
+{
+    private const string Empresa = "Torrefação Serra Alta";
+    private const string Link = "serraalta.com.br/privacidade";
+
+    [Fact]
+    public void O_aviso_curto_cabe_em_uma_frase_que_alguem_le_ate_o_fim()
+    {
+        var aviso = AvisoDeTransparencia.Curto(Empresa, Link);
+
+        Assert.True(aviso.Length <= AvisoDeTransparencia.TetoDoAvisoCurto,
+            $"O aviso tem {aviso.Length} caracteres.");
+    }
+
+    [Fact]
+    public void O_aviso_curto_diz_as_tres_coisas_que_nao_podem_faltar()
+    {
+        // Registro, IA, e a pessoa do outro lado. O resto cabe no link.
+        var aviso = AvisoDeTransparencia.Curto(Empresa, Link);
+
+        Assert.Contains("registrada", aviso);
+        Assert.Contains("IA", aviso);
+        Assert.Contains("uma pessoa", aviso);
+        Assert.Contains(Link, aviso);
+    }
+
+    [Fact]
+    public void O_aviso_nomeia_a_empresa_e_nao_fala_em_terceira_pessoa()
+    {
+        // "Esta conversa e registrada" sem dizer por quem deixa o cliente sem
+        // saber de quem cobrar.
+        Assert.Contains(Empresa, AvisoDeTransparencia.Curto(Empresa, Link));
+    }
+
+    [Fact]
+    public void Link_comprido_demais_falha_alto_em_vez_de_estourar_o_aviso()
+    {
+        // Falhar na configuracao e melhor que mandar ao cliente um bloco que
+        // ele nao vai ler: o erro aparece para quem instala, e nao para quem
+        // compra.
+        var linkEnorme = "empresa.com.br/" + new string('a', 250);
+
+        var erro = Assert.Throws<InvalidOperationException>(
+            () => AvisoDeTransparencia.Curto(Empresa, linkEnorme));
+
+        Assert.Contains("Encurte o link", erro.Message);
+    }
+
+    [Fact]
+    public void Aviso_sem_empresa_ou_sem_link_e_recusado()
+    {
+        Assert.Throws<ArgumentException>(() => AvisoDeTransparencia.Curto("  ", Link));
+        Assert.Throws<ArgumentException>(() => AvisoDeTransparencia.Curto(Empresa, ""));
+    }
+
+    [Fact]
+    public void A_versao_completa_traz_os_cinco_pontos_da_issue()
+    {
+        var completo = AvisoDeTransparencia.Completo(Empresa, "atendimento@serraalta.com.br");
+
+        Assert.Contains("O que registramos", completo);
+        Assert.Contains("inteligência artificial", completo);
+        Assert.Contains("Para quê", completo);
+        Assert.Contains("Com quem compartilhamos", completo);
+        Assert.Contains("Seus direitos", completo);
+    }
+
+    [Fact]
+    public void A_versao_completa_diz_que_quem_responde_e_gente()
+    {
+        // E a vantagem real que este produto tem a comunicar: dizer isso e
+        // melhor para a empresa do que ficar calado e o cliente descobrir por
+        // conta.
+        var completo = AvisoDeTransparencia.Completo(Empresa, "atendimento@serraalta.com.br");
+
+        Assert.Contains("A IA não conversa com você", completo);
+        Assert.Contains("escrita por uma pessoa", completo);
+    }
+
+    [Fact]
+    public void A_versao_completa_informa_o_direito_de_opor_se_a_analise()
+    {
+        // Sem isto, a base de legitimo interesse fica no papel: o titular nao
+        // tem como exercer um direito que ninguem contou que ele tem (#77, #81).
+        var completo = AvisoDeTransparencia.Completo(Empresa, "atendimento@serraalta.com.br");
+
+        Assert.Contains("análise por IA pare", completo);
+        Assert.Contains("sem perder o atendimento", completo);
+    }
+
+    [Fact]
+    public void A_versao_completa_evita_juridiques()
+    {
+        // Linguagem simples e criterio de aceite, e o jeito de verificar e
+        // procurar as palavras que so aparecem em contrato.
+        var completo = AvisoDeTransparencia.Completo(Empresa, "atendimento@serraalta.com.br");
+
+        foreach (var palavra in new[] { "outrossim", "doravante", "nos termos do", "art." })
+            Assert.DoesNotContain(palavra, completo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void O_cliente_e_avisado_uma_vez_e_nao_a_cada_conversa()
+    {
+        // Repetir o aviso a cada retomada transforma transparencia em ruido, e
+        // ruido e a forma mais eficiente de nao ser lido.
+        Assert.True(AvisoDeTransparencia.PrecisaAvisar(null));
+        Assert.False(AvisoDeTransparencia.PrecisaAvisar(
+            new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero)));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `77-base-legal` (#77), que torna o aviso obrigatorio.

## O que muda
Aviso curto (teto de 220 caracteres) e versao completa, em linguagem simples.

## Decisoes
- A ordem da frase e decidida: o que acontece com a conversa, depois "quem responde aqui e uma pessoa", e o link por ultimo.
- Nome/link que nao couberem DERRUBAM a construcao: o erro aparece para quem instala, nao para quem compra.
- O aviso nao e a IA falando com o cliente: e texto fixo da empresa.
- Ha teste que procura juridiques ("outrossim", "doravante").

Closes #80