### PR TITLE
Dados de parceiros fora da base de precedentes de venda

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -277,6 +277,26 @@ isolada.
 Mitigação: o que é indexado passa pelo PII Shield **antes** de virar embedding, e a
 recuperação devolve padrão e técnica, não transcrição literal de terceiros.
 
+### 11.45 Parceiro não entra na base de precedentes (#85)
+
+Conversa com fornecedor, transportadora ou representante fica **fora** do índice de
+precedentes de venda, e a regra mora no domínio — não num filtro de consulta, que é o tipo
+de coisa esquecida na segunda consulta que alguém escrever.
+
+O risco não é só de dado pessoal (o contato na empresa parceira é pessoa física, ainda que
+a relação seja B2B): se conversa de fornecimento entra no mesmo índice que conversa de
+cliente, o sistema pode recuperar **uma negociação de compra, com margem e custo**,
+enquanto o vendedor atende um comprador. É vazamento comercial saindo pela porta que
+ninguém estava vigiando.
+
+O filtro vale **nos dois sentidos** — nada de parceiro sai para atendimento de cliente, e
+nada de cliente sai para atendimento de parceiro. Conferir só a origem deixaria metade do
+problema em pé.
+
+E não existe flag para "incluir parceiros": flag assim é ligada uma vez e nunca mais
+revisada. Se um dia houver base de precedentes de *compra*, ela é outra base, com outro
+escopo.
+
 ### 11.5 RAG precisa provar que serve
 
 Antes de virar padrão, a recuperação é comparada contra o baseline sem RAG nas

--- a/docs/REGISTRO-DE-TRATAMENTO.md
+++ b/docs/REGISTRO-DE-TRATAMENTO.md
@@ -162,6 +162,22 @@ que reprova o build se algum desses rótulos faltar.
   rodar no dia em que ninguém tem tempo.
 - **Estado:** existe.
 
+## 11. Dados de parceiro comercial
+
+- **Finalidade:** manter a relação com fornecedores, transportadoras e representantes —
+  compra, prazo de entrega, condição de fornecimento.
+- **Titulares:** o contato na empresa parceira. **É pessoa física**, ainda que a relação
+  seja B2B.
+- **Dados:** nome, telefone, cargo, e o conteúdo da conversa comercial.
+- **Base legal:** execução de contrato (art. 7, V) — base **própria**, distinta da usada
+  para clientes.
+- **Compartilhamento:** nenhum. Conversa de parceiro **não vai** para a base de precedentes
+  de venda.
+- **Retenção:** enquanto durar a relação de fornecimento, mais o prazo contratual.
+- **Segurança:** minimização (não guardar o que não se usa); isolamento do índice de
+  precedentes, cobrado por teste nas duas direções; consulta separável no banco.
+- **Estado:** existe (a marcação e o isolamento; o índice em si é #60).
+
 ---
 
 ## O que este registro ainda não fecha

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
@@ -14,6 +14,10 @@ public class LeadMap : IEntityTypeConfiguration<Lead>
         e.Property(l => l.Nome).HasMaxLength(200);
         e.Property(l => l.CriadoEm).IsRequired();
 
+        // Relacao como texto, e nao numero: a coluna e lida em investigacao e
+        // em consulta manual, e um `1` obriga quem le a abrir o codigo (#85).
+        e.Property(l => l.Relacao).HasConversion<string>().HasMaxLength(20).IsRequired();
+
         // O indice UNICO e o ponto que nao da para deixar so no codigo.
         //
         // A #22 resolveu a normalizacao, mas duas instancias processando a mesma

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904034232_RelacaoDoLead.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904034232_RelacaoDoLead.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904034232_RelacaoDoLead")]
+    partial class RelacaoDoLead
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904034232_RelacaoDoLead.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904034232_RelacaoDoLead.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class RelacaoDoLead : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // O default gerado era string vazia, que NAO e um valor do enum: a
+            // primeira leitura de um lead antigo quebraria a conversao, e o
+            // erro apareceria como falha de consulta, longe da causa.
+            //
+            // "Cliente" e o default certo tambem no merito: todo lead que ja
+            // existe entrou como comprador, e errar para esse lado e o lado
+            // seguro — parceiro marcado como cliente e o que precisa ser
+            // corrigido a mao, e por isso o UPDATE abaixo e explicito.
+            migrationBuilder.AddColumn<string>(
+                name: "Relacao",
+                table: "leads",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Cliente");
+
+            migrationBuilder.Sql(
+                "UPDATE leads SET \"Relacao\" = 'Cliente' WHERE \"Relacao\" = '';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Relacao",
+                table: "leads");
+        }
+    }
+}

