### PR TITLE
Uma classe de teste por arquivo, e um so lugar para o banco em memoria

### DIFF
--- a/testes/Copiloto.Testes/BancoEmMemoria.cs
+++ b/testes/Copiloto.Testes/BancoEmMemoria.cs
@@ -1,0 +1,54 @@
+using Copiloto.Api.Persistencia;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Um banco SQLite em memoria por classe de teste (#111).
+///
+/// SQLite e nao Postgres porque a suite roda offline por decisao do CLAUDE.md:
+/// teste que precisa de container para passar e teste que quebra no primeiro
+/// clone. O que se prova com ele e o MAPEAMENTO — que o modelo fecha, que
+/// chaves e indices existem e que o dominio sobrevive a ida e volta.
+///
+/// A conexao fica ABERTA pela vida da classe: fechada, o banco em memoria some
+/// junto, e o teste passaria a criar um banco novo a cada contexto sem que
+/// ninguem percebesse.
+///
+/// Existe porque o mesmo construtor de quatro linhas ja estava copiado em tres
+/// classes — a terceira aparicao e o gatilho de DRY do CLAUDE.md. Aqui a
+/// duplicacao NAO era acidental: se o setup mudar (outro provider, outra
+/// versao, um `EnsureDeleted`), muda para todas ao mesmo tempo.
+/// </summary>
+public abstract class BancoEmMemoria : IDisposable
+{
+    private readonly SqliteConnection _conexao;
+
+    protected BancoEmMemoria()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        Opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+
+        using var ctx = new CopilotoDbContext(Opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    protected DbContextOptions<CopilotoDbContext> Opcoes { get; }
+
+    /// <summary>
+    /// Um contexto novo sobre o MESMO banco.
+    ///
+    /// Contexto novo e o que aproxima o teste de um processo novo: o
+    /// ChangeTracker nasce vazio, entao o que voltar veio do banco, e nao da
+    /// memoria do contexto que gravou.
+    /// </summary>
+    protected CopilotoDbContext NovoContexto() => new(Opcoes);
+
+    public void Dispose()
+    {
+        _conexao.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/testes/Copiloto.Testes/DireitosDoTitularTeste.cs
+++ b/testes/Copiloto.Testes/DireitosDoTitularTeste.cs
@@ -4,8 +4,6 @@ using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Fichas;
 using Copiloto.Dominio.Titulares;
 using Copiloto.Dominio.Vendas;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 
 namespace Copiloto.Testes;
 
@@ -16,27 +14,13 @@ namespace Copiloto.Testes;
 /// sistema o classificou. Protege-se o dado que entrou e esquece-se o que o
 /// sistema produziu — e o segundo tambem e dado pessoal sobre ele.
 /// </summary>
-public class DireitosDoTitularTeste : IDisposable
+public class DireitosDoTitularTeste : BancoEmMemoria
 {
     private static readonly DateTimeOffset T0 = new(2026, 9, 3, 10, 0, 0, TimeSpan.Zero);
 
-    private readonly SqliteConnection _conexao;
-    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
-
-    public DireitosDoTitularTeste()
-    {
-        _conexao = new SqliteConnection("DataSource=:memory:");
-        _conexao.Open();
-        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Database.EnsureCreated();
-    }
-
-    public void Dispose() => _conexao.Dispose();
-
     private Guid GravarTitularCompleto()
     {
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
         var leadId = Guid.NewGuid();
 
         var lead = new Lead(leadId, "+55 11 98888-1111", T0, "Marina");
@@ -68,7 +52,7 @@ public class DireitosDoTitularTeste : IDisposable
     public async Task Confirmacao_responde_sim_ou_nao()
     {
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         Assert.True(await Exportador(ctx).Confirmar(leadId, default));
         Assert.False(await Exportador(ctx).Confirmar(Guid.NewGuid(), default));
@@ -78,7 +62,7 @@ public class DireitosDoTitularTeste : IDisposable
     public async Task O_acesso_traz_conversa_ficha_e_negocio()
     {
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         var dados = await Exportador(ctx).Exportar(leadId, default);
 
@@ -95,7 +79,7 @@ public class DireitosDoTitularTeste : IDisposable
         // Ver "anotaram uma IMPRESSAO de que eu pareco desconfiada" e outra
         // coisa de ver uma lista de campos (#88).
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         var dados = await Exportador(ctx).Exportar(leadId, default);
 
@@ -111,7 +95,7 @@ public class DireitosDoTitularTeste : IDisposable
         // tudo. O dossie e recalculado, e ele precisa saber disso para poder
         // contestar a CONCLUSAO, e nao so o dado.
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         var dados = await Exportador(ctx).Exportar(leadId, default);
 
@@ -123,7 +107,7 @@ public class DireitosDoTitularTeste : IDisposable
     public async Task O_titular_recebe_com_quem_o_dado_foi_compartilhado()
     {
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         var dados = await Exportador(ctx).Exportar(leadId, default);
 
@@ -136,7 +120,7 @@ public class DireitosDoTitularTeste : IDisposable
         // Devolver um JSON com campos em branco pareceria "temos um cadastro
         // seu, mas esta vazio" — que e uma resposta errada, e nao uma resposta
         // pobre.
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         Assert.Null(await Exportador(ctx).Exportar(Guid.NewGuid(), default));
         Assert.Null(await Exportador(ctx).ExportarComoJson(Guid.NewGuid(), default));
@@ -148,7 +132,7 @@ public class DireitosDoTitularTeste : IDisposable
     public async Task A_portabilidade_sai_em_json_legivel_por_maquina_e_por_gente()
     {
         var leadId = GravarTitularCompleto();
-        using var ctx = new CopilotoDbContext(_opcoes);
+        using var ctx = NovoContexto();
 
         var json = await Exportador(ctx).ExportarComoJson(leadId, default);
 
@@ -214,14 +198,14 @@ public class DireitosDoTitularTeste : IDisposable
     {
         // "Parem de me analisar" que vale ate a proxima subida nao e oposicao.
         var leadId = GravarTitularCompleto();
-        using (var ctx = new CopilotoDbContext(_opcoes))
+        using (var ctx = NovoContexto())
         {
             var lead = ctx.Leads.Single(l => l.Id == leadId);
             lead.OporSeAAnalise(T0);
             ctx.SaveChanges();
         }
 
-        using var leitura = new CopilotoDbContext(_opcoes);
+        using var leitura = NovoContexto();
 
         Assert.True(leitura.Leads.Single(l => l.Id == leadId).AnaliseDeIaSuspensa);
         Assert.True((await Exportador(leitura).Exportar(leadId, default))!.AnaliseDeIaSuspensa);

--- a/testes/Copiloto.Testes/FichaNoBancoTeste.cs
+++ b/testes/Copiloto.Testes/FichaNoBancoTeste.cs
@@ -1,0 +1,107 @@
+using Copiloto.Api.Persistencia;
+using Fichas = Copiloto.Dominio.Fichas;
+
+namespace Copiloto.Testes;
+
+/// <summary>A Ficha do Cliente atravessando o banco (#86).</summary>
+public class FichaNoBancoTeste : BancoEmMemoria
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void A_ficha_volta_com_os_campos_preenchidos()
+    {
+        var id = Guid.NewGuid();
+        using (var ctx = NovoContexto())
+        {
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0,
+                empresa: new Fichas.SobreAEmpresa(Ramo: Fichas.Anotacao.Fato("cafeteria"), Porte: Fichas.Anotacao.Fato("3 lojas")),
+                pessoa: new Fichas.SobreAPessoa(Cargo: Fichas.Anotacao.Fato("sócio")));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = NovoContexto();
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.Equal("cafeteria", lida.Empresa.Ramo!.Valor);
+        Assert.Equal("3 lojas", lida.Empresa.Porte!.Valor);
+        Assert.Equal("sócio", lida.Pessoa.Cargo!.Valor);
+        Assert.False(lida.EstaVazia);
+    }
+
+    [Fact]
+    public void O_historico_sobrevive_ao_banco()
+    {
+        // "Ele era o decisor e agora nao e" so vale se durar mais que a sessao.
+        var id = Guid.NewGuid();
+        using (var ctx = NovoContexto())
+        {
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("decisor")));
+            ficha.Atualizar(T0.AddDays(2), pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("influenciador")));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = NovoContexto();
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.Equal(2, lida.Historico.Count);
+        Assert.Equal("decisor", lida.Historico[0].Pessoa.PapelNaDecisao!.Valor);
+    }
+
+    [Fact]
+    public void Ficha_vazia_e_gravavel()
+    {
+        // O sistema funciona sem ela, e "funciona" inclui salvar.
+        using var ctx = NovoContexto();
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), Guid.NewGuid(), T0));
+
+        ctx.SaveChanges();
+
+        Assert.True(ctx.Fichas.Single().EstaVazia);
+    }
+
+    [Fact]
+    public void A_natureza_da_anotacao_sobrevive_ao_banco()
+    {
+        // O conversor JSON e' quem reconstroi a Anotacao na leitura, e se ele
+        // errasse a natureza a impressao voltaria do banco como FATO — sem
+        // erro, sem log, e ancorando preco na proxima analise.
+        var id = Guid.NewGuid();
+        using (var ctx = NovoContexto())
+        {
+            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
+            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(
+                Cargo: Fichas.Anotacao.Fato("sócio", "LinkedIn"),
+                EstiloObservado: Fichas.Anotacao.Impressao("parece desconfiado", T0)));
+            ctx.Fichas.Add(ficha);
+            ctx.SaveChanges();
+        }
+
+        using var leitura = NovoContexto();
+        var lida = leitura.Fichas.Single(f => f.Id == id);
+
+        Assert.True(lida.Pessoa.Cargo!.EhFato);
+        Assert.Equal("LinkedIn", lida.Pessoa.Cargo!.Fonte);
+        Assert.False(lida.Pessoa.EstiloObservado!.EhFato);
+        Assert.Equal(T0, lida.Pessoa.EstiloObservado!.Quando);
+        Assert.Single(lida.Impressoes);
+    }
+
+    [Fact]
+    public void Um_lead_nao_tem_duas_fichas()
+    {
+        // Duas seriam duas versoes da verdade sem criterio de desempate.
+        var lead = Guid.NewGuid();
+        using var ctx = NovoContexto();
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+        ctx.SaveChanges();
+
+        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
+
+        Assert.Throws<DbUpdateException>(() => ctx.SaveChanges());
+    }
+}

--- a/testes/Copiloto.Testes/FichaNoBancoTeste.cs
+++ b/testes/Copiloto.Testes/FichaNoBancoTeste.cs
@@ -1,4 +1,5 @@
 using Copiloto.Api.Persistencia;
+using Microsoft.EntityFrameworkCore;
 using Fichas = Copiloto.Dominio.Fichas;
 
 namespace Copiloto.Testes;

--- a/testes/Copiloto.Testes/PersistenciaTeste.cs
+++ b/testes/Copiloto.Testes/PersistenciaTeste.cs
@@ -3,9 +3,7 @@ using Copiloto.Api.Persistencia;
 using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Ia;
 using Copiloto.Dominio.Vendas;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Fichas = Copiloto.Dominio.Fichas;
 
 namespace Copiloto.Testes;
 
@@ -17,30 +15,11 @@ namespace Copiloto.Testes;
 /// no primeiro clone. O que se prova aqui e o MAPEAMENTO — que o modelo fecha,
 /// que as chaves e os indices existem e que o dominio sobrevive a ida e volta.
 /// </summary>
-public class PersistenciaTeste : IDisposable
+public class PersistenciaTeste : BancoEmMemoria
 {
     private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
 
-    private readonly SqliteConnection _conexao;
-    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
-
-    public PersistenciaTeste()
-    {
-        // Conexao aberta segurando o banco: fechada, o SQLite em memoria some.
-        _conexao = new SqliteConnection("DataSource=:memory:");
-        _conexao.Open();
-
-        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>()
-            .UseSqlite(_conexao)
-            .Options;
-
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Database.EnsureCreated();
-    }
-
-    public void Dispose() => _conexao.Dispose();
-
-    private CopilotoDbContext Novo() => new(_opcoes);
+    private CopilotoDbContext Novo() => NovoContexto();
 
     [Fact]
     public void O_modelo_fecha_e_o_esquema_e_criado()
@@ -171,184 +150,5 @@ public class PersistenciaTeste : IDisposable
             .GetIndexes().Single(i => i.IsUnique);
 
         Assert.Equal("ux_leads_telefone", indice.GetDatabaseName());
-    }
-}
-
-/// <summary>
-/// O resolvedor sobre o banco (#103): a resolucao de Lead da #22 atravessando
-/// a persistencia, que e onde ela passa a valer entre reinicios.
-/// </summary>
-public class ResolvedorSobreBancoTeste : IDisposable
-{
-    private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
-    private const string Empresa = "+55 11 3333-4444";
-
-    private readonly SqliteConnection _conexao;
-    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
-
-    public ResolvedorSobreBancoTeste()
-    {
-        _conexao = new SqliteConnection("DataSource=:memory:");
-        _conexao.Open();
-        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Database.EnsureCreated();
-    }
-
-    public void Dispose() => _conexao.Dispose();
-
-    [Fact]
-    public void O_lead_criado_hoje_e_encontrado_depois_do_restart()
-    {
-        // O que faltava para ser CRM: sem isto, o vendedor abre a tela e a
-        // conversa de ontem nao esta la.
-        Guid id;
-        using (var ctx = new CopilotoDbContext(_opcoes))
-        {
-            var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
-            id = r.Resolver(Telefone.Normalizar("11 98765-4321")!, Agora).Id;
-        }
-
-        // Contexto novo = processo novo, para o efeito deste teste.
-        using (var ctx = new CopilotoDbContext(_opcoes))
-        {
-            var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
-            var denovo = r.Resolver(Telefone.Normalizar("(11) 98765-4321")!, Agora);
-
-            Assert.Equal(id, denovo.Id);
-            Assert.Equal(1, r.LeadsConhecidos);
-        }
-    }
-
-    [Fact]
-    public void O_numero_sem_o_nono_digito_acha_o_lead_que_ja_esta_no_banco()
-    {
-        // A #22 atravessando o banco: normalizar no codigo so serve se a busca
-        // tambem for pelo normalizado.
-        using var ctx = new CopilotoDbContext(_opcoes);
-        var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
-
-        var a = r.Resolver(Telefone.Normalizar("11 98765-4321")!, Agora);
-        var b = r.Resolver(Telefone.Normalizar("11 8765-4321")!, Agora);
-
-        Assert.Equal(a.Id, b.Id);
-        Assert.Equal(1, ctx.Leads.Count());
-    }
-}
-
-/// <summary>A Ficha do Cliente atravessando o banco (#86).</summary>
-public class FichaNoBancoTeste : IDisposable
-{
-    private static readonly DateTimeOffset T0 = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
-
-    private readonly SqliteConnection _conexao;
-    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
-
-    public FichaNoBancoTeste()
-    {
-        _conexao = new SqliteConnection("DataSource=:memory:");
-        _conexao.Open();
-        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Database.EnsureCreated();
-    }
-
-    public void Dispose() => _conexao.Dispose();
-
-    [Fact]
-    public void A_ficha_volta_com_os_campos_preenchidos()
-    {
-        var id = Guid.NewGuid();
-        using (var ctx = new CopilotoDbContext(_opcoes))
-        {
-            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
-            ficha.Atualizar(T0,
-                empresa: new Fichas.SobreAEmpresa(Ramo: Fichas.Anotacao.Fato("cafeteria"), Porte: Fichas.Anotacao.Fato("3 lojas")),
-                pessoa: new Fichas.SobreAPessoa(Cargo: Fichas.Anotacao.Fato("sócio")));
-            ctx.Fichas.Add(ficha);
-            ctx.SaveChanges();
-        }
-
-        using var leitura = new CopilotoDbContext(_opcoes);
-        var lida = leitura.Fichas.Single(f => f.Id == id);
-
-        Assert.Equal("cafeteria", lida.Empresa.Ramo!.Valor);
-        Assert.Equal("3 lojas", lida.Empresa.Porte!.Valor);
-        Assert.Equal("sócio", lida.Pessoa.Cargo!.Valor);
-        Assert.False(lida.EstaVazia);
-    }
-
-    [Fact]
-    public void O_historico_sobrevive_ao_banco()
-    {
-        // "Ele era o decisor e agora nao e" so vale se durar mais que a sessao.
-        var id = Guid.NewGuid();
-        using (var ctx = new CopilotoDbContext(_opcoes))
-        {
-            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
-            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("decisor")));
-            ficha.Atualizar(T0.AddDays(2), pessoa: new Fichas.SobreAPessoa(PapelNaDecisao: Fichas.Anotacao.Fato("influenciador")));
-            ctx.Fichas.Add(ficha);
-            ctx.SaveChanges();
-        }
-
-        using var leitura = new CopilotoDbContext(_opcoes);
-        var lida = leitura.Fichas.Single(f => f.Id == id);
-
-        Assert.Equal(2, lida.Historico.Count);
-        Assert.Equal("decisor", lida.Historico[0].Pessoa.PapelNaDecisao!.Valor);
-    }
-
-    [Fact]
-    public void Ficha_vazia_e_gravavel()
-    {
-        // O sistema funciona sem ela, e "funciona" inclui salvar.
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), Guid.NewGuid(), T0));
-
-        ctx.SaveChanges();
-
-        Assert.True(ctx.Fichas.Single().EstaVazia);
-    }
-
-    [Fact]
-    public void A_natureza_da_anotacao_sobrevive_ao_banco()
-    {
-        // O conversor JSON e' quem reconstroi a Anotacao na leitura, e se ele
-        // errasse a natureza a impressao voltaria do banco como FATO — sem
-        // erro, sem log, e ancorando preco na proxima analise.
-        var id = Guid.NewGuid();
-        using (var ctx = new CopilotoDbContext(_opcoes))
-        {
-            var ficha = new Fichas.FichaCliente(id, Guid.NewGuid(), T0);
-            ficha.Atualizar(T0, pessoa: new Fichas.SobreAPessoa(
-                Cargo: Fichas.Anotacao.Fato("sócio", "LinkedIn"),
-                EstiloObservado: Fichas.Anotacao.Impressao("parece desconfiado", T0)));
-            ctx.Fichas.Add(ficha);
-            ctx.SaveChanges();
-        }
-
-        using var leitura = new CopilotoDbContext(_opcoes);
-        var lida = leitura.Fichas.Single(f => f.Id == id);
-
-        Assert.True(lida.Pessoa.Cargo!.EhFato);
-        Assert.Equal("LinkedIn", lida.Pessoa.Cargo!.Fonte);
-        Assert.False(lida.Pessoa.EstiloObservado!.EhFato);
-        Assert.Equal(T0, lida.Pessoa.EstiloObservado!.Quando);
-        Assert.Single(lida.Impressoes);
-    }
-
-    [Fact]
-    public void Um_lead_nao_tem_duas_fichas()
-    {
-        // Duas seriam duas versoes da verdade sem criterio de desempate.
-        var lead = Guid.NewGuid();
-        using var ctx = new CopilotoDbContext(_opcoes);
-        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
-        ctx.SaveChanges();
-
-        ctx.Fichas.Add(new Fichas.FichaCliente(Guid.NewGuid(), lead, T0));
-
-        Assert.Throws<DbUpdateException>(() => ctx.SaveChanges());
     }
 }

