### PR TITLE
Agente Vigia em job agendado

### DIFF
--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -169,6 +169,36 @@ não confiável, nunca como instrução. Há teste dedicado com payloads de inje
 
 ---
 
+## 8.5 O Vigia: o trabalho que ninguém pede
+
+Negócio esquecido **não gera evento**. Não abre tela, não chega por webhook, não vira
+requisição — ele só fica parado, e é a forma mais barata de perder venda já qualificada.
+Por isso o agente A6 tem o relógio como gatilho, e não o request (#53).
+
+Três motivos, cada um preso a um dado: cliente sem responder há 3 dias (cita a última
+fala dele), negócio parado no mesmo estágio há 10, e proposta na mesa há 5 — o limiar da
+proposta é menor porque cada dia sem resposta ali é uma comparação a mais com a
+concorrência. Quando os dois últimos coincidem, sai **um** alerta: quem está em Proposta
+há 12 dias também está "parado há 12 dias", e mandar as duas linhas cobra em dobro a
+atenção do vendedor pelo mesmo fato.
+
+**A varredura é determinística e não chama modelo.** Silêncio e tempo em estágio são
+contas de data; gastar token para descobrir que faz nove dias que ninguém fala seria pagar
+para fazer subtração. O custo do A6 no ledger só aparece quando ele passar a redigir o
+aviso com um modelo — e aí é invocação como outra qualquer, ligada ao Deal.
+
+O defeito mais caro aqui não é o falso positivo: é **repetir**. Aviso repetido treina o
+vendedor a fechar a lista sem ler, e aí o alerta certo, quando vier, também não é lido. A
+chave de deduplicação inclui o **marco** — a data do dado que originou o alerta —, e não
+só o motivo: o job roda de hora em hora sem repetir, mas se o cliente volta a falar e
+some de novo, o silêncio passa a contar de outra fala e aquilo é outro acontecimento.
+
+Hoje o conjunto de avisados vive na memória do processo, o que significa alerta duplicado
+com duas réplicas e lista reavisada depois de um restart. É limitação declarada, com o
+lugar certo já nomeado: o estado compartilhado da #66/#67.
+
+---
+
 ## 9. O ledger e a conta fechada
 
 `ai_invocations` registra por chamada: agente, modelo, tokens de entrada e saída, custo

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/DealMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/DealMap.cs
@@ -13,6 +13,7 @@ public class DealMap : IEntityTypeConfiguration<Deal>
         e.Property(d => d.LeadId).IsRequired();
         e.Property(d => d.AbertoEm).IsRequired();
         e.Property(d => d.Estagio).HasConversion<string>().HasMaxLength(20).IsRequired();
+        e.Property(d => d.EstagioDesde).IsRequired();
         e.Property(d => d.FechadoEm);
 
         // Dinheiro em `decimal(18,6)`, nunca em ponto flutuante: seis casas

--- a/src/Copiloto.Api/Persistencia/Migrations/20260903233516_EstagioDesdeNoDeal.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260903233516_EstagioDesdeNoDeal.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903233516_EstagioDesdeNoDeal")]
+    partial class EstagioDesdeNoDeal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260903233516_EstagioDesdeNoDeal.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260903233516_EstagioDesdeNoDeal.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class EstagioDesdeNoDeal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // O default gerado e DateTimeOffset.MinValue (ano 1), e para linha
+            // existente isso nao e "vazio": e "parado ha dois mil anos". O Vigia
+            // (#53) alertaria o funil inteiro na primeira passagem, e o vendedor
+            // aprenderia no primeiro dia a ignorar a lista.
+            //
+            // O backfill usa AbertoEm porque e a unica data verdadeira que
+            // temos: o negocio esteve no estagio atual, no minimo, desde que
+            // abriu. Erra para o lado seguro — alerta cedo demais, nunca tarde.
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "EstagioDesde",
+                table: "deals",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.Sql(
+                "UPDATE deals SET \"EstagioDesde\" = \"AbertoEm\" "
+                + "WHERE \"EstagioDesde\" = '0001-01-01T00:00:00Z';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EstagioDesde",
+                table: "deals");
+        }
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,6 +1,7 @@
 using Copiloto.Api.Ia;
 using Copiloto.Api.Ingestao;
 using Copiloto.Api.Persistencia;
