### PR TITLE
Expor o CRM como servidor MCP (ferramentas de leitura)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,12 @@
          mapeamento sem exigir Postgres de pe. -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
 
+    <!-- Servidor MCP (#56). Conferido em 04/09/2026 via `dotnet package search`:
+         ModelContextProtocol 2.2.0 e ModelContextProtocol.AspNetCore 2.2.0 sao as
+         versoes correntes. A issue citava 2.1.0, levantada em outra data — o
+         numero envelheceu, e por isso a data fica escrita ao lado. -->
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
+
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -23,4 +23,13 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
+  <!--
+    Servidor MCP (#56). Fica na Api pelo mesmo motivo do EF: e borda. O dominio
+    nao sabe que existe MCP, e as ferramentas apenas traduzem o que ele ja
+    responde.
+  -->
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
+  </ItemGroup>
+
 </Project>

--- a/src/Copiloto.Api/Mcp/ConsultasDoCrm.cs
+++ b/src/Copiloto.Api/Mcp/ConsultasDoCrm.cs
@@ -1,4 +1,5 @@
 using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Vendas;
 using Microsoft.EntityFrameworkCore;
 
@@ -54,18 +55,33 @@ public static class ConsultasDoCrm
         if (lead is null) return null;
 
         var ficha = await ctx.Fichas.AsNoTracking().FirstOrDefaultAsync(f => f.LeadId == leadId, ct);
-        var deal = await ctx.Deals.AsNoTracking()
+        // A ordenacao acontece no cliente, e nao no banco: o SQLite da suite
+        // NAO ordena DateTimeOffset ("SQLite does not support expressions of
+        // type 'DateTimeOffset' in ORDER BY clauses"), e o Postgres de producao
+        // ordena. Ordenar no servidor daria uma consulta que passa em producao e
+        // quebra so no teste — e o desfecho provavel disso e alguem apagar o
+        // teste. Aqui o custo e nenhum: negocio ABERTO por lead sao poucos.
+        var abertos = await ctx.Deals.AsNoTracking()
             .Where(d => d.LeadId == leadId && d.FechadoEm == null)
-            .OrderByDescending(d => d.AbertoEm)
-            .FirstOrDefaultAsync(ct);
+            .ToListAsync(ct);
+
+        var deal = abertos.OrderByDescending(d => d.AbertoEm).FirstOrDefault();
 
         var conversa = await ctx.Conversas.AsNoTracking()
             .Include(c => c.Mensagens)
             .FirstOrDefaultAsync(c => c.LeadId == leadId, ct);
 
-        var silencio = conversa?.UltimaDoCliente is { } ultima
-            ? (int)(agora - ultima.EnviadaEm).TotalDays
-            : (int?)null;
+        // O silencio sai do MAXIMO, e nao de `UltimaDoCliente`: aquela
+        // propriedade usa `LastOrDefault`, que so vale enquanto a lista foi
+        // montada por `Registrar`. Lida do banco, a colecao vem na ordem do
+        // provedor — a PK e Guid — e "a ultima fala" pode ser a primeira. Ja
+        // aconteceu aqui: 9 dias de silencio onde eram 8. O conserto e no
+        // dominio e esta na #136; esta linha nao espera por ele.
+        var ultima = conversa?.Mensagens
+            .Where(m => m.Autor == Autor.Cliente)
+            .MaxBy(m => m.EnviadaEm);
+
+        var silencio = ultima is null ? (int?)null : (int)(agora - ultima.EnviadaEm).TotalDays;
 
         // `Anotado` e um dicionario chato de proposito: nesta base a ficha ainda
         // guarda texto simples. Quando a #88 entrar, cada linha passa a dizer se
@@ -87,14 +103,26 @@ public static class ConsultasDoCrm
         if (dias < 0) dias = 0;
         var limite = agora.AddDays(-dias);
 
-        var parados = await ctx.Deals.AsNoTracking()
-            .Where(d => d.FechadoEm == null && d.EstagioDesde <= limite)
-            .OrderBy(d => d.EstagioDesde)
-            .Take(TetoDeResultados)
+        // O filtro por DATA tambem sai para o cliente, e nao so a ordem: no
+        // SQLite da suite, `DateTimeOffset` nao e comparavel nem ordenavel em
+        // SQL ("could not be translated"). O que fica no banco e o que ele sabe
+        // fazer — negocio ABERTO —, e e esse recorte que segura o tamanho.
+        //
+        // Em Postgres o filtro rodaria no servidor. Escrever assim e o menor
+        // denominador, e o preco esta pago enquanto o funil couber em memoria;
+        // quando nao couber, a saida e mapear a coluna como DateTime UTC, e ai
+        // os dois bancos filtram. Isso e mudanca de modelo, e nao cabia aqui.
+        var abertos = await ctx.Deals.AsNoTracking()
+            .Where(d => d.FechadoEm == null)
             .Join(ctx.Leads.AsNoTracking(), d => d.LeadId, l => l.Id, (d, l) => new { d, l.Nome })
             .ToListAsync(ct);
 
-        return parados
+        // O teto entra DEPOIS de ordenar, senao "os 50 mais parados" viraria
+        // "50 quaisquer entre os parados" — a resposta errada para a pergunta.
+        return abertos
+            .Where(x => x.d.EstagioDesde <= limite)
+            .OrderBy(x => x.d.EstagioDesde)
+            .Take(TetoDeResultados)
             .Select(x => new NegocioParado(
                 x.d.Id, x.d.LeadId, x.Nome, x.d.Estagio.ToString(),
                 (int)(agora - x.d.EstagioDesde).TotalDays))

--- a/src/Copiloto.Api/Mcp/ConsultasDoCrm.cs
+++ b/src/Copiloto.Api/Mcp/ConsultasDoCrm.cs
@@ -1,0 +1,125 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Vendas;
+using Microsoft.EntityFrameworkCore;
+
+namespace Copiloto.Api.Mcp;
+
+/// <summary>O que o CRM responde sobre um lead, sem a analise de IA.</summary>
+public record FichaDoLead(
+    Guid LeadId, string? Nome, string Telefone,
+    IReadOnlyDictionary<string, string> Anotado,
+    IReadOnlyList<string> Lacunas,
+    string? Estagio, int? DiasNoEstagio, int? DiasSemFalarComOCliente);
+
+/// <summary>Um negocio parado, com o dado que sustenta o "parado".</summary>
+public record NegocioParado(Guid DealId, Guid LeadId, string? Nome, string Estagio, int DiasParado);
+
+public record LeadEncontrado(Guid LeadId, string? Nome, string Telefone);
+
+public record FalaDaConversa(string Autor, string Texto, DateTimeOffset EnviadaEm);
+
+/// <summary>
+/// As consultas de leitura do CRM (#56).
+///
+/// Ficam FORA da classe de ferramentas MCP de proposito: o que responde a
+/// pergunta e codigo comum, testavel sem subir servidor nem cliente MCP. A
+/// camada MCP e so a porta — e porta que carrega regra vira regra que so o
+/// protocolo enxerga.
+/// </summary>
+public static class ConsultasDoCrm
+{
+    public const int TetoDeResultados = 50;
+
+    public static async Task<IReadOnlyList<LeadEncontrado>> BuscarLead(
+        CopilotoDbContext ctx, string termo, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(termo)) return [];
+
+        var porTelefone = Telefone.Normalizar(termo);
+        var busca = termo.Trim();
+
+        var leads = await ctx.Leads.AsNoTracking()
+            .Where(l => (porTelefone != null && l.Telefone == porTelefone.ToString())
+                        || (l.Nome != null && EF.Functions.Like(l.Nome, $"%{busca}%")))
+            .Take(TetoDeResultados)
+            .ToListAsync(ct);
+
+        return leads.Select(l => new LeadEncontrado(l.Id, l.Nome, l.Telefone)).ToList();
+    }
+
+    public static async Task<FichaDoLead?> ObterFicha(
+        CopilotoDbContext ctx, Guid leadId, DateTimeOffset agora, CancellationToken ct)
+    {
+        var lead = await ctx.Leads.AsNoTracking().FirstOrDefaultAsync(l => l.Id == leadId, ct);
+        if (lead is null) return null;
+
+        var ficha = await ctx.Fichas.AsNoTracking().FirstOrDefaultAsync(f => f.LeadId == leadId, ct);
+        var deal = await ctx.Deals.AsNoTracking()
+            .Where(d => d.LeadId == leadId && d.FechadoEm == null)
+            .OrderByDescending(d => d.AbertoEm)
+            .FirstOrDefaultAsync(ct);
+
+        var conversa = await ctx.Conversas.AsNoTracking()
+            .Include(c => c.Mensagens)
+            .FirstOrDefaultAsync(c => c.LeadId == leadId, ct);
+
+        var silencio = conversa?.UltimaDoCliente is { } ultima
+            ? (int)(agora - ultima.EnviadaEm).TotalDays
+            : (int?)null;
+
+        // `Anotado` e um dicionario chato de proposito: nesta base a ficha ainda
+        // guarda texto simples. Quando a #88 entrar, cada linha passa a dizer se
+        // e FATO ou IMPRESSAO, com a fonte — e a ferramenta ganha a distincao
+        // sem mudar de forma, porque quem chama ja recebe rotulo e valor.
+        return new FichaDoLead(
+            lead.Id, lead.Nome, lead.Telefone,
+            ficha?.Preenchidos.ToDictionary(a => a.Key, a => a.Value)
+                ?? new Dictionary<string, string>(),
+            ficha?.Lacunas() ?? [],
+            deal?.Estagio.ToString(),
+            deal is null ? null : (int)(agora - deal.EstagioDesde).TotalDays,
+            silencio);
+    }
+
+    public static async Task<IReadOnlyList<NegocioParado>> ListarNegociosParados(
+        CopilotoDbContext ctx, int dias, DateTimeOffset agora, CancellationToken ct)
+    {
+        if (dias < 0) dias = 0;
+        var limite = agora.AddDays(-dias);
+
+        var parados = await ctx.Deals.AsNoTracking()
+            .Where(d => d.FechadoEm == null && d.EstagioDesde <= limite)
+            .OrderBy(d => d.EstagioDesde)
+            .Take(TetoDeResultados)
+            .Join(ctx.Leads.AsNoTracking(), d => d.LeadId, l => l.Id, (d, l) => new { d, l.Nome })
+            .ToListAsync(ct);
+
+        return parados
+            .Select(x => new NegocioParado(
+                x.d.Id, x.d.LeadId, x.Nome, x.d.Estagio.ToString(),
+                (int)(agora - x.d.EstagioDesde).TotalDays))
+            .ToList();
+    }
+
+    public static async Task<IReadOnlyList<FalaDaConversa>> HistoricoDaConversa(
+        CopilotoDbContext ctx, Guid leadId, int limite, CancellationToken ct)
+    {
+        // Teto sempre, mesmo quando quem chama pede mais: do outro lado ha um
+        // agente que nao sente a conta crescer, e conversa inteira num contexto
+        // e token gasto antes de alguem decidir se precisava.
+        limite = Math.Clamp(limite <= 0 ? 20 : limite, 1, TetoDeResultados);
+
+        var conversa = await ctx.Conversas.AsNoTracking()
+            .Include(c => c.Mensagens)
+            .FirstOrDefaultAsync(c => c.LeadId == leadId, ct);
+
+        if (conversa is null) return [];
+
+        return conversa.Mensagens
+            .OrderByDescending(m => m.EnviadaEm)
+            .Take(limite)
+            .OrderBy(m => m.EnviadaEm)
+            .Select(m => new FalaDaConversa(m.Autor.ToString(), m.Texto, m.EnviadaEm))
+            .ToList();
+    }
+}

--- a/src/Copiloto.Api/Mcp/FerramentasDoCrm.cs
+++ b/src/Copiloto.Api/Mcp/FerramentasDoCrm.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using Copiloto.Api.Persistencia;
+using ModelContextProtocol.Server;
+
+namespace Copiloto.Api.Mcp;
+
+/// <summary>
+/// O CRM exposto como servidor MCP, so leitura (#56).
+///
+/// O CRM deixa de ser um destino e vira capacidade componivel: o gestor
+/// pergunta "quais negocios travaram este mes?" de qualquer cliente MCP, sem
+/// que exista tela para isso.
+///
+/// NADA aqui altera estado, e isso e limite desta issue e nao acaso. Escrita
+/// por MCP significaria um agente movendo negocio de estagio a partir de uma
+/// frase — e o produto inteiro existe para o contrario: quem decide e a pessoa.
+///
+/// As descricoes sao escritas PARA UM CLIENTE MCP escolher sozinho a ferramenta
+/// certa. Descricao vaga aqui nao produz erro: produz o agente chamando a
+/// ferramenta errada e respondendo com confianca.
+/// </summary>
+[McpServerToolType]
+public static class FerramentasDoCrm
+{
+    [McpServerTool(Name = "buscar_lead")]
+    [Description("Procura um lead por nome ou telefone e devolve o identificador dele. "
+        + "Use PRIMEIRO quando a pergunta cita uma pessoa ou empresa pelo nome, porque as "
+        + "outras ferramentas pedem o lead_id. Aceita telefone em qualquer formato "
+        + "(com ou sem DDI, com ou sem nono digito). Devolve no maximo 50 resultados.")]
+    public static async Task<IReadOnlyList<LeadEncontrado>> BuscarLead(
+        CopilotoDbContext ctx,
+        [Description("Nome (parcial) ou telefone do cliente.")] string termo,
+        CancellationToken ct = default) =>
+        await ConsultasDoCrm.BuscarLead(ctx, termo, ct);
+
+    [McpServerTool(Name = "obter_ficha")]
+    [Description("Traz o que a EMPRESA sabe sobre um lead: o que o vendedor anotou antes "
+        + "de falar, o que ainda falta descobrir, o estagio do negocio aberto, ha quantos "
+        + "dias ele nao anda e ha quantos dias o cliente nao responde. NAO e o dossie "
+        + "gerado por IA e nao contem analise: sao os dados do CRM. Parte do que esta "
+        + "anotado e impressao de quem atendeu, e nao fato apurado — trate como hipotese.")]
+    public static async Task<FichaDoLead?> ObterFicha(
+        CopilotoDbContext ctx,
+        [Description("Identificador do lead, obtido em buscar_lead.")] Guid lead_id,
+        CancellationToken ct = default) =>
+        await ConsultasDoCrm.ObterFicha(ctx, lead_id, DateTimeOffset.UtcNow, ct);
+
+    [McpServerTool(Name = "listar_negocios_parados")]
+    [Description("Lista negocios ABERTOS que estao no mesmo estagio ha pelo menos N dias, "
+        + "do mais parado para o menos, com o nome do cliente e ha quantos dias parou. "
+        + "Use para perguntas como 'o que travou' ou 'o que precisa de atencao'. Conta o "
+        + "tempo desde a ultima mudanca de estagio, e nao desde a abertura: negocio de "
+        + "dois meses que andou ontem nao esta parado. Devolve no maximo 50.")]
+    public static async Task<IReadOnlyList<NegocioParado>> ListarNegociosParados(
+        CopilotoDbContext ctx,
+        [Description("Minimo de dias sem mudar de estagio. Ex.: 10.")] int dias,
+        CancellationToken ct = default) =>
+        await ConsultasDoCrm.ListarNegociosParados(ctx, dias, DateTimeOffset.UtcNow, ct);
+
+    [McpServerTool(Name = "historico_conversa")]
+    [Description("Devolve as ultimas falas trocadas com o cliente, em ordem cronologica, "
+        + "com quem falou e quando. Use quando a pergunta depende do que foi DITO — "
+        + "objecao, combinado, preco citado. O limite e cortado em 50 mesmo que voce peca "
+        + "mais: conversa inteira em contexto e token gasto antes de alguem precisar.")]
+    public static async Task<IReadOnlyList<FalaDaConversa>> HistoricoConversa(
+        CopilotoDbContext ctx,
+        [Description("Identificador do lead, obtido em buscar_lead.")] Guid lead_id,
+        [Description("Quantas falas trazer, das mais recentes. Padrao 20, teto 50.")] int limite = 20,
+        CancellationToken ct = default) =>
+        await ConsultasDoCrm.HistoricoDaConversa(ctx, lead_id, limite, ct);
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,5 +1,6 @@
 using Copiloto.Api.Ia;
 using Copiloto.Api.Ingestao;
+using Copiloto.Api.Mcp;
 using Copiloto.Api.Persistencia;
 using Copiloto.Api.Vigia;
 using Copiloto.Dominio.Ia;
@@ -32,7 +33,23 @@ builder.Services.AddHostedService<ProcessadorDeMensagens>();
 // evento nenhum — ele so fica parado (#53).
 builder.Services.AddHostedService<JobDoVigia>();
 
+// O CRM como servidor MCP (#56), DESLIGADO por padrao.
+//
+// Escopo e autenticacao sao a #58, e ate la o servidor e superficie de leitura
+// de dado de cliente sem porteiro. Ligar por padrao seria abrir essa porta para
+// quem so fez `docker compose up` — a demo nao precisa dela de pe, e quem for
+// experimentar liga de proposito.
+var mcpLigado = builder.Configuration.GetValue("MCP_HABILITADO", false);
+if (mcpLigado)
+{
+    builder.Services.AddMcpServer()
+        .WithHttpTransport(o => o.Stateless = true)
+        .WithToolsFromAssembly();
+}
+
 var app = builder.Build();
+
+if (mcpLigado) app.MapMcp();
 
 app.MapGet("/saude", () => Results.Ok(new { ok = true }));
 

--- a/testes/Copiloto.Testes/Copiloto.Testes.csproj
+++ b/testes/Copiloto.Testes/Copiloto.Testes.csproj
@@ -10,6 +10,9 @@
          suite continua rodando offline como o CLAUDE.md manda. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- Os atributos do servidor MCP sao lidos por reflexao no teste de
+         contrato das ferramentas (#56). -->
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/testes/Copiloto.Testes/ServidorMcpTeste.cs
+++ b/testes/Copiloto.Testes/ServidorMcpTeste.cs
@@ -1,0 +1,281 @@
+using System.ComponentModel;
+using System.Reflection;
+using Copiloto.Api.Mcp;
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Conversas;
+using Copiloto.Dominio.Fichas;
+using Copiloto.Dominio.Vendas;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// O CRM exposto como servidor MCP, so leitura (#56).
+///
+/// O contrato aqui tem duas metades. A primeira e o que a ferramenta responde,
+/// testado contra o banco. A segunda e o que ela DIZ de si mesma: do outro lado
+/// nao ha uma pessoa lendo a tela, ha um agente escolhendo sozinho qual chamar,
+/// e descricao vaga nao produz erro — produz o agente chamando a ferramenta
+/// errada e respondendo com confianca.
+/// </summary>
+public class ServidorMcpTeste : IDisposable
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _conexao;
+    private readonly DbContextOptions<CopilotoDbContext> _opcoes;
+
+    public ServidorMcpTeste()
+    {
+        _conexao = new SqliteConnection("DataSource=:memory:");
+        _conexao.Open();
+        _opcoes = new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(_conexao).Options;
+        using var ctx = new CopilotoDbContext(_opcoes);
+        ctx.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _conexao.Dispose();
+
+    private Guid SemearMarina()
+    {
+        using var ctx = new CopilotoDbContext(_opcoes);
+        var leadId = Guid.NewGuid();
+
+        ctx.Leads.Add(new Lead(leadId, "+55 11 98888-1111", T0.AddDays(-30), "Marina"));
+
+        var deal = new Deal(Guid.NewGuid(), leadId, T0.AddDays(-30));
+        deal.MoverPara(Estagio.Qualificacao, T0.AddDays(-20));
+        ctx.Deals.Add(deal);
+
+        var conversa = new Conversa(Guid.NewGuid(), leadId);
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "qual o valor do kg?", T0.AddDays(-9)));
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Vendedor, "R$ 68", T0.AddDays(-9).AddMinutes(4)));
+        conversa.Registrar(new Mensagem(Guid.NewGuid(), Autor.Cliente, "vou pensar", T0.AddDays(-8)));
+        ctx.Conversas.Add(conversa);
+
+        var ficha = new FichaCliente(Guid.NewGuid(), leadId, T0.AddDays(-30));
+        ficha.Atualizar(T0.AddDays(-30), empresa: new SobreAEmpresa(Ramo: "cafeteria de bairro"));
+        ctx.Fichas.Add(ficha);
+
+        ctx.SaveChanges();
+        return leadId;
+    }
+
+    // --- O que as ferramentas respondem ---
+
+    [Fact]
+    public async Task Buscar_lead_acha_por_nome_parcial()
+    {
+        SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var achados = await ConsultasDoCrm.BuscarLead(ctx, "mari", default);
+
+        Assert.Single(achados);
+        Assert.Equal("Marina", achados[0].Nome);
+    }
+
+    [Fact]
+    public async Task Buscar_lead_acha_por_telefone_em_qualquer_formato()
+    {
+        // O agente do outro lado copia o telefone como veio na conversa.
+        SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.Single(await ConsultasDoCrm.BuscarLead(ctx, "(11) 98888-1111", default));
+        Assert.Single(await ConsultasDoCrm.BuscarLead(ctx, "11988881111", default));
+    }
+
+    [Fact]
+    public async Task Busca_vazia_devolve_lista_vazia_e_nao_a_base_inteira()
+    {
+        // Termo em branco vindo de um agente e o caminho mais curto para
+        // exportar a carteira sem querer.
+        SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.Empty(await ConsultasDoCrm.BuscarLead(ctx, "   ", default));
+    }
+
+    [Fact]
+    public async Task A_ficha_traz_o_anotado_a_lacuna_e_os_dois_relogios()
+    {
+        var leadId = SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var ficha = await ConsultasDoCrm.ObterFicha(ctx, leadId, T0, default);
+
+        Assert.NotNull(ficha);
+        Assert.Equal("cafeteria de bairro", ficha!.Anotado["Ramo"]);
+        Assert.Contains("Cargo", ficha.Lacunas);
+        Assert.Equal("Qualificacao", ficha.Estagio);
+        Assert.Equal(20, ficha.DiasNoEstagio);
+        Assert.Equal(8, ficha.DiasSemFalarComOCliente);
+    }
+
+    [Fact]
+    public async Task Lead_inexistente_devolve_nulo_e_nao_ficha_vazia()
+    {
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        Assert.Null(await ConsultasDoCrm.ObterFicha(ctx, Guid.NewGuid(), T0, default));
+    }
+
+    [Fact]
+    public async Task Negocios_parados_contam_da_ultima_mudanca_de_estagio()
+    {
+        // Negocio de dois meses que andou ontem nao esta parado.
+        SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var parados = await ConsultasDoCrm.ListarNegociosParados(ctx, dias: 10, T0, default);
+
+        var parado = Assert.Single(parados);
+        Assert.Equal(20, parado.DiasParado);
+        Assert.Equal("Marina", parado.Nome);
+
+        Assert.Empty(await ConsultasDoCrm.ListarNegociosParados(ctx, dias: 30, T0, default));
+    }
+
+    [Fact]
+    public async Task Negocio_fechado_nao_entra_na_lista_de_parados()
+    {
+        var leadId = SemearMarina();
+        using (var ctx = new CopilotoDbContext(_opcoes))
+        {
+            var deal = ctx.Deals.Single(d => d.LeadId == leadId);
+            deal.MoverPara(Estagio.Ganho, T0.AddDays(-1));
+            ctx.SaveChanges();
+        }
+
+        using var leitura = new CopilotoDbContext(_opcoes);
+
+        Assert.Empty(await ConsultasDoCrm.ListarNegociosParados(leitura, dias: 0, T0, default));
+    }
+
+    [Fact]
+    public async Task O_historico_vem_em_ordem_cronologica()
+    {
+        var leadId = SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var falas = await ConsultasDoCrm.HistoricoDaConversa(ctx, leadId, limite: 20, default);
+
+        Assert.Equal(3, falas.Count);
+        Assert.Equal("qual o valor do kg?", falas[0].Texto);
+        Assert.Equal("vou pensar", falas[2].Texto);
+    }
+
+    [Fact]
+    public async Task O_historico_traz_as_MAIS_RECENTES_quando_o_limite_corta()
+    {
+        // Cortar pelas primeiras devolveria o comeco da conversa e esconderia a
+        // objecao, que e sempre a ultima coisa dita.
+        var leadId = SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var falas = await ConsultasDoCrm.HistoricoDaConversa(ctx, leadId, limite: 1, default);
+
+        Assert.Single(falas);
+        Assert.Equal("vou pensar", falas[0].Texto);
+    }
+
+    [Fact]
+    public async Task O_teto_vale_mesmo_quando_o_agente_pede_mais()
+    {
+        // Do outro lado ha um agente que nao sente a conta crescer.
+        var leadId = SemearMarina();
+        using var ctx = new CopilotoDbContext(_opcoes);
+
+        var falas = await ConsultasDoCrm.HistoricoDaConversa(ctx, leadId, limite: 5000, default);
+
+        Assert.True(falas.Count <= ConsultasDoCrm.TetoDeResultados);
+    }
+
+    // --- O que as ferramentas dizem de si mesmas ---
+
+    private static IReadOnlyList<MethodInfo> Ferramentas() =>
+        typeof(FerramentasDoCrm).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .ToList();
+
+    [Fact]
+    public void As_quatro_ferramentas_de_leitura_estao_expostas()
+    {
+        var nomes = Ferramentas()
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()!.Name)
+            .ToList();
+
+        Assert.Contains("buscar_lead", nomes);
+        Assert.Contains("obter_ficha", nomes);
+        Assert.Contains("listar_negocios_parados", nomes);
+        Assert.Contains("historico_conversa", nomes);
+    }
+
+    [Fact]
+    public void Toda_ferramenta_diz_o_que_faz_e_quando_usar()
+    {
+        // Criterio de aceite da issue: descricao boa o bastante para o cliente
+        // MCP escolher sozinho. Uma linha generica ("busca dados") passaria em
+        // qualquer teste de existencia e falharia na hora que importa.
+        foreach (var ferramenta in Ferramentas())
+        {
+            var descricao = ferramenta.GetCustomAttribute<DescriptionAttribute>()?.Description ?? "";
+
+            Assert.True(descricao.Length >= 120,
+                $"{ferramenta.Name}: descricao com {descricao.Length} caracteres, curta "
+                + "demais para um agente escolher sozinho.");
+        }
+    }
+
+    [Fact]
+    public void Todo_parametro_de_ferramenta_e_descrito()
+    {
+        // Parametro sem descricao e onde o agente inventa: manda o nome no
+        // campo que espera id, recebe vazio, e conclui que nao ha dado.
+        foreach (var ferramenta in Ferramentas())
+        {
+            foreach (var p in ferramenta.GetParameters())
+            {
+                if (p.ParameterType == typeof(CopilotoDbContext)
+                    || p.ParameterType == typeof(CancellationToken)) continue;
+
+                Assert.True(p.GetCustomAttribute<DescriptionAttribute>() is not null,
+                    $"{ferramenta.Name}: parametro '{p.Name}' sem descricao.");
+            }
+        }
+    }
+
+    [Fact]
+    public void Nenhuma_ferramenta_altera_estado()
+    {
+        // Limite desta issue, e conferido no FONTE porque reflexao nao le corpo
+        // de metodo. Escrita por MCP significaria um agente movendo negocio de
+        // estagio a partir de uma frase — e o produto existe para o contrario.
+        var pasta = Path.Combine(RaizDoRepositorio(), "src", "Copiloto.Api", "Mcp");
+        var proibidos = new[] { "SaveChanges", ".Add(", ".Remove(", ".Update(", ".ExecuteDelete" };
+
+        foreach (var arquivo in Directory.GetFiles(pasta, "*.cs"))
+        {
+            var codigo = File.ReadAllText(arquivo);
+            foreach (var termo in proibidos)
+            {
+                Assert.False(codigo.Contains(termo, StringComparison.Ordinal),
+                    $"{Path.GetFileName(arquivo)} contem '{termo}': a superficie MCP e "
+                    + "somente leitura nesta issue (#56).");
+            }
+        }
+    }
+
+    private static string RaizDoRepositorio()
+    {
+        var raiz = typeof(ServidorMcpTeste).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "RaizDoRepositorio")?.Value;
+
+        Assert.False(string.IsNullOrWhiteSpace(raiz), "Metadado RaizDoRepositorio ausente.");
+        return raiz!;
+    }
+}

--- a/testes/Copiloto.Testes/ServidorMcpTeste.cs
+++ b/testes/Copiloto.Testes/ServidorMcpTeste.cs
@@ -43,7 +43,10 @@ public class ServidorMcpTeste : IDisposable
         using var ctx = new CopilotoDbContext(_opcoes);
         var leadId = Guid.NewGuid();
 
-        ctx.Leads.Add(new Lead(leadId, "+55 11 98888-1111", T0.AddDays(-30), "Marina"));
+        // Telefone NORMALIZADO, como o ResolvedorDeLead grava em producao: a
+        // busca por telefone so acha quem foi gravado assim.
+        ctx.Leads.Add(new Lead(
+            leadId, Telefone.Normalizar("+55 11 98888-1111")!.ToString(), T0.AddDays(-30), "Marina"));
 
         var deal = new Deal(Guid.NewGuid(), leadId, T0.AddDays(-30));
         deal.MoverPara(Estagio.Qualificacao, T0.AddDays(-20));


### PR DESCRIPTION
**Base:** sai de `53-agente-vigia` (#53), porque `listar_negocios_parados` usa o `Deal.EstagioDesde` que aquela issue criou.

## O que muda
Quatro ferramentas de leitura por MCP: `buscar_lead`, `obter_ficha`, `listar_negocios_parados`, `historico_conversa`.

## Decisoes
- **Nasce desligado** (`MCP_HABILITADO=false`). Escopo e autenticacao sao a #58, e ate la o servidor e leitura de dado de cliente sem porteiro.
- **Nada altera estado**, conferido no FONTE (reflexao nao le corpo de metodo): o teste procura `SaveChanges`, `.Add(`, `.Remove(`, `.Update(` nos arquivos de `Mcp/`.
- **A regra fica fora da porta**: `ConsultasDoCrm` e codigo comum, testavel sem subir servidor nem cliente MCP.
- **Limites nos resultados**: busca em branco devolve vazio (nao a base inteira) e o historico corta em 50 mesmo quando o agente pede mais.

## O que mudou o desenho
Quem le a descricao do outro lado nao e uma pessoa, e um agente escolhendo sozinho. Descricao vaga nao da erro — da a ferramenta errada chamada com confianca. O teste de contrato exige descricao com 120+ caracteres e descricao em todo parametro, e cada uma diz QUANDO usar.

## Dependencia conferida
`dotnet package search` em 04/09/2026: `ModelContextProtocol.AspNetCore` **2.2.0**. A issue citava 2.1.0, de outro levantamento.

## Fora deste PR
`ler_playbook`, que a issue lista: o Playbook e dominio e ainda nao e persistido. **Nao testei contra um cliente MCP real** — a injecao do `CopilotoDbContext` como parametro de ferramenta segue o padrao do SDK, mas so uma sessao com cliente de verdade confirma.

Closes #56