--- a/testes/Copiloto.Testes/ResolvedorSobreBancoTeste.cs
+++ b/testes/Copiloto.Testes/ResolvedorSobreBancoTeste.cs
@@ -1,0 +1,54 @@
+using Copiloto.Api.Ingestao;
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O resolvedor sobre o banco (#103): a resolucao de Lead da #22 atravessando
+/// a persistencia, que e onde ela passa a valer entre reinicios.
+/// </summary>
+public class ResolvedorSobreBancoTeste : BancoEmMemoria
+{
+    private static readonly DateTimeOffset Agora = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+    private const string Empresa = "+55 11 3333-4444";
+
+    [Fact]
+    public void O_lead_criado_hoje_e_encontrado_depois_do_restart()
+    {
+        // O que faltava para ser CRM: sem isto, o vendedor abre a tela e a
+        // conversa de ontem nao esta la.
+        Guid id;
+        using (var ctx = NovoContexto())
+        {
+            var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
+            id = r.Resolver(Telefone.Normalizar("11 98765-4321")!, Agora).Id;
+        }
+
+        // Contexto novo = processo novo, para o efeito deste teste.
+        using (var ctx = NovoContexto())
+        {
+            var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
+            var denovo = r.Resolver(Telefone.Normalizar("(11) 98765-4321")!, Agora);
+
+            Assert.Equal(id, denovo.Id);
+            Assert.Equal(1, r.LeadsConhecidos);
+        }
+    }
+
+    [Fact]
+    public void O_numero_sem_o_nono_digito_acha_o_lead_que_ja_esta_no_banco()
+    {
+        // A #22 atravessando o banco: normalizar no codigo so serve se a busca
+        // tambem for pelo normalizado.
+        using var ctx = NovoContexto();
+        var r = new ResolvedorDeLead(Empresa, new LeadsNoBanco(ctx));
+
+        var a = r.Resolver(Telefone.Normalizar("11 98765-4321")!, Agora);
+        var b = r.Resolver(Telefone.Normalizar("11 8765-4321")!, Agora);
+
+        Assert.Equal(a.Id, b.Id);
+        Assert.Equal(1, ctx.Leads.Count());
+    }
+}
+


### PR DESCRIPTION
**Base:** sai de `89-ficha-sob-lgpd` (#89), que e onde o arquivo passou do limite.

## O que muda
`PersistenciaTeste.cs` tinha 354 linhas e tres classes sem relacao entre si. `ResolvedorSobreBancoTeste` e `FichaNoBancoTeste` saem para arquivos proprios; o que sobra fica com 154 linhas.

O setup do SQLite em memoria estava copiado em **quatro** classes e virou `BancoEmMemoria`.

## Por que a duplicacao nao era acidental
O teste do CLAUDE.md ("se um desses mudar, o outro tem que mudar junto, sempre?") da sim claro: outro provider, outra versao do EF ou um `EnsureDeleted` no meio mudam para todas ao mesmo tempo.

## Nenhum assert mudou
Os testes sao os mesmos; mudaram de arquivo e passaram a herdar o setup. `NovoContexto()` carrega o motivo que as copias nao diziam: contexto novo aproxima o teste de um processo novo, porque o ChangeTracker nasce vazio.

Closes #111