+using Copiloto.Api.Vigia;
 using Copiloto.Dominio.Ia;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +27,10 @@ builder.Services.AddSingleton<FilaDeMensagens>();
 builder.Services.AddSingleton(_ => new ResolvedorDeLead(
     builder.Configuration["WHATSAPP_NUMERO_EMPRESA"] ?? "+55 11 3333-4444"));
 builder.Services.AddHostedService<ProcessadorDeMensagens>();
+
+// O Vigia roda pelo relogio, e nao por requisicao: negocio esquecido nao gera
+// evento nenhum — ele so fica parado (#53).
+builder.Services.AddHostedService<JobDoVigia>();
 
 var app = builder.Build();
 

--- a/src/Copiloto.Api/Vigia/JobDoVigia.cs
+++ b/src/Copiloto.Api/Vigia/JobDoVigia.cs
@@ -1,0 +1,112 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Vigia;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Api.Vigia;
+
+/// <summary>
+/// O Vigia rodando sozinho, fora do ciclo request/response (#53).
+///
+/// Nenhum vendedor pede este trabalho: negocio esquecido nao gera evento, nao
+/// abre tela e nao chega por webhook — ele so fica parado. Por isso o gatilho e
+/// o relogio, e nao uma requisicao.
+/// </summary>
+public class JobDoVigia : BackgroundService
+{
+    /// <summary>
+    /// De hora em hora. A varredura e de datas, entao o custo e de banco e nao
+    /// de modelo — mas rodar de minuto em minuto encheria o log com o mesmo
+    /// alerta que ja foi dado, e a dedupe nao existe para justificar polling
+    /// desnecessario.
+    /// </summary>
+    public static readonly TimeSpan Intervalo = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// O que ja foi avisado, nesta instancia.
+    ///
+    /// Em memoria, e isso e LIMITACAO DECLARADA: com duas replicas o vendedor
+    /// recebe o mesmo alerta duas vezes, e um restart faz a lista inteira ser
+    /// reavisada. O lugar certo e o estado compartilhado (#66/#67); enquanto ele
+    /// nao existe, o conjunto fica aqui e o comentario fica junto — premissa
+    /// nao declarada e o que quebra no primeiro deploy com replica.
+    /// </summary>
+    private readonly HashSet<string> _jaAvisados = new();
+
+    private readonly IServiceScopeFactory _escopos;
+    private readonly ILogger<JobDoVigia> _log;
+
+    public JobDoVigia(IServiceScopeFactory escopos, ILogger<JobDoVigia> log)
+    {
+        _escopos = escopos;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        using var relogio = new PeriodicTimer(Intervalo);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var escopo = _escopos.CreateScope();
+                var ctx = escopo.ServiceProvider.GetRequiredService<CopilotoDbContext>();
+
+                foreach (var alerta in await Varrer(ctx, DateTimeOffset.UtcNow, ct))
+                {
+                    // O alerta vai para o log ate a tela existir (#50): o valor
+                    // ja e verificavel, e prender a varredura ao SignalR faria
+                    // uma issue depender da outra sem motivo.
+                    _log.LogInformation(
+                        "Vigia · {Motivo} no deal {Deal}: {Texto}",
+                        alerta.Motivo, alerta.DealId, alerta.Texto);
+                }
+            }
+            catch (Exception erro) when (erro is not OperationCanceledException)
+            {
+                // Job que morre no primeiro erro para de vigiar em silencio, que
+                // e o mesmo desfecho de nao existir.
+                _log.LogError(erro, "Vigia falhou nesta passagem; tenta de novo em {Intervalo}", Intervalo);
+            }
+
+            try
+            {
+                await relogio.WaitForNextTickAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Uma passagem da varredura. Publico e sem timer para o teste conseguir
+    /// chamar sem subir a aplicacao nem esperar uma hora.
+    /// </summary>
+    public async Task<IReadOnlyList<Alerta>> Varrer(
+        CopilotoDbContext ctx, DateTimeOffset agora, CancellationToken ct)
+    {
+        // Deals fechados nao entram na consulta, e nao so no filtro do dominio:
+        // e a diferenca entre varrer o funil ativo e varrer o historico inteiro
+        // da empresa toda hora.
+        var abertos = await ctx.Deals
+            .AsNoTracking()
+            .Where(d => d.FechadoEm == null)
+            .ToListAsync(ct);
+
+        if (abertos.Count == 0) return [];
+
+        var leads = abertos.Select(d => d.LeadId).ToList();
+        var conversas = await ctx.Conversas
+            .AsNoTracking()
+            .Include(c => c.Mensagens)
+            .Where(c => leads.Contains(c.LeadId))
+            .ToListAsync(ct);
+
+        var achados = abertos.SelectMany(deal => Dominio.Vigia.Vigia.Varrer(
+            deal, conversas.FirstOrDefault(c => c.LeadId == deal.LeadId), agora));
+
+        return Dominio.Vigia.Vigia.Novos(achados, _jaAvisados).ToList();
+    }
+}

--- a/src/Copiloto.Dominio/Vendas/Deal.cs
+++ b/src/Copiloto.Dominio/Vendas/Deal.cs
@@ -25,12 +25,23 @@ public class Deal
         LeadId = leadId;
         AbertoEm = abertoEm;
         Estagio = Estagio.Novo;
+        EstagioDesde = abertoEm;
     }
 
     public Guid Id { get; }
     public Guid LeadId { get; }
     public DateTimeOffset AbertoEm { get; }
     public Estagio Estagio { get; private set; }