--- a/src/Copiloto.Dominio/Rag/BaseDePrecedentes.cs
+++ b/src/Copiloto.Dominio/Rag/BaseDePrecedentes.cs
@@ -1,0 +1,53 @@
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Dominio.Rag;
+
+/// <summary>
+/// Quem pode entrar na base de precedentes de venda, e o que pode sair dela
+/// para cada atendimento (#85, #62).
+///
+/// A regra existe ANTES do RAG de proposito. Se ela nascesse junto com a
+/// indexacao, nasceria como filtro numa consulta — e filtro em consulta e
+/// esquecido na segunda consulta que alguem escrever. Aqui ela e do dominio, e
+/// a indexacao pergunta a ela.
+///
+/// O risco nao e so de dado pessoal: se conversa com fornecedor entra no mesmo
+/// indice que conversa com cliente, o sistema pode recuperar uma negociacao de
+/// fornecimento — com margem e custo — enquanto o vendedor atende um comprador.
+/// Vazamento comercial, saindo pela porta que ninguem estava vigiando.
+/// </summary>
+public static class BaseDePrecedentes
+{
+    /// <summary>
+    /// Conversa de parceiro NAO entra na base de precedentes de venda.
+    ///
+    /// O "salvo decisao explicita" da issue nao virou parametro aqui: uma flag
+    /// `incluirParceiros` seria ligada uma vez em algum lugar e nunca mais
+    /// revisada. Se um dia houver base de precedentes de COMPRA, ela e outra
+    /// base, com outro escopo — e nao esta com um booleano invertido.
+    /// </summary>
+    public static bool PodeIndexar(Lead lead)
+    {
+        ArgumentNullException.ThrowIfNull(lead);
+
+        return lead.Relacao == Relacao.Cliente;
+    }
+
+    /// <summary>
+    /// Os precedentes que podem ser mostrados no atendimento a este lead.
+    ///
+    /// Filtra pelos DOIS lados: nada de parceiro sai, e nada sai para um
+    /// atendimento de parceiro. Conferir so a origem deixaria metade do
+    /// problema em pe — o dossie de um fornecedor recheado com conversas de
+    /// clientes e o mesmo vazamento na direcao contraria.
+    /// </summary>
+    public static IReadOnlyList<T> Filtrar<T>(
+        IEnumerable<T> candidatos, Func<T, Lead> deQuem, Lead paraQuem)
+    {
+        ArgumentNullException.ThrowIfNull(paraQuem);
+
+        if (paraQuem.Relacao != Relacao.Cliente) return [];
+
+        return candidatos.Where(c => PodeIndexar(deQuem(c))).ToList();
+    }
+}

--- a/src/Copiloto.Dominio/Vendas/Lead.cs
+++ b/src/Copiloto.Dominio/Vendas/Lead.cs
@@ -24,8 +24,25 @@ public class Lead
 
     public Guid Id { get; }
     public string Telefone { get; }
+
+    /// <summary>
+    /// De que lado da mesa esta esta pessoa (#85).
+    ///
+    /// Nasce Cliente porque e o caso comum e porque errar para esse lado e
+    /// menos grave: cliente marcado como parceiro perde recurso; parceiro
+    /// marcado como cliente entra na base de precedentes de venda, e a
+    /// negociacao de fornecimento — com margem e custo — pode ser recuperada
+    /// enquanto o vendedor atende um comprador.
+    /// </summary>
+    public Relacao Relacao { get; private set; } = Relacao.Cliente;
     public string? Nome { get; private set; }
     public DateTimeOffset CriadoEm { get; }
+
+    /// <summary>
+    /// Marca quem esta do outro lado como fornecedor, transportadora,
+    /// representante — quem vende PARA a empresa, e nao compra dela.
+    /// </summary>
+    public void MarcarComo(Relacao relacao) => Relacao = relacao;
 
     /// <summary>Nome descoberto no meio da conversa, que e como ele costuma chegar.</summary>
     public void Identificar(string nome)

--- a/src/Copiloto.Dominio/Vendas/Relacao.cs
+++ b/src/Copiloto.Dominio/Vendas/Relacao.cs
@@ -1,0 +1,18 @@
+namespace Copiloto.Dominio.Vendas;
+
+/// <summary>
+/// De que lado da mesa esta a pessoa do outro lado da conversa (#85).
+///
+/// Dado de parceiro tambem e dado pessoal — o contato na empresa parceira e
+/// uma pessoa fisica, ainda que a relacao seja B2B —, mas o motivo de separar
+/// nao e so esse: conversa de fornecimento carrega margem, custo e condicao
+/// que nao podem sair perto de um comprador.
+/// </summary>
+public enum Relacao
+{
+    /// <summary>Compra da empresa. O caso comum.</summary>
+    Cliente = 0,
+
+    /// <summary>Fornecedor, transportadora, representante: vende PARA a empresa.</summary>
+    Parceiro = 1,
+}

