### PR TITLE
Resposta a incidente e trilha de auditoria

### DIFF
--- a/docs/INCIDENTE.md
+++ b/docs/INCIDENTE.md
@@ -1,0 +1,131 @@
+# Resposta a incidente com dado pessoal
+
+Procedimento para quando dado pessoal escapa, é acessado indevidamente ou se perde
+(art. 48 · #84). **Minuta técnica: precisa de revisão jurídica junto do controlador**, que
+é quem comunica a ANPD e os titulares — o Copiloto é operador e comunica **o controlador**
+([LGPD.md](LGPD.md#25-quem-responde-pelo-quê)).
+
+Este documento é curto de propósito. Plano de incidente que ninguém lê inteiro em cinco
+minutos não é usado no dia em que precisa.
+
+---
+
+## 1. Os cinco passos, na ordem
+
+| Passo | O que fazer | Quem |
+|---|---|---|
+| **Detectar** | Registrar o horário em que se soube, e por qual sinal | Quem percebeu |
+| **Conter** | Cortar o acesso antes de investigar: revogar credencial, desligar integração, girar chave | Quem estiver de plantão, **sem esperar autorização** |
+| **Avaliar** | Quais dados, quantos titulares, se há risco relevante | Responsável técnico + controlador |
+| **Comunicar** | Controlador imediatamente; ANPD e titulares conforme a avaliação | Controlador decide; operador fornece os fatos |
+| **Registrar** | O que aconteceu, o que se fez, o que mudou para não repetir | Responsável técnico |
+
+**Conter vem antes de avaliar, e isso é decisão.** A tentação é entender primeiro para não
+agir errado — mas cada minuto de investigação com o acesso ainda aberto é um minuto de
+incidente ainda acontecendo. Credencial revogada por engano custa uma reconexão; credencial
+viva durante a investigação custa o incidente inteiro de novo.
+
+## 2. Quem decide, e em quanto tempo
+
+- **Contenção:** imediata, sem autorização. Quem está de plantão corta.
+- **Comunicação ao controlador:** sem demora injustificada, com o que se sabe **até
+  então** — esperar o quadro completo é o erro que atrasa a comunicação legal dele.
+- **Comunicação à ANPD e aos titulares:** decisão do **controlador**, com base na avaliação
+  de risco. O operador entrega os fatos e a lista de afetados; não decide por ele.
+- **Prazo interno alvo:** primeira comunicação ao controlador em **até 4 horas** do
+  conhecimento. É meta operacional, não prazo legal.
+
+## 3. A pergunta que decide o tamanho: quem foi afetado?
+
+Sem trilha de auditoria, a resposta honesta é "não sabemos" — e "não sabemos" obriga a
+tratar **todos** os titulares como afetados. Um incidente de 40 pessoas vira um evento de
+reputação sobre a base inteira.
+
+A trilha (`acessos`) responde três perguntas, e as três estão em código com teste:
+
+- **quais titulares uma credencial alcançou** numa janela → vazamento de credencial;
+- **quem tocou neste titular** → pergunta do próprio titular;
+- **o que saiu da nossa rede** (`EnviouParaModelo`) → chave de provedor vazada.
+
+A trilha guarda quem, qual titular, o quê, quando e por onde — **e não o conteúdo**. Trilha
+que copia dado pessoal vira a segunda cópia a proteger, e a primeira a vazar junto.
+
+## 4. Cenários deste projeto
+
+Um CRM comum não tem as duas primeiras superfícies.
+
+### 4.1 Vazamento do índice de embeddings
+
+**O que é:** vetores derivados de conversas reais, recuperáveis por semelhança.
+
+**Por que é pior do que parece:** vetor não parece dado pessoal — parece número —, então
+tende a ficar fora do inventário e do controle de acesso. E o conteúdo é conversa de
+cliente, não metadado.
+
+**Conter:** cortar o acesso ao banco vetorial; girar credenciais; suspender indexação.
+**Avaliar:** quais conversas foram indexadas na janela (a indexação é registrada).
+**Não repetir:** PII mascarada antes de indexar e isolamento por titular já são requisito
+(#62); o incidente testa se eles estavam mesmo ligados.
+
+### 4.2 Credencial do servidor MCP exposta
+
+**O que é:** o servidor MCP existe para um agente consumir **em volume** — é a superfície
+com maior razão de dano por minuto do projeto.
+
+**Conter:** revogar o token, derrubar o servidor MCP se necessário. O CRM continua
+funcionando sem ele.
+**Avaliar:** `VolumeAnormalPorMcp` e a lista de titulares alcançados pelo token.
+**Não repetir:** escopo por usuário, limite de volume e auditoria por chamada (#58).
+
+### 4.3 Chave de provedor de IA vazada
+
+**O que é:** custo alheio na nossa conta e, dependendo do provedor, acesso a histórico de
+chamadas — que contém conversa pseudonimizada.
+
+**Conter:** girar a chave no provedor **antes** de investigar; conferir o gasto.
+**Avaliar:** `TitularesEnviadosParaModelo` na janela.
+**Não repetir:** chave só por variável de ambiente, varredura de segredo no CI (#47).
+
+### 4.4 Dump do Postgres
+
+**O que é:** o pior caso — tudo, sem máscara, incluindo o mapa que reverte a
+pseudonimização.
+
+**Conter:** girar credenciais do banco, revogar acesso de rede, preservar log para
+investigação.
+**Avaliar:** o dump alcança **todos** os titulares; aqui não há redução por trilha.
+**Não repetir:** acesso ao banco só pela aplicação, backup cifrado, credencial nunca em
+repositório.
+
+## 5. Modelos de comunicação
+
+### 5.1 Ao controlador (imediata, incompleta é aceitável)
+
+> **Incidente de segurança — comunicação inicial**
+> Detectamos em *[data e hora]* que *[o que aconteceu, em uma frase]*.
+> **Já contivemos** *[o que foi cortado]*.
+> **Ainda estamos apurando** *[o que falta]*.
+> **Dados possivelmente envolvidos:** *[categorias]*.
+> **Titulares possivelmente afetados:** *[número, ou "em apuração"]*.
+> Próxima atualização em *[prazo]*.
+
+### 5.2 À ANPD (o controlador comunica)
+
+Natureza dos dados, titulares envolvidos, medidas técnicas e de segurança utilizadas,
+riscos, motivo da demora se houver, e medidas adotadas para reverter ou mitigar.
+
+### 5.3 Ao titular
+
+> Olá, *[nome]*. Precisamos avisar que, em *[data]*, *[o que aconteceu]*, e isso pode ter
+> envolvido *[quais dados seus]*. **O que já fizemos:** *[contenção]*. **O que você pode
+> fazer:** *[orientação prática, se houver]*. Se quiser saber exatamente o que temos sobre
+> você, é só pedir: *[canal]*.
+
+Sem juridiquês e sem "lamentamos o ocorrido" antes de dizer o que aconteceu — a pessoa
+precisa entender o risco dela em uma leitura.
+
+## 6. Depois: o registro
+
+Todo incidente encerra com um registro do que aconteceu, o que foi feito, e **o que mudou
+no sistema** para não repetir. Incidente que fecha sem mudança vira o mesmo incidente
+depois — e, na segunda vez, com a agravante de já se saber.

--- a/docs/LGPD.md
+++ b/docs/LGPD.md
@@ -191,5 +191,4 @@ vocabulário jurídico. Convenção que depende de alguém lembrar tem prazo de 
 | Onde o provedor de IA processa (transferência internacional) | #79 |
 | Direitos do titular além da exclusão | #81 |
 | Dado sensível em regime próprio | #82 |
-| Resposta a incidente e log de auditoria | #84 |
 | Dado de terceiro na Ficha do Cliente | #89 |

--- a/docs/REGISTRO-DE-TRATAMENTO.md
+++ b/docs/REGISTRO-DE-TRATAMENTO.md
@@ -146,6 +146,22 @@ que reprova o build se algum desses rótulos faltar.
   arquivo vazio que pareceria cadastro em branco; prazo de 15 dias medido em código (#81).
 - **Estado:** existe.
 
+## 10. Trilha de auditoria
+
+- **Finalidade:** saber quem acessou o dado de qual titular, para conter e dimensionar
+  incidente (#84) e responder ao titular que pergunta.
+- **Titulares:** clientes (como alvo do acesso); vendedores (como autores).
+- **Dados:** id do usuário, id do lead, operação, origem, data e hora. **Não guarda
+  conteúdo de mensagem nem valor de campo.**
+- **Base legal:** cumprimento de obrigação legal (segurança e resposta a incidente) e
+  legítimo interesse na proteção do próprio tratamento.
+- **Compartilhamento:** nenhum; vai ao controlador e à ANPD apenas quando houver incidente.
+- **Retenção:** 24 meses — precisa cobrir um incidente descoberto tarde, que é a regra e
+  não a exceção.
+- **Segurança:** registro imutável; índices por usuário e por titular para a consulta
+  rodar no dia em que ninguém tem tempo.
+- **Estado:** existe.
+
 ---
 
 ## O que este registro ainda não fecha

--- a/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
+++ b/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
@@ -1,3 +1,4 @@
+using Copiloto.Dominio.Auditoria;
 using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Fichas;
 using Copiloto.Dominio.Ia;
@@ -28,6 +29,9 @@ public class CopilotoDbContext : DbContext
     public DbSet<Conversa> Conversas => Set<Conversa>();
     public DbSet<Mensagem> Mensagens => Set<Mensagem>();
     public DbSet<FichaCliente> Fichas => Set<FichaCliente>();
+
+    /// <summary>A trilha de auditoria (#84): quem tocou no dado de quem.</summary>
+    public DbSet<AcessoRegistrado> Acessos => Set<AcessoRegistrado>();
 
     protected override void OnModelCreating(ModelBuilder b) =>
         b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/AcessoRegistradoMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/AcessoRegistradoMap.cs
@@ -1,0 +1,30 @@
+using Copiloto.Dominio.Auditoria;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Copiloto.Api.Persistencia.Mapeamentos;
+
+public class AcessoRegistradoMap : IEntityTypeConfiguration<AcessoRegistrado>
+{
+    public void Configure(EntityTypeBuilder<AcessoRegistrado> e)
+    {
+        e.ToTable("acessos");
+        e.HasKey(a => a.Id);
+        e.Property(a => a.LeadId).IsRequired();
+        e.Property(a => a.UsuarioId);
+        e.Property(a => a.Quando).IsRequired();
+        e.Property(a => a.Detalhe).HasMaxLength(500);
+
+        // Enum como texto: a trilha e lida por gente em investigacao, e um `3`
+        // na coluna obriga quem le a abrir o codigo para saber o que aconteceu.
+        e.Property(a => a.Operacao).HasConversion<string>().HasMaxLength(30).IsRequired();
+        e.Property(a => a.Origem).HasConversion<string>().HasMaxLength(20).IsRequired();
+
+        // Os dois indices sao as duas perguntas do incidente: "o que este
+        // usuario alcancou" e "quem tocou neste titular". Sem eles, a consulta
+        // que decide o tamanho da comunicacao roda em varredura de tabela —
+        // justamente no dia em que ninguem tem tempo.
+        e.HasIndex(a => new { a.UsuarioId, a.Quando }).HasDatabaseName("ix_acessos_usuario");
+        e.HasIndex(a => new { a.LeadId, a.Quando }).HasDatabaseName("ix_acessos_lead");
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904033751_TrilhaDeAuditoria.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904033751_TrilhaDeAuditoria.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904033751_TrilhaDeAuditoria")]
+    partial class TrilhaDeAuditoria
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904033751_TrilhaDeAuditoria.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904033751_TrilhaDeAuditoria.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrilhaDeAuditoria : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "acessos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UsuarioId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LeadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Operacao = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    Origem = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Quando = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Detalhe = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_acessos", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_acessos_lead",
+                table: "acessos",
+                columns: new[] { "LeadId", "Quando" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_acessos_usuario",
+                table: "acessos",
+                columns: new[] { "UsuarioId", "Quando" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "acessos");
+        }
+    }
+}

--- a/src/Copiloto.Dominio/Auditoria/AcessoRegistrado.cs
+++ b/src/Copiloto.Dominio/Auditoria/AcessoRegistrado.cs
@@ -1,0 +1,97 @@
+namespace Copiloto.Dominio.Auditoria;
+
+/// <summary>O que foi feito com o dado de um titular.</summary>
+public enum OperacaoAuditada
+{
+    Leu = 0,
+    Exportou = 1,
+    Editou = 2,
+    Excluiu = 3,
+
+    /// <summary>Mandou para analise de modelo — saiu da nossa rede.</summary>
+    EnviouParaModelo = 4,
+}
+
+/// <summary>De onde partiu o acesso. Muda o que se investiga.</summary>
+public enum OrigemDoAcesso
+{
+    Tela = 0,
+    Api = 1,
+
+    /// <summary>Servidor MCP: agente consumindo em volume (#56, #58).</summary>
+    Mcp = 2,
+
+    /// <summary>Rotina do proprio sistema, sem gente pedindo.</summary>
+    Job = 3,
+}
+
+/// <summary>
+/// Uma linha da trilha de auditoria: quem, qual titular, o que, quando, por
+/// onde (#84).
+///
+/// E o registro que decide o resultado de um incidente real. Sem ele, a
+/// empresa nao consegue dizer QUAIS titulares foram afetados — e ai precisa
+/// comunicar todos, transformando um incidente pequeno num evento de reputacao
+/// grande.
+///
+/// Imutavel, porque e o registro do que ja aconteceu: trilha que pode ser
+/// editada nao serve para provar nada, e e a primeira coisa que um invasor
+/// esperto mexeria.
+/// </summary>
+public class AcessoRegistrado
+{
+    /// <param name="usuarioId">
+    /// Quem acessou. Nulo APENAS quando ninguem pediu — rotina do sistema. O
+    /// tipo e anulavel de proposito: passar Guid.Empty por "nao sei" faria a
+    /// trilha apontar para um usuario que nao existe, e ninguem descobriria
+    /// isso ate precisar dela.
+    /// </param>
+    public AcessoRegistrado(
+        Guid id, Guid? usuarioId, Guid leadId, OperacaoAuditada operacao,
+        OrigemDoAcesso origem, DateTimeOffset quando, string? detalhe = null)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Acesso sem id.", nameof(id));
+        if (leadId == Guid.Empty)
+            throw new ArgumentException(
+                "Acesso sem titular nao responde a pergunta que a trilha existe para "
+                + "responder: QUEM foi afetado.", nameof(leadId));
+
+        // Usuario vazio e permitido so quando ninguem pediu: rotina do sistema.
+        // Em qualquer outra origem, acesso sem autor e trilha que nao aponta
+        // para pessoa nenhuma — e ai ela nao serve nem para conter o incidente
+        // nem para responder a ANPD.
+        if ((usuarioId is null || usuarioId == Guid.Empty) && origem != OrigemDoAcesso.Job)
+            throw new ArgumentException(
+                $"Acesso de origem {origem} sem usuario: a trilha precisa dizer quem "
+                + "acessou. Se foi rotina do sistema, use OrigemDoAcesso.Job.",
+                nameof(usuarioId));
+
+        Id = id;
+        UsuarioId = usuarioId == Guid.Empty ? null : usuarioId;
+        LeadId = leadId;
+        Operacao = operacao;
+        Origem = origem;
+        Quando = quando;
+        Detalhe = string.IsNullOrWhiteSpace(detalhe) ? null : detalhe.Trim();
+    }
+
+    public Guid Id { get; }
+
+    /// <summary>Nulo apenas para rotina do sistema.</summary>
+    public Guid? UsuarioId { get; }
+
+    public Guid LeadId { get; }
+    public OperacaoAuditada Operacao { get; }
+    public OrigemDoAcesso Origem { get; }
+    public DateTimeOffset Quando { get; }
+
+    /// <summary>
+    /// O que ajuda a reconstruir depois — a ferramenta MCP chamada, o campo
+    /// editado, o provedor para onde foi.
+    ///
+    /// NAO carrega conteudo de mensagem nem valor de campo: a trilha existe
+    /// para dizer o que foi tocado, e uma trilha que copia o dado pessoal vira
+    /// a segunda copia a proteger, e a primeira a vazar junto.
+    /// </summary>
+    public string? Detalhe { get; }
+}

--- a/src/Copiloto.Dominio/Auditoria/TrilhaDeAuditoria.cs
+++ b/src/Copiloto.Dominio/Auditoria/TrilhaDeAuditoria.cs
@@ -1,0 +1,67 @@
+namespace Copiloto.Dominio.Auditoria;
+
+/// <summary>
+/// As perguntas que a trilha precisa responder num incidente (#84).
+///
+/// Nao e "guardar log": e conseguir dizer, no dia seguinte a uma credencial
+/// vazar, QUAIS titulares aquele acesso alcancou. A diferenca entre comunicar
+/// 40 pessoas e comunicar a base inteira e esta consulta.
+/// </summary>
+public static class TrilhaDeAuditoria
+{
+    /// <summary>
+    /// Os titulares alcancados por um usuario dentro de uma janela — a
+    /// pergunta do vazamento de credencial.
+    /// </summary>
+    public static IReadOnlyList<Guid> TitularesAlcancadosPor(
+        IEnumerable<AcessoRegistrado> acessos, Guid usuarioId,
+        DateTimeOffset de, DateTimeOffset ate) =>
+        acessos
+            .Where(a => a.UsuarioId == usuarioId && a.Quando >= de && a.Quando <= ate)
+            .Select(a => a.LeadId)
+            .Distinct()
+            .ToList();
+
+    /// <summary>
+    /// Quem tocou neste titular — a pergunta que o proprio titular faz, e que
+    /// a LGPD lhe da o direito de fazer.
+    /// </summary>
+    public static IReadOnlyList<AcessoRegistrado> QuemAcessou(
+        IEnumerable<AcessoRegistrado> acessos, Guid leadId) =>
+        acessos.Where(a => a.LeadId == leadId).OrderBy(a => a.Quando).ToList();
+
+    /// <summary>
+    /// Acesso por MCP acima do normal na janela.
+    ///
+    /// Esta superficie e diferente das outras e por isso tem consulta propria:
+    /// o servidor MCP existe para um agente consumir em VOLUME, entao o padrao
+    /// que denuncia abuso ali nao e "acessou algo estranho", e "acessou muita
+    /// gente rapido" (#58). Numa tela, trinta titulares numa hora e um dia
+    /// cheio; por MCP, pode ser uma extracao.
+    /// </summary>
+    public static bool VolumeAnormalPorMcp(
+        IEnumerable<AcessoRegistrado> acessos, DateTimeOffset agora,
+        TimeSpan janela, int limite)
+    {
+        var recentes = acessos
+            .Where(a => a.Origem == OrigemDoAcesso.Mcp && a.Quando >= agora - janela)
+            .Select(a => a.LeadId)
+            .Distinct()
+            .Count();
+
+        return recentes > limite;
+    }
+
+    /// <summary>
+    /// O que saiu da nossa rede na janela. E a primeira lista pedida quando uma
+    /// chave de provedor vaza.
+    /// </summary>
+    public static IReadOnlyList<Guid> TitularesEnviadosParaModelo(
+        IEnumerable<AcessoRegistrado> acessos, DateTimeOffset de, DateTimeOffset ate) =>
+        acessos
+            .Where(a => a.Operacao == OperacaoAuditada.EnviouParaModelo
+                        && a.Quando >= de && a.Quando <= ate)
+            .Select(a => a.LeadId)
+            .Distinct()
+            .ToList();
+}

--- a/testes/Copiloto.Testes/AuditoriaTeste.cs
+++ b/testes/Copiloto.Testes/AuditoriaTeste.cs
@@ -1,0 +1,200 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Auditoria;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A trilha que decide o tamanho de um incidente (#84).
+///
+/// Sem ela, a empresa nao consegue dizer QUAIS titulares foram afetados — e ai
+/// precisa comunicar todos, transformando um incidente pequeno num evento de
+/// reputacao grande.
+/// </summary>
+public class AuditoriaTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public AuditoriaTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    private static AcessoRegistrado Acesso(
+        Guid usuario, Guid lead, DateTimeOffset quando,
+        OperacaoAuditada operacao = OperacaoAuditada.Leu,
+        OrigemDoAcesso origem = OrigemDoAcesso.Tela) =>
+        new(Guid.NewGuid(), usuario, lead, operacao, origem, quando);
+
+    [Fact]
+    public void Acesso_sem_titular_nao_existe()
+    {
+        // A trilha existe para responder QUEM foi afetado.
+        Assert.Throws<ArgumentException>(() => new AcessoRegistrado(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.Empty,
+            OperacaoAuditada.Leu, OrigemDoAcesso.Tela, T0));
+    }
+
+    [Fact]
+    public void Acesso_de_gente_sem_autor_nao_existe()
+    {
+        // Trilha que nao aponta para pessoa nenhuma nao serve nem para conter o
+        // incidente nem para responder a ANPD.
+        Assert.Throws<ArgumentException>(() => new AcessoRegistrado(
+            Guid.NewGuid(), null, Guid.NewGuid(),
+            OperacaoAuditada.Leu, OrigemDoAcesso.Mcp, T0));
+    }
+
+    [Fact]
+    public void Rotina_do_sistema_pode_nao_ter_autor()
+    {
+        // O Vigia varre sem ninguem pedir, e forcar um usuario ali seria
+        // inventar um responsavel que nao existe.
+        var acesso = new AcessoRegistrado(
+            Guid.NewGuid(), null, Guid.NewGuid(),
+            OperacaoAuditada.Leu, OrigemDoAcesso.Job, T0);
+
+        Assert.Null(acesso.UsuarioId);
+    }
+
+    [Fact]
+    public void A_trilha_diz_quais_titulares_uma_credencial_alcancou()
+    {
+        // A pergunta do dia seguinte ao vazamento — e a diferenca entre
+        // comunicar tres pessoas e comunicar a base inteira.
+        var vazado = Guid.NewGuid();
+        var outro = Guid.NewGuid();
+        var marina = Guid.NewGuid();
+        var lucas = Guid.NewGuid();
+
+        var acessos = new[]
+        {
+            Acesso(vazado, marina, T0),
+            Acesso(vazado, lucas, T0.AddMinutes(2)),
+            Acesso(vazado, marina, T0.AddMinutes(5)),          // repetido: conta uma vez
+            Acesso(outro, Guid.NewGuid(), T0.AddMinutes(3)),   // outro usuario: fora
+            Acesso(vazado, Guid.NewGuid(), T0.AddDays(-2)),    // antes da janela: fora
+        };
+
+        var alcancados = TrilhaDeAuditoria.TitularesAlcancadosPor(
+            acessos, vazado, T0.AddMinutes(-10), T0.AddHours(1));
+
+        Assert.Equal(2, alcancados.Count);
+        Assert.Contains(marina, alcancados);
+        Assert.Contains(lucas, alcancados);
+    }
+
+    [Fact]
+    public void A_trilha_diz_quem_tocou_num_titular_em_ordem()
+    {
+        // A pergunta que o proprio titular tem direito de fazer.
+        var marina = Guid.NewGuid();
+        var acessos = new[]
+        {
+            Acesso(Guid.NewGuid(), marina, T0.AddHours(3)),
+            Acesso(Guid.NewGuid(), marina, T0),
+            Acesso(Guid.NewGuid(), Guid.NewGuid(), T0.AddHours(1)),
+        };
+
+        var historico = TrilhaDeAuditoria.QuemAcessou(acessos, marina);
+
+        Assert.Equal(2, historico.Count);
+        Assert.Equal(T0, historico[0].Quando);
+    }
+
+    [Fact]
+    public void Volume_anormal_por_MCP_e_medido_a_parte()
+    {
+        // O servidor MCP existe para agente consumir em VOLUME: o que denuncia
+        // abuso ali nao e "acessou algo estranho", e "acessou muita gente
+        // rapido". Numa tela, trinta numa hora e um dia cheio.
+        var agente = Guid.NewGuid();
+        var muitos = Enumerable.Range(0, 40)
+            .Select(i => Acesso(agente, Guid.NewGuid(), T0.AddSeconds(i), origem: OrigemDoAcesso.Mcp))
+            .ToList();
+
+        Assert.True(TrilhaDeAuditoria.VolumeAnormalPorMcp(
+            muitos, T0.AddMinutes(1), TimeSpan.FromHours(1), limite: 30));
+    }
+
+    [Fact]
+    public void Movimento_normal_de_tela_nao_vira_alarme_de_MCP()
+    {
+        var vendedor = Guid.NewGuid();
+        var dia = Enumerable.Range(0, 40)
+            .Select(i => Acesso(vendedor, Guid.NewGuid(), T0.AddMinutes(i)))
+            .ToList();
+
+        Assert.False(TrilhaDeAuditoria.VolumeAnormalPorMcp(
+            dia, T0.AddHours(1), TimeSpan.FromHours(1), limite: 30));
+    }
+
+    [Fact]
+    public void A_trilha_lista_o_que_saiu_da_nossa_rede()
+    {
+        // Primeira lista pedida quando uma chave de provedor vaza.
+        var vendedor = Guid.NewGuid();
+        var marina = Guid.NewGuid();
+        var acessos = new[]
+        {
+            Acesso(vendedor, marina, T0, OperacaoAuditada.EnviouParaModelo),
+            Acesso(vendedor, Guid.NewGuid(), T0.AddMinutes(1)),
+        };
+
+        var enviados = TrilhaDeAuditoria.TitularesEnviadosParaModelo(
+            acessos, T0.AddMinutes(-1), T0.AddMinutes(5));
+
+        Assert.Single(enviados);
+        Assert.Equal(marina, enviados[0]);
+    }
+
+    [Fact]
+    public void A_trilha_nao_guarda_conteudo_de_mensagem()
+    {
+        // Trilha que copia o dado pessoal vira a segunda copia a proteger, e a
+        // primeira a vazar junto.
+        var acesso = new AcessoRegistrado(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            OperacaoAuditada.Exportou, OrigemDoAcesso.Api, T0,
+            detalhe: "exportacao de acesso, art. 18");
+
+        Assert.Equal("exportacao de acesso, art. 18", acesso.Detalhe);
+        Assert.DoesNotContain("R$", acesso.Detalhe);
+    }
+
+    [Fact]
+    public void A_trilha_sobrevive_ao_banco_e_e_consultavel_por_usuario()
+    {
+        // A consulta que decide o tamanho da comunicacao roda no dia em que
+        // ninguem tem tempo — por isso ela e indexada, e por isso ela e testada
+        // contra o banco e nao so em memoria.
+        var usuario = Guid.NewGuid();
+        var marina = Guid.NewGuid();
+
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            ctx.Acessos.Add(Acesso(usuario, marina, T0, OperacaoAuditada.Exportou, OrigemDoAcesso.Mcp));
+            ctx.Acessos.Add(Acesso(usuario, Guid.NewGuid(), T0.AddMinutes(1)));
+            ctx.Acessos.Add(Acesso(Guid.NewGuid(), Guid.NewGuid(), T0.AddMinutes(2)));
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+        var doUsuario = leitura.Acessos.Where(a => a.UsuarioId == usuario).ToList();
+
+        Assert.Equal(2, doUsuario.Count);
+        Assert.Contains(doUsuario, a => a.Operacao == OperacaoAuditada.Exportou
+                                        && a.Origem == OrigemDoAcesso.Mcp
+                                        && a.LeadId == marina);
+    }
+}

--- a/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
+++ b/testes/Copiloto.Testes/LinguagemDaLgpdTeste.cs
@@ -35,6 +35,7 @@ public class LinguagemDaLgpdTeste
         Path.Combine("docs", "CONTRATO-TRATAMENTO.md"),
         Path.Combine("docs", "REGISTRO-DE-TRATAMENTO.md"),
         Path.Combine("docs", "BASE-LEGAL.md"),
+        Path.Combine("docs", "INCIDENTE.md"),
     };
 
     [Theory]
@@ -216,6 +217,32 @@ public class LinguagemDaLgpdTeste
         Assert.Contains("provavelmente não", texto, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("oposição", texto, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("revisão jurídica", texto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void O_plano_de_incidente_manda_conter_antes_de_avaliar()
+    {
+        // A tentacao e entender primeiro para nao agir errado, e cada minuto de
+        // investigacao com o acesso aberto e um minuto de incidente ainda
+        // acontecendo (#84).
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "INCIDENTE.md"));
+
+        Assert.Contains("Conter vem antes de avaliar", texto);
+        Assert.True(
+            texto.IndexOf("**Conter**", StringComparison.Ordinal)
+            < texto.IndexOf("**Avaliar**", StringComparison.Ordinal),
+            "No procedimento, conter precisa vir antes de avaliar.");
+    }
+
+    [Fact]
+    public void Os_cenarios_proprios_deste_projeto_estao_mapeados()
+    {
+        // Um CRM comum nao tem indice vetorial com conversa dentro nem servidor
+        // MCP feito para agente consumir em volume.
+        var texto = File.ReadAllText(Path.Combine(RaizDoRepositorio(), "docs", "INCIDENTE.md"));
+
+        foreach (var cenario in new[] { "embeddings", "MCP", "provedor de IA", "Postgres" })
+            Assert.Contains(cenario, texto, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string RaizDoRepositorio()


### PR DESCRIPTION
**Base:** sai de `80-transparencia` (#80).

## O que muda
Trilha de auditoria (tabela `acessos`, com indices pelas duas perguntas do incidente) e `docs/INCIDENTE.md`.

## Decisoes
- Sem trilha, a resposta a "quem foi afetado?" e "nao sabemos" — e isso obriga a comunicar todos.
- A trilha nao guarda conteudo: copia de dado pessoal vira a segunda copia a proteger.
- Acesso sem autor so existe com origem Job.
- No plano: CONTER VEM ANTES DE AVALIAR, com teste cobrando a ordem no documento.

Closes #84