+
+    /// <summary>
+    /// Quando o Deal entrou no estagio atual.
+    ///
+    /// Sem isto, "parado ha 12 dias" nao tem como ser dito: `AbertoEm` conta a
+    /// idade do negocio, e negocio de dois meses que andou ontem nao esta
+    /// parado. E o dado que o Vigia cita no alerta (#53).
+    /// </summary>
+    public DateTimeOffset EstagioDesde { get; private set; }
+
     public DateTimeOffset? FechadoEm { get; private set; }
 
     /// <summary>
@@ -71,6 +82,7 @@ public class Deal
                  + "de um em um, e estagio pulado e negocio sem qualificacao.";
 
         Estagio = destino;
+        EstagioDesde = quando;
         if (EstaFechado) FechadoEm = quando;
         return null;
     }

--- a/src/Copiloto.Dominio/Vigia/Vigia.cs
+++ b/src/Copiloto.Dominio/Vigia/Vigia.cs
@@ -1,0 +1,126 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Dominio.Vigia;
+
+/// <summary>Por que o Vigia chamou a atencao para este negocio.</summary>
+public enum MotivoDeAlerta
+{
+    /// <summary>O cliente parou de responder.</summary>
+    ClienteEmSilencio = 0,
+
+    /// <summary>O negocio nao anda de estagio ha tempo demais.</summary>
+    NegocioParado = 1,
+
+    /// <summary>Proposta na mesa esfriando.</summary>
+    PropostaEnvelhecendo = 2,
+}
+
+/// <summary>
+/// Um alerta do Vigia: o motivo, o negocio, e o DADO que o originou.
+///
+/// A citacao segue a mesma regra do sinal do dossie: sem ela, o alerta e
+/// opiniao do sistema e o vendedor so pode aceitar ou ignorar. Com ela, ele
+/// discorda com base em algo — "esse cliente respondeu por telefone ontem" — e
+/// o alerta vira conversa em vez de ruido.
+/// </summary>
+public record Alerta(MotivoDeAlerta Motivo, Guid DealId, string Texto, DateTimeOffset Marco)
+{
+    /// <summary>
+    /// A identidade do alerta para efeito de repeticao.
+    ///
+    /// Inclui o MARCO — a data do dado que o originou — e nao so o motivo. E o
+    /// que faz o job rodar de hora em hora sem repetir, e ao mesmo tempo
+    /// permite um alerta NOVO quando o cliente volta a falar e some de novo: o
+    /// silencio passa a contar de outra fala, o marco muda, e aquilo e outro
+    /// acontecimento.
+    /// </summary>
+    public string Chave => $"{DealId}:{Motivo}:{Marco:O}";
+}
+
+/// <summary>
+/// O agente A6, que varre em vez de responder (#53).
+///
+/// Prova que a orquestracao nao e so request/response: ha trabalho autonomo,
+/// agendado, que ninguem pediu — e resolve o problema real de negocio
+/// esquecido, que e a forma mais barata de perder venda ja qualificada.
+///
+/// A varredura e DETERMINISTICA e nao chama modelo: silencio e tempo em
+/// estagio sao contas de data. Gastar token para descobrir que faz nove dias
+/// que ninguem fala seria pagar para fazer subtracao.
+/// </summary>
+public static class Vigia
+{
+    public static readonly TimeSpan SilencioQuePreocupa = TimeSpan.FromDays(3);
+    public static readonly TimeSpan ParadoDemais = TimeSpan.FromDays(10);
+
+    /// <summary>
+    /// Proposta esfria mais rapido que negocio em qualificacao: o cliente
+    /// pediu preco, recebeu, e cada dia sem resposta e uma comparacao a mais
+    /// com a concorrencia.
+    /// </summary>
+    public static readonly TimeSpan PropostaEsfriando = TimeSpan.FromDays(5);
+
+    /// <summary>
+    /// O que merece a atencao do vendedor neste negocio, agora.
+    ///
+    /// Deal fechado nao gera alerta: ganho ou perdido, nao ha o que retomar, e
+    /// alerta sobre negocio encerrado e o tipo de ruido que ensina o vendedor a
+    /// ignorar a lista inteira.
+    /// </summary>
+    public static IEnumerable<Alerta> Varrer(Deal deal, Conversa? conversa, DateTimeOffset agora)
+    {
+        ArgumentNullException.ThrowIfNull(deal);
+
+        if (deal.EstaFechado) yield break;
+
+        var ultimaDoCliente = conversa?.UltimaDoCliente;
+        if (ultimaDoCliente is not null)
+        {
+            var silencio = agora - ultimaDoCliente.EnviadaEm;
+            if (silencio >= SilencioQuePreocupa)
+            {
+                yield return new Alerta(MotivoDeAlerta.ClienteEmSilencio, deal.Id,
+                    $"Cliente sem responder há {(int)silencio.TotalDays} dias. "
+                    + $"Última fala dele, em {ultimaDoCliente.EnviadaEm:dd/MM}: "
+                    + $"\"{ultimaDoCliente.Texto}\"",
+                    ultimaDoCliente.EnviadaEm);
+            }
+        }
+
+        var parado = agora - deal.EstagioDesde;
+
+        if (deal.Estagio == Estagio.Proposta && parado >= PropostaEsfriando)
+        {
+            yield return new Alerta(MotivoDeAlerta.PropostaEnvelhecendo, deal.Id,
+                $"Proposta na mesa há {(int)parado.TotalDays} dias, desde "
+                + $"{deal.EstagioDesde:dd/MM}. Cada dia é uma comparação a mais com a "
+                + "concorrência.",
+                deal.EstagioDesde);
+
+            // Um acontecimento, um alerta: quem esta em Proposta ha 12 dias
+            // tambem esta "parado ha 12 dias", e mandar as duas linhas seria o
+            // mesmo aviso cobrado em dobro da atencao do vendedor.
+            yield break;
+        }
+
+        if (parado >= ParadoDemais)
+        {
+            yield return new Alerta(MotivoDeAlerta.NegocioParado, deal.Id,
+                $"Parado em {deal.Estagio} há {(int)parado.TotalDays} dias, desde "
+                + $"{deal.EstagioDesde:dd/MM}.",
+                deal.EstagioDesde);
+        }
+    }
+
+    /// <summary>
+    /// Filtra o que ja foi avisado. `jaAvisados` guarda <see cref="Alerta.Chave"/>.
+    ///
+    /// Ficar de fora daqui e o defeito mais caro do Vigia, e nao e o falso
+    /// positivo: e repetir. Aviso repetido treina o vendedor a fechar a lista
+    /// sem ler, e ai o alerta certo, quando vier, tambem nao e lido.
+    /// </summary>
+    public static IEnumerable<Alerta> Novos(
+        IEnumerable<Alerta> alertas, ISet<string> jaAvisados) =>
+        alertas.Where(a => jaAvisados.Add(a.Chave));
+}

--- a/testes/Copiloto.Testes/VigiaNoBancoTeste.cs
+++ b/testes/Copiloto.Testes/VigiaNoBancoTeste.cs
@@ -1,0 +1,139 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Api.Vigia;
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+using Copiloto.Dominio.Vigia;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A varredura do Vigia contra o banco (#53).
+///
+/// O metodo e publico e sem timer justamente para isto: testar o job esperando
+/// uma hora seria testar o `PeriodicTimer`, nao a varredura.
+/// </summary>
+public class VigiaNoBancoTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public VigiaNoBancoTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    private static JobDoVigia Job() => new(new EscopoFalso(), NullLogger<JobDoVigia>.Instance);
+
+    /// <summary>O job so usa a fabrica no laco do timer; a varredura recebe o contexto.</summary>
+    private class EscopoFalso : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope() => throw new NotSupportedException(
+            "A varredura do teste recebe o DbContext direto, sem passar pelo laco.");
+    }
+
+    private Guid GravarDealComFala(string texto, DateTimeOffset falaEm, DateTimeOffset abertoEm)
+    {
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var leadId = Guid.NewGuid();
+        var lead = new Lead(leadId, "+55 11 98888-1111", abertoEm, "Marina");
+        var deal = new Deal(Guid.NewGuid(), leadId, abertoEm);
+        var conversa = new Conversa(Guid.NewGuid(), leadId);
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, texto, falaEm));
+
+        ctx.Leads.Add(lead);
+        ctx.Deals.Add(deal);
+        ctx.Conversas.Add(conversa);
+        ctx.SaveChanges();
+
+        return deal.Id;
+    }
+
+    [Fact]
+    public async Task A_varredura_acha_o_cliente_calado_no_banco()
+    {
+        var dealId = GravarDealComFala("vou pensar", T0, T0);
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var alertas = await Job().Varrer(ctx, T0.AddDays(5), default);
+
+        var alerta = Assert.Single(alertas);
+        Assert.Equal(dealId, alerta.DealId);
+        Assert.Equal(MotivoDeAlerta.ClienteEmSilencio, alerta.Motivo);
+        Assert.Contains("vou pensar", alerta.Texto);
+    }
+
+    [Fact]
+    public async Task A_segunda_passagem_nao_repete_o_que_ja_avisou()
+    {
+        // O job roda de hora em hora sobre os mesmos dados: repetir treinaria o
+        // vendedor a fechar a lista sem ler.
+        GravarDealComFala("vou pensar", T0, T0);
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var job = Job();
+
+        Assert.Single(await job.Varrer(ctx, T0.AddDays(5), default));
+        Assert.Empty(await job.Varrer(ctx, T0.AddDays(6), default));
+    }
+
+    [Fact]
+    public async Task Deal_fechado_nao_entra_nem_na_consulta()
+    {
+        var abertoEm = T0;
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var leadId = Guid.NewGuid();
+            var deal = new Deal(Guid.NewGuid(), leadId, abertoEm);
+            deal.MoverPara(Estagio.Ganho, abertoEm);
+
+            ctx.Leads.Add(new Lead(leadId, "+55 11 98888-2222", abertoEm, "Marina"));
+            ctx.Deals.Add(deal);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.Empty(await Job().Varrer(leitura, T0.AddDays(60), default));
+    }
+
+    [Fact]
+    public async Task Banco_vazio_nao_quebra_a_passagem()
+    {
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.Empty(await Job().Varrer(ctx, T0, default));
+    }
+
+    [Fact]
+    public async Task O_estagio_desde_sobrevive_ao_banco()
+    {
+        // Sem esta coluna, "parado ha 12 dias" nao teria como ser dito depois
+        // de um restart.
+        var id = Guid.NewGuid();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var leadId = Guid.NewGuid();
+            var deal = new Deal(id, leadId, T0);
+            deal.MoverPara(Estagio.Qualificacao, T0.AddDays(2));
+
+            ctx.Leads.Add(new Lead(leadId, "+55 11 98888-3333", T0, "Marina"));
+            ctx.Deals.Add(deal);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.Equal(T0.AddDays(2), leitura.Deals.Single(d => d.Id == id).EstagioDesde);
+    }
+}

--- a/testes/Copiloto.Testes/VigiaTeste.cs
+++ b/testes/Copiloto.Testes/VigiaTeste.cs
@@ -1,0 +1,191 @@
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Vendas;
+using Copiloto.Dominio.Vigia;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O agente A6, que varre em vez de responder (#53).
+///
+/// Negocio esquecido nao gera evento, nao abre tela e nao chega por webhook —
+/// ele so fica parado. E a forma mais barata de perder venda ja qualificada.
+/// </summary>
+public class VigiaTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static Deal DealNovo() => new(Guid.NewGuid(), Guid.NewGuid(), T0);
+
+    private static Conversa ComFalaDoCliente(string texto, DateTimeOffset quando)
+    {
+        var conversa = new Conversa(Guid.NewGuid(), Guid.NewGuid());
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, texto, quando));
+        return conversa;
+    }
+
+    [Fact]
+    public void Cliente_calado_ha_dias_vira_alerta_que_cita_a_ultima_fala()
+    {
+        // "Alerta cita o motivo e o dado que o originou": sem a citacao, o
+        // vendedor so pode aceitar ou ignorar — com ela, ele discorda.
+        var alertas = Vigia.Varrer(
+            DealNovo(), ComFalaDoCliente("vou pensar", T0), T0.AddDays(4)).ToList();
+
+        var silencio = Assert.Single(alertas, a => a.Motivo == MotivoDeAlerta.ClienteEmSilencio);
+        Assert.Contains("4 dias", silencio.Texto);
+        Assert.Contains("vou pensar", silencio.Texto);
+    }
+
+    [Fact]
+    public void Silencio_curto_nao_incomoda_ninguem()
+    {
+        var alertas = Vigia.Varrer(
+            DealNovo(), ComFalaDoCliente("vou pensar", T0), T0.AddHours(20));
+
+        Assert.Empty(alertas);
+    }
+
+    [Fact]
+    public void Negocio_parado_no_mesmo_estagio_vira_alerta()
+    {
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0);
+
+        var alertas = Vigia.Varrer(deal, conversa: null, T0.AddDays(11)).ToList();
+
+        var parado = Assert.Single(alertas);
+        Assert.Equal(MotivoDeAlerta.NegocioParado, parado.Motivo);
+        Assert.Contains("Qualificacao", parado.Texto);
+        Assert.Contains("11 dias", parado.Texto);
+    }
+
+    [Fact]
+    public void O_relogio_do_parado_conta_da_ultima_mudanca_e_nao_da_abertura()
+    {
+        // Negocio de dois meses que andou ontem NAO esta parado.
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0.AddDays(60));
+
+        Assert.Empty(Vigia.Varrer(deal, conversa: null, T0.AddDays(61)));
+    }
+
+    [Fact]
+    public void Proposta_esfria_mais_rapido_que_o_resto_do_funil()
+    {
+        // O cliente pediu preco, recebeu, e cada dia sem resposta e uma
+        // comparacao a mais com a concorrencia.
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0);
+        deal.MoverPara(Estagio.Proposta, T0);
+
+        var alertas = Vigia.Varrer(deal, conversa: null, T0.AddDays(6)).ToList();
+
+        Assert.Single(alertas, a => a.Motivo == MotivoDeAlerta.PropostaEnvelhecendo);
+    }
+
+    [Fact]
+    public void Proposta_velha_nao_gera_dois_alertas_pelo_mesmo_acontecimento()
+    {
+        // Quem esta em Proposta ha 12 dias tambem esta "parado ha 12 dias":
+        // mandar as duas linhas cobraria em dobro a atencao do vendedor pelo
+        // mesmo fato.
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0);
+        deal.MoverPara(Estagio.Proposta, T0);
+
+        var alertas = Vigia.Varrer(deal, conversa: null, T0.AddDays(12)).ToList();
+
+        Assert.Single(alertas);
+        Assert.Equal(MotivoDeAlerta.PropostaEnvelhecendo, alertas[0].Motivo);
+    }
+
+    [Fact]
+    public void Deal_fechado_nao_gera_alerta()
+    {
+        // Alerta sobre negocio encerrado e o ruido que ensina o vendedor a
+        // ignorar a lista inteira.
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0);
+        deal.MoverPara(Estagio.Proposta, T0);
+        deal.MoverPara(Estagio.Ganho, T0);
+
+        Assert.Empty(Vigia.Varrer(deal, ComFalaDoCliente("fechado!", T0), T0.AddDays(30)));
+    }
+
+    [Fact]
+    public void Deal_sem_conversa_ainda_e_vigiado_pelo_estagio()
+    {
+        var deal = DealNovo();
+        deal.MoverPara(Estagio.Qualificacao, T0);
+
+        Assert.NotEmpty(Vigia.Varrer(deal, conversa: null, T0.AddDays(15)));
+    }
+
+    // --- Nao avisar duas vezes ---
+
+    [Fact]
+    public void O_mesmo_alerta_nao_e_dado_duas_vezes()
+    {
+        // O job roda de hora em hora: sem isto, o vendedor recebe o mesmo aviso
+        // 24 vezes por dia e aprende a fechar a lista sem ler.
+        var deal = DealNovo();
+        var conversa = ComFalaDoCliente("vou pensar", T0);
+        var jaAvisados = new HashSet<string>();
+
+        var primeira = Vigia.Novos(Vigia.Varrer(deal, conversa, T0.AddDays(4)), jaAvisados);
+        Assert.Single(primeira);
+
+        var segunda = Vigia.Novos(Vigia.Varrer(deal, conversa, T0.AddDays(5)), jaAvisados);
+        Assert.Empty(segunda);
+    }
+
+    [Fact]
+    public void Cliente_que_volta_a_falar_e_some_de_novo_gera_alerta_novo()
+    {
+        // E o ponto do marco na chave: o silencio passa a contar de OUTRA fala,
+        // entao aquilo e outro acontecimento — nao a repeticao do anterior.
+        var deal = DealNovo();
+        var conversa = ComFalaDoCliente("vou pensar", T0);
+        var jaAvisados = new HashSet<string>();
+
+        Assert.Single(Vigia.Novos(Vigia.Varrer(deal, conversa, T0.AddDays(4)), jaAvisados));
+
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "voltei", T0.AddDays(5)));
+
+        Assert.Single(Vigia.Novos(Vigia.Varrer(deal, conversa, T0.AddDays(9)), jaAvisados));
+    }
+
+    [Fact]
+    public void Alertas_de_deals_diferentes_nao_se_cancelam()
+    {
+        var jaAvisados = new HashSet<string>();
+        var conversa = ComFalaDoCliente("vou pensar", T0);
+
+        Assert.Single(Vigia.Novos(Vigia.Varrer(DealNovo(), conversa, T0.AddDays(4)), jaAvisados));
+        Assert.Single(Vigia.Novos(Vigia.Varrer(DealNovo(), conversa, T0.AddDays(4)), jaAvisados));
+    }
+
+    [Fact]
+    public void O_deal_registra_desde_quando_esta_no_estagio()
+    {
+        var deal = DealNovo();
+        Assert.Equal(T0, deal.EstagioDesde);
+
+        deal.MoverPara(Estagio.Qualificacao, T0.AddDays(3));
+
+        Assert.Equal(T0.AddDays(3), deal.EstagioDesde);
+    }
+
+    [Fact]
+    public void Transicao_recusada_nao_mexe_no_relogio_do_estagio()
+    {
+        // Arrastar o card para um estagio invalido nao pode "zerar" o parado —
+        // seria uma forma silenciosa de o negocio nunca mais ser vigiado.
+        var deal = DealNovo();
+
+        // Novo -> Negociacao pula dois estagios, e o Deal recusa.
+        Assert.NotNull(deal.MoverPara(Estagio.Negociacao, T0.AddDays(5)));
+
+        Assert.Equal(T0, deal.EstagioDesde);
+    }
+}


### PR DESCRIPTION
## O que muda
Varredura por relogio: cliente calado, negocio parado e proposta esfriando. `Deal.EstagioDesde` entrou junto.

## Decisoes
- O defeito mais caro nao e o falso positivo, e REPETIR: a chave de dedupe inclui o marco (a data do dado), nao so o motivo.
- Proposta velha nao gera dois alertas pelo mesmo fato.
- A varredura nao chama modelo: silencio e tempo em estagio sao contas de data.
- Migration com backfill: o default seria o ano 1, e o Vigia alertaria o funil inteiro na primeira passagem.

## Limitacoes declaradas
Ja-avisados vive na memoria do processo (o lugar certo e #66/#67), e "proposta perto do vencimento" virou tempo no estagio porque nao existe entidade Proposta.

Closes #53