--- a/testes/Copiloto.Testes/DadosDeParceiroTeste.cs
+++ b/testes/Copiloto.Testes/DadosDeParceiroTeste.cs
@@ -1,0 +1,140 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Rag;
+using Copiloto.Dominio.Vendas;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Conversa de parceiro fora da base de precedentes de venda (#85).
+///
+/// O risco nao e so de dado pessoal: se conversa com fornecedor entra no mesmo
+/// indice que conversa com cliente, o sistema pode recuperar uma negociacao de
+/// fornecimento — com margem e custo — enquanto o vendedor atende um comprador.
+/// </summary>
+public class DadosDeParceiroTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public DadosDeParceiroTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    private static Lead Cliente(string telefone = "+55 11 98888-1111") =>
+        new(Guid.NewGuid(), telefone, T0, "Marina");
+
+    private static Lead Parceiro(string telefone = "+55 35 98888-2222")
+    {
+        var lead = new Lead(Guid.NewGuid(), telefone, T0, "Fazenda Serra Alta");
+        lead.MarcarComo(Relacao.Parceiro);
+        return lead;
+    }
+
+    [Fact]
+    public void Lead_nasce_cliente()
+    {
+        // Errar para esse lado e menos grave: cliente marcado como parceiro
+        // perde recurso; parceiro marcado como cliente vaza margem.
+        Assert.Equal(Relacao.Cliente, Cliente().Relacao);
+    }
+
+    [Fact]
+    public void Conversa_de_parceiro_nao_entra_na_base_de_precedentes()
+    {
+        Assert.True(BaseDePrecedentes.PodeIndexar(Cliente()));
+        Assert.False(BaseDePrecedentes.PodeIndexar(Parceiro()));
+    }
+
+    [Fact]
+    public void Precedente_de_parceiro_nunca_sai_para_atendimento_de_cliente()
+    {
+        // O criterio concreto da issue: margem e custo do fornecedor perto de
+        // um comprador.
+        var comprador = Cliente();
+        var candidatos = new[]
+        {
+            (Origem: Cliente("+55 11 97777-0001"), Texto: "fechou com 8% em 5kg"),
+            (Origem: Parceiro(), Texto: "compramos o lote a R$ 32 o quilo"),
+        };
+
+        var permitidos = BaseDePrecedentes.Filtrar(candidatos, c => c.Origem, comprador);
+
+        Assert.Single(permitidos);
+        Assert.DoesNotContain(permitidos, p => p.Texto.Contains("R$ 32"));
+    }
+
+    [Fact]
+    public void Atendimento_de_parceiro_nao_recebe_precedente_de_cliente()
+    {
+        // A direcao contraria do mesmo vazamento: o dossie de um fornecedor
+        // recheado com conversas de clientes.
+        var fornecedor = Parceiro();
+        var candidatos = new[] { (Origem: Cliente(), Texto: "cliente fechou 3kg") };
+
+        Assert.Empty(BaseDePrecedentes.Filtrar(candidatos, c => c.Origem, fornecedor));
+    }
+
+    [Fact]
+    public void Nao_ha_flag_para_ligar_parceiro_no_indice_de_vendas()
+    {
+        // "Salvo decisao explicita" nao virou parametro: flag assim e ligada
+        // uma vez e nunca mais revisada. Se houver base de precedentes de
+        // COMPRA, ela e outra base — nao esta com um booleano invertido.
+        var metodos = typeof(BaseDePrecedentes).GetMethods()
+            .SelectMany(m => m.GetParameters())
+            .Select(p => p.ParameterType);
+
+        Assert.DoesNotContain(typeof(bool), metodos);
+    }
+
+    [Fact]
+    public void A_relacao_sobrevive_ao_banco()
+    {
+        // Se a relacao se perdesse no restart, o isolamento valeria ate a
+        // proxima subida — e o vazamento voltaria sem ninguem mexer em nada.
+        var id = Guid.NewGuid();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var lead = new Lead(id, "+55 35 98888-2222", T0, "Fazenda Serra Alta");
+            lead.MarcarComo(Relacao.Parceiro);
+            ctx.Leads.Add(lead);
+            ctx.Leads.Add(Cliente());
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.Equal(Relacao.Parceiro, leitura.Leads.Single(l => l.Id == id).Relacao);
+        Assert.Single(leitura.Leads.Where(l => l.Relacao == Relacao.Cliente));
+    }
+
+    [Fact]
+    public void Da_para_consultar_parceiros_separado_no_banco()
+    {
+        // Escopo de acesso separado comeca por conseguir SEPARAR na consulta:
+        // sem isso, "so leads de cliente" viraria filtro em memoria, e filtro
+        // em memoria e o que alguem esquece na proxima tela.
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            ctx.Leads.Add(Parceiro());
+            ctx.Leads.Add(Parceiro("+55 35 98888-3333"));
+            ctx.Leads.Add(Cliente());
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.Equal(2, leitura.Leads.Count(l => l.Relacao == Relacao.Parceiro));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `84-incidente-e-auditoria` (#84).

## O que muda
`Lead.Relacao` (Cliente | Parceiro) e a regra de quem entra no indice de precedentes.

## Decisoes
- A regra ficou no DOMINIO, antes do RAG existir: nascendo junto da indexacao, nasceria como filtro de consulta — esquecido na segunda consulta.
- O filtro vale nos DOIS sentidos.
- Sem flag "incluir parceiros": ha teste por reflexao garantindo que nenhum metodo aceite bool.
- Migration: o default gerado era string vazia, que nao e valor do enum — trocado por Cliente com UPDATE explicito.

Closes #85