### PR TITLE
Medir o catalogo antes de decidir se merece RAG

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -249,6 +249,30 @@ Fichas técnicas, notas de degustação, origem, torra, moagem recomendada. Vale
 **se** o catálogo for grande o bastante para não caber no contexto. Com poucos
 produtos, é mais barato e mais confiável mandar o catálogo inteiro.
 
+**Medido (#63), e a decisão é "não agora".** Com a ficha completa — variedade, origem,
+notas, torra, moagem e harmonização — o catálogo do seed dá:
+
+| Medida | Valor |
+|---|---|
+| Produtos | 3 |
+| Tokens estimados (~4 caracteres/token) | 179 |
+| Tokens por produto | 60 |
+| Teto, dentro da fatia do catálogo em C1 (60% de 800) | **8 produtos** |
+
+Cabe, então **manda inteiro, sem RAG**: trocar uma solução exata por uma aproximada,
+pagando latência, custo de embedding e reindexação, não se justifica por 179 tokens.
+
+O número que interessa não é o 179 — é o **8**. Uma torrefação com dez ou vinte cafés no
+catálogo é comum, e a conta estoura antes do que a intuição diz. Por isso há um teste que
+**falha quando o catálogo passa do teto**: no dia em que passar, "sem RAG" deixa de valer
+por medida, e não porque alguém lembrou de reabrir a issue.
+
+E quando passar, RAG ainda não é o primeiro passo. A mesma conta com a **ficha curta**
+(nome, notas e moagem) dá 27 tokens por produto e teto de **17** — e o passo seguinte é
+filtrar por característica antes de mandar ("doce, para espresso" seleciona por moagem e
+nota), o que continua sendo solução exata e custa uma comparação de string. RAG entra
+depois disso, se entrar.
+
 Critério de decisão, não de gosto: se o catálogo cabe no orçamento de tokens, não
 há RAG.
 

--- a/seed/catalogo.json
+++ b/seed/catalogo.json
@@ -1,0 +1,40 @@
+{
+  "_comentario": [
+    "Fichas de produto do cenario de cafe, usadas para MEDIR o catalogo (#63).",
+    "Dados ficticios, no formato que uma torrefacao pequena realmente mantem:",
+    "variedade, origem, notas, torra, moagem e harmonizacao.",
+    "",
+    "A ficha aqui e deliberadamente COMPLETA. Medir com ficha curta daria um",
+    "numero otimista e a decisao sairia errada — o catalogo real de quem vende",
+    "cafe especial tem nota de degustacao, e e ela que ocupa espaco."
+  ],
+  "produtos": [
+    {
+      "nome": "Bourbon Amarelo",
+      "variedade": "Bourbon Amarelo",
+      "origem": "Serra da Mantiqueira, MG — 1.150m",
+      "notas": "caramelo, castanha-do-para e um final de laranja",
+      "torra": "media",
+      "moagem": "media, para coador de papel e prensa",
+      "harmonizacao": "pao de queijo, bolo simples, sobremesa com doce de leite"
+    },
+    {
+      "nome": "Catuai Vermelho",
+      "variedade": "Catuai Vermelho",
+      "origem": "Sul de Minas, Carmo de Minas — 1.000m",
+      "notas": "chocolate ao leite, amendoa e corpo alto",
+      "torra": "media escura",
+      "moagem": "fina, para espresso e moka",
+      "harmonizacao": "leite, doces com chocolate, comeco de manha"
+    },
+    {
+      "nome": "Geisha Microlote",
+      "variedade": "Geisha",
+      "origem": "Chapada Diamantina, BA — 1.300m, lote de 60kg",
+      "notas": "jasmim, bergamota e mel, acidez citrica marcante",
+      "torra": "clara",
+      "moagem": "media grossa, para metodos filtrados",
+      "harmonizacao": "sozinho, sem leite e sem acucar"
+    }
+  ]
+}

--- a/src/Copiloto.Api/Ingestao/CatalogoGravado.cs
+++ b/src/Copiloto.Api/Ingestao/CatalogoGravado.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Copiloto.Dominio.Produtos;
+
+namespace Copiloto.Api.Ingestao;
+
+/// <summary>
+/// O catalogo do `seed/catalogo.json`, no formato em que ele esta no arquivo.
+///
+/// Mora ao lado do `ConversaGravada` pelo mesmo motivo: o dominio nao le
+/// arquivo nem conhece JSON, e o seed e material de demonstracao — nao e
+/// cadastro de produto, que seria tela e banco (fora de escopo hoje).
+/// </summary>
+public record CatalogoGravado(IReadOnlyList<FichaDeProduto> Produtos)
+{
+    private static readonly JsonSerializerOptions Opcoes = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public static Catalogo Ler(string json)
+    {
+        var gravado = JsonSerializer.Deserialize<CatalogoGravado>(json, Opcoes)
+            ?? throw new InvalidOperationException("catalogo vazio");
+
+        return new Catalogo(gravado.Produtos);
+    }
+
+    public static Catalogo DoArquivo(string caminho)
+    {
+        if (!File.Exists(caminho))
+            throw new FileNotFoundException(
+                $"Catalogo nao encontrado em {caminho}. Ele e o que a medicao da #63 "
+                + "usa para decidir se o contexto aguenta o catalogo inteiro.", caminho);
+
+        return Ler(File.ReadAllText(caminho));
+    }
+}

--- a/src/Copiloto.Dominio/Produtos/Catalogo.cs
+++ b/src/Copiloto.Dominio/Produtos/Catalogo.cs
@@ -1,0 +1,84 @@
+namespace Copiloto.Dominio.Produtos;
+
+/// <summary>A ficha de um produto, como a torrefacao a mantem.</summary>
+public record FichaDeProduto(
+    string Nome,
+    string Variedade,
+    string Origem,
+    string Notas,
+    string Torra,
+    string Moagem,
+    string Harmonizacao)
+{
+    /// <summary>A ficha como uma linha de contexto.</summary>
+    public string ParaContexto() =>
+        $"- {Nome} ({Variedade}, {Origem}): {Notas}. Torra {Torra}; moagem {Moagem}. "
+        + $"Harmoniza com {Harmonizacao}.";
+}
+
+/// <summary>
+/// O catalogo, e a conta que decide se ele precisa de RAG (#63).
+///
+/// A pergunta nao e "RAG e melhor?", e "o catalogo CABE no contexto?". Se cabe,
+/// mandar inteiro e uma solucao exata; trocar por busca por similaridade seria
+/// pagar latencia, custo de embedding e reindexacao para receber uma resposta
+/// aproximada no lugar de uma certa.
+///
+/// Por isso a classe existe antes de qualquer decisao: ela devolve o numero.
+/// </summary>
+public class Catalogo
+{
+    /// <summary>
+    /// O orcamento da camada C1 (ARQUITETURA secao 2), onde o catalogo entra
+    /// junto do playbook. Nao e o orcamento do catalogo sozinho — o playbook
+    /// tambem come dali, e por isso a conta usa uma folga.
+    /// </summary>
+    public const int OrcamentoC1EmTokens = 800;
+
+    /// <summary>
+    /// Quanto de C1 o catalogo pode ocupar. Os 40% restantes sao do playbook
+    /// (tom, politica de desconto, o jeito da casa), que e a parte que a
+    /// empresa escreve e nao pode ser espremida por causa do produto.
+    /// </summary>
+    public const double FatiaDoCatalogo = 0.6;
+
+    private readonly IReadOnlyList<FichaDeProduto> _produtos;
+
+    public Catalogo(IReadOnlyList<FichaDeProduto> produtos)
+    {
+        ArgumentNullException.ThrowIfNull(produtos);
+        _produtos = produtos;
+    }
+
+    public IReadOnlyList<FichaDeProduto> Produtos => _produtos;
+
+    public string ParaContexto() =>
+        string.Join("\n", _produtos.Select(p => p.ParaContexto()));
+
+    /// <summary>
+    /// Estimativa por ~4 caracteres/token, a mesma razao que a <c>CamadaC2</c>
+    /// usa. E ESTIMATIVA: a conta exata depende do tokenizador de cada modelo,
+    /// e chamar o provedor so para contar seria pagar para saber quanto se vai
+    /// pagar. Serve para decidir ordem de grandeza, que e o que esta em jogo.
+    /// </summary>
+    public int TokensEstimados() => (int)Math.Ceiling(ParaContexto().Length / 4.0);
+
+    public int TokensPorProduto() =>
+        _produtos.Count == 0 ? 0 : (int)Math.Ceiling((double)TokensEstimados() / _produtos.Count);
+
+    /// <summary>
+    /// Quantos produtos ainda cabem mandando o catalogo inteiro. E o numero que
+    /// a decisao da issue depende, e o que a torna revisavel: no dia em que o
+    /// catalogo passar disso, "sem RAG" deixa de valer por medida, e nao por
+    /// alguem ter achado.
+    /// </summary>
+    public int ProdutosQueCabem()
+    {
+        var porProduto = TokensPorProduto();
+        if (porProduto == 0) return int.MaxValue;
+
+        return (int)(OrcamentoC1EmTokens * FatiaDoCatalogo) / porProduto;
+    }
+
+    public bool CabeNoContexto() => _produtos.Count <= ProdutosQueCabem();
+}

--- a/testes/Copiloto.Testes/CatalogoTeste.cs
+++ b/testes/Copiloto.Testes/CatalogoTeste.cs
@@ -1,0 +1,104 @@
+using System.Reflection;
+using Copiloto.Api.Ingestao;
+using Copiloto.Dominio.Produtos;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A medicao que decide se o catalogo merece RAG (#63).
+///
+/// A issue podia legitimamente terminar em "nao vamos fazer", e terminou. O que
+/// a torna honesta e o numero: adicionar RAG a um catalogo que cabe no contexto
+/// e trocar uma solucao exata por uma aproximada, pagando latencia, custo de
+/// embedding e reindexacao pela troca.
+/// </summary>
+public class CatalogoTeste
+{
+    private static Catalogo DoSeed() => CatalogoGravado.DoArquivo(
+        Path.Combine(RaizDoRepositorio(), "seed", "catalogo.json"));
+
+    [Fact]
+    public void O_catalogo_do_seed_cabe_no_contexto()
+    {
+        // O gate da decisao. No dia em que o catalogo passar do que cabe, ESTE
+        // teste falha — e ai "sem RAG" deixa de valer por medida, nao porque
+        // alguem lembrou de reabrir a issue.
+        var catalogo = DoSeed();
+
+        Assert.True(catalogo.CabeNoContexto(),
+            $"O catalogo tem {catalogo.Produtos.Count} produtos e "
+            + $"{catalogo.TokensEstimados()} tokens estimados, e o teto e "
+            + $"{catalogo.ProdutosQueCabem()} produtos. Passou do ponto em que "
+            + "mandar inteiro ainda era a solucao exata: reabra a #63 com estes "
+            + "numeros antes de escolher RAG.");
+    }
+
+    [Fact]
+    public void A_medicao_que_sustenta_a_decisao_esta_aqui()
+    {
+        // Os numeros da #63, presos ao build. Se a ficha de produto mudar de
+        // formato, este teste falha e a decisao volta para a mesa com o numero
+        // novo — que e' o unico jeito de "medimos e decidimos" nao virar
+        // folclore seis meses depois.
+        var catalogo = DoSeed();
+
+        Assert.Equal(3, catalogo.Produtos.Count);
+        Assert.Equal(179, catalogo.TokensEstimados());
+        Assert.Equal(60, catalogo.TokensPorProduto());
+        Assert.Equal(8, catalogo.ProdutosQueCabem());
+    }
+
+    [Fact]
+    public void A_medicao_devolve_numero_por_produto()
+    {
+        // E o numero que extrapola: a decisao nao vale so para os tres produtos
+        // do seed, vale para "quantos produtos esta empresa pode ter".
+        var catalogo = DoSeed();
+
+        Assert.InRange(catalogo.TokensPorProduto(), 20, 200);
+        Assert.True(catalogo.ProdutosQueCabem() >= catalogo.Produtos.Count);
+    }
+
+    [Fact]
+    public void Catalogo_grande_nao_cabe_e_a_conta_diz_isso()
+    {
+        // A conta precisa saber dizer NAO, senao ela e decoracao.
+        var muitos = Enumerable.Range(0, 200).Select(i => new FichaDeProduto(
+            $"Cafe {i}", "Bourbon", "Sul de Minas, 1.000m",
+            "chocolate e castanha", "media", "media", "pao de queijo")).ToList();
+
+        Assert.False(new Catalogo(muitos).CabeNoContexto());
+    }
+
+    [Fact]
+    public void Catalogo_vazio_nao_quebra_a_conta()
+    {
+        var vazio = new Catalogo([]);
+
+        Assert.Equal(0, vazio.TokensEstimados());
+        Assert.True(vazio.CabeNoContexto());
+    }
+
+    [Fact]
+    public void A_ficha_leva_ao_contexto_o_que_o_vendedor_usa_para_vender()
+    {
+        // Nome sozinho nao responde "qual voces indicam para espresso doce?",
+        // que e a pergunta real do balcao.
+        var linha = DoSeed().Produtos[0].ParaContexto();
+
+        Assert.Contains("caramelo", linha);
+        Assert.Contains("moagem", linha);
+        Assert.Contains("Harmoniza", linha);
+    }
+
+    private static string RaizDoRepositorio()
+    {
+        var raiz = typeof(CatalogoTeste).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "RaizDoRepositorio")
+            ?.Value;
+
+        Assert.False(string.IsNullOrWhiteSpace(raiz), "Metadado RaizDoRepositorio ausente.");
+        return raiz!;
+    }
+}


### PR DESCRIPTION
## O que muda
`seed/catalogo.json`, a conta que decide, e a decisao: **nao fazer RAG agora**.

## Os numeros
3 produtos, 179 tokens, 60 por produto, **teto de 8 produtos**. A medicao esta comentada na issue.

## Decisao
Medir mudou a conclusao: o teto de 8 estoura antes do que a intuicao diz para uma torrefacao com dez ou vinte cafes. Por isso ha teste que FALHA quando o catalogo passa do teto, e os quatro numeros estao fixados em assert.

E quando passar, RAG nao e o primeiro passo: ficha curta da teto de 17, e filtrar por caracteristica continua sendo solucao exata.

Closes #63