### PR TITLE
Auth JWT com perfis de vendedor e gestor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,13 @@ CLOUDAPI_PHONE_NUMBER_ID=
 CLOUDAPI_ACCESS_TOKEN=
 CLOUDAPI_VERIFY_TOKEN=
 
+# ---------- Autenticacao ----------
+# Segredo do JWT (#49). Minimo 32 caracteres, e SEM valor padrao: a aplicacao
+# nao sobe sem ele. Cair para um segredo embutido daria a impressao de proteger
+# enquanto qualquer um forja um token de gestor.
+# Gere com: openssl rand -base64 48
+JWT_SEGREDO=
+
 # ---------- Provedores de modelo ----------
 # fake | (provedor real, a definir)
 # O FakeProvider responde a partir de arquivos em seed/ e nao usa rede.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,12 @@
          mapeamento sem exigir Postgres de pe. -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
 
+    <!-- Auth (#49). Conferidos em 04/09/2026 via `dotnet package search`:
+         JwtBearer 9.0.19 (mesma faixa do EF Core ja usado) e BCrypt.Net-Next
+         4.2.0. BCrypt e nao MD5/SHA-1: velocidade e defeito em hash de senha. -->
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.19" />
+    <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
+
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/src/Copiloto.Api/Auth/Senhas.cs
+++ b/src/Copiloto.Api/Auth/Senhas.cs
@@ -1,0 +1,53 @@
+namespace Copiloto.Api.Auth;
+
+/// <summary>
+/// Hash e conferencia de senha (#49).
+///
+/// BCrypt, e nao MD5 nem SHA-1: os dois ultimos sao RAPIDOS, e velocidade e
+/// defeito aqui. Uma GPU testa bilhoes de MD5 por segundo, entao uma base
+/// vazada com MD5 esta quebrada no mesmo fim de semana; com BCrypt no custo
+/// certo, cada tentativa custa tempo tambem para quem ataca.
+///
+/// Fica na Api porque o dominio nao tem PackageReference (#48). O que o
+/// dominio garante e o que ele consegue garantir sem pacote: que o hash
+/// guardado tem tamanho de hash moderno.
+/// </summary>
+public static class Senhas
+{
+    /// <summary>
+    /// Custo do BCrypt. Cada +1 DOBRA o tempo.
+    ///
+    /// 12 e o ponto em que o login ainda parece instantaneo para quem digita a
+    /// senha e ja e caro para quem testa listas. Baixar isto para "acelerar o
+    /// login" e o tipo de otimizacao que so aparece depois do vazamento.
+    /// </summary>
+    public const int Custo = 12;
+
+    public static string Hash(string senha)
+    {
+        if (string.IsNullOrWhiteSpace(senha))
+            throw new ArgumentException("Senha vazia nao vira hash.", nameof(senha));
+
+        return BCrypt.Net.BCrypt.HashPassword(senha, Custo);
+    }
+
+    /// <summary>
+    /// Confere. Devolve false em vez de lancar quando o hash guardado esta
+    /// corrompido: a resposta certa para "essa senha vale?" continua sendo
+    /// "nao", e uma excecao aqui viraria erro 500 no login — que conta ao
+    /// atacante que aquele usuario existe e tem algo diferente.
+    /// </summary>
+    public static bool Confere(string senha, string hash)
+    {
+        if (string.IsNullOrWhiteSpace(senha) || string.IsNullOrWhiteSpace(hash)) return false;
+
+        try
+        {
+            return BCrypt.Net.BCrypt.Verify(senha, hash);
+        }
+        catch (BCrypt.Net.SaltParseException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Copiloto.Api/Auth/Tokens.cs
+++ b/src/Copiloto.Api/Auth/Tokens.cs
@@ -1,0 +1,117 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Copiloto.Dominio.Vendas;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Copiloto.Api.Auth;
+
+/// <summary>
+/// Emite e valida o token de sessao (#49).
+///
+/// O segredo vem de variavel de ambiente, sempre. Segredo em appsettings e
+/// segredo no repositorio, e a varredura da esteira (#47) existe justamente
+/// para impedir que ele chegue la — mas a defesa de verdade e nao ter um
+/// caminho em que isso funcione.
+/// </summary>
+public class Tokens
+{
+    /// <summary>
+    /// Tamanho minimo do segredo. HMAC-SHA256 usa chave de 256 bits, e um
+    /// segredo curto e adivinhavel torna a assinatura decorativa: qualquer um
+    /// forja um token de gestor.
+    /// </summary>
+    public const int TamanhoMinimoDoSegredo = 32;
+
+    /// <summary>
+    /// Oito horas: um turno. Token que nao expira e credencial permanente
+    /// entregue ao navegador; token de quinze minutos, sem renovacao, e um
+    /// vendedor relogando no meio do atendimento — e ai alguem "resolve" isso
+    /// aumentando para um ano.
+    /// </summary>
+    public static readonly TimeSpan Validade = TimeSpan.FromHours(8);
+
+    public const string Emissor = "copiloto";
+
+    private readonly SymmetricSecurityKey _chave;
+
+    public Tokens(string segredo)
+    {
+        if (string.IsNullOrWhiteSpace(segredo) || segredo.Length < TamanhoMinimoDoSegredo)
+            throw new ArgumentException(
+                $"JWT_SEGREDO ausente ou com menos de {TamanhoMinimoDoSegredo} caracteres. "
+                + "Sem segredo forte a assinatura nao protege nada — qualquer um forja um "
+                + "token de gestor. Defina a variavel de ambiente antes de subir.",
+                nameof(segredo));
+
+        _chave = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(segredo));
+    }
+
+    public string Emitir(Usuario usuario, DateTimeOffset agora)
+    {
+        ArgumentNullException.ThrowIfNull(usuario);
+
+        // O token leva id, perfil e nome — e NAO leva o email nem o hash: ele
+        // trafega em header e fica no navegador, entao carrega o minimo que o
+        // servidor precisa para decidir.
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, usuario.Id.ToString()),
+            new(ClaimTypes.Role, usuario.Perfil.ToString()),
+            new(ClaimTypes.Name, usuario.Nome),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: Emissor,
+            audience: Emissor,
+            claims: claims,
+            notBefore: agora.UtcDateTime,
+            expires: (agora + Validade).UtcDateTime,
+            signingCredentials: new SigningCredentials(_chave, SecurityAlgorithms.HmacSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>Os parametros que a Api usa para validar o que chega.</summary>
+    public TokenValidationParameters Validacao() => new()
+    {
+        ValidateIssuer = true,
+        ValidIssuer = Emissor,
+        ValidateAudience = true,
+        ValidAudience = Emissor,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = _chave,
+        ValidateLifetime = true,
+
+        // Sem tolerancia de relogio: o padrao da biblioteca e cinco minutos, e
+        // "expira em oito horas" com cinco minutos de bonus silencioso e uma
+        // regra que ninguem escreveu. Se um dia houver deriva de relogio entre
+        // maquinas, isso vira decisao explicita, com numero.
+        ClockSkew = TimeSpan.Zero,
+    };
+
+    /// <summary>Quem esta no token, ou null se ele nao vale.</summary>
+    public (Guid UsuarioId, PerfilDeAcesso Perfil)? Ler(string token)
+    {
+        try
+        {
+            var principal = new JwtSecurityTokenHandler()
+                .ValidateToken(token, Validacao(), out _);
+
+            var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+                      ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var papel = principal.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (!Guid.TryParse(sub, out var id)) return null;
+            if (!Enum.TryParse<PerfilDeAcesso>(papel, out var perfil)) return null;
+
+            return (id, perfil);
+        }
+        catch (SecurityTokenException)
+        {
+            // Expirado, assinatura errada, emissor errado: para quem chama, e
+            // tudo a mesma coisa — nao autenticado.
+            return null;
+        }
+    }
+}

--- a/src/Copiloto.Api/Auth/Tokens.cs
+++ b/src/Copiloto.Api/Auth/Tokens.cs
@@ -107,10 +107,12 @@ public class Tokens
 
             return (id, perfil);
         }
-        catch (SecurityTokenException)
+        catch (Exception erro) when (erro is SecurityTokenException or ArgumentException)
         {
-            // Expirado, assinatura errada, emissor errado: para quem chama, e
-            // tudo a mesma coisa — nao autenticado.
+            // Expirado, assinatura errada, emissor errado, ou texto que nem e
+            // token: para quem chama e tudo a mesma coisa — nao autenticado. O
+            // handler lanca ArgumentException para entrada malformada, e deixar
+            // isso subir viraria erro 500 num caminho que qualquer um alcanca.
             return null;
         }
     }

--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -23,4 +23,14 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
+  <!--
+    Auth (#49). Fica na Api porque e borda: o dominio guarda o HASH e o perfil,
+    e nao sabe o que e JWT nem BCrypt — sem PackageReference ele nao teria como
+    saber (#48).
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="BCrypt.Net-Next" />
+  </ItemGroup>
+
 </Project>

--- a/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
+++ b/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
@@ -29,6 +29,9 @@ public class CopilotoDbContext : DbContext
     public DbSet<Mensagem> Mensagens => Set<Mensagem>();
     public DbSet<FichaCliente> Fichas => Set<FichaCliente>();
 
+    /// <summary>Quem entra no CRM, com perfil e hash de senha (#49).</summary>
+    public DbSet<Usuario> Usuarios => Set<Usuario>();
+
     protected override void OnModelCreating(ModelBuilder b) =>
         b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);
 }

--- a/src/Copiloto.Api/Persistencia/FabricaDeContextoParaMigrations.cs
+++ b/src/Copiloto.Api/Persistencia/FabricaDeContextoParaMigrations.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Copiloto.Api.Persistencia;
+
+/// <summary>
+/// O contexto que o `dotnet ef` usa para gerar migration (#49).
+///
+/// Sem isto, a ferramenta sobe o `Program` inteiro so para descobrir o
+/// DbContext — e passa a depender de tudo que a aplicacao exige para subir. Foi
+/// o que aconteceu quando a auth entrou: `JWT_SEGREDO` ausente derrubava
+/// `dotnet ef migrations add`, e a saida barata teria sido enfraquecer a
+/// validacao do segredo para a ferramenta voltar a funcionar. Enfraquecer
+/// seguranca para satisfazer uma ferramenta de build e como isso costuma
+/// comecar.
+///
+/// Aqui a migration precisa apenas do provider e de uma cadeia de conexao, que
+/// nem precisa apontar para um banco de pe: o `dotnet ef` gera SQL, nao executa.
+/// </summary>
+public class FabricaDeContextoParaMigrations : IDesignTimeDbContextFactory<CopilotoDbContext>
+{
+    public CopilotoDbContext CreateDbContext(string[] args)
+    {
+        var cadeia = Environment.GetEnvironmentVariable("ConnectionStrings__Postgres")
+                     ?? "Host=localhost;Database=copiloto;Username=copiloto";
+
+        return new CopilotoDbContext(
+            new DbContextOptionsBuilder<CopilotoDbContext>().UseNpgsql(cadeia).Options);
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/LeadMap.cs
@@ -14,6 +14,12 @@ public class LeadMap : IEntityTypeConfiguration<Lead>
         e.Property(l => l.Nome).HasMaxLength(200);
         e.Property(l => l.CriadoEm).IsRequired();
 
+        // O dono do lead (#49). Indice porque a consulta do vendedor filtra por
+        // ele em toda tela — e sem indice a lista fica lenta exatamente para
+        // quem tem carteira grande.
+        e.Property(l => l.VendedorId);
+        e.HasIndex(l => l.VendedorId).HasDatabaseName("ix_leads_vendedor");
+
         // O indice UNICO e o ponto que nao da para deixar so no codigo.
         //
         // A #22 resolveu a normalizacao, mas duas instancias processando a mesma

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/UsuarioMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/UsuarioMap.cs
@@ -1,0 +1,26 @@
+using Copiloto.Dominio.Vendas;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Copiloto.Api.Persistencia.Mapeamentos;
+
+public class UsuarioMap : IEntityTypeConfiguration<Usuario>
+{
+    public void Configure(EntityTypeBuilder<Usuario> e)
+    {
+        e.ToTable("usuarios");
+        e.HasKey(u => u.Id);
+        e.Property(u => u.Nome).HasMaxLength(200).IsRequired();
+        e.Property(u => u.Email).HasMaxLength(200).IsRequired();
+
+        // 100 e folga sobre os 60 do BCrypt: Argon2 e mais longo, e a coluna
+        // curta demais seria descoberta no dia da troca de algoritmo, com o
+        // hash truncado silenciosamente pelo banco.
+        e.Property(u => u.SenhaHash).HasMaxLength(100).IsRequired();
+        e.Property(u => u.Perfil).HasConversion<string>().HasMaxLength(20).IsRequired();
+
+        // O email e a credencial de login: dois usuarios com o mesmo email
+        // fariam o login depender de qual linha o banco devolve primeiro.
+        e.HasIndex(u => u.Email).IsUnique().HasDatabaseName("ux_usuarios_email");
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904045810_UsuariosEDonoDoLead.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904045810_UsuariosEDonoDoLead.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904045810_UsuariosEDonoDoLead")]
+    partial class UsuariosEDonoDoLead
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904045810_UsuariosEDonoDoLead.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904045810_UsuariosEDonoDoLead.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class UsuariosEDonoDoLead : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "VendedorId",
+                table: "leads",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "usuarios",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Email = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    SenhaHash = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Perfil = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_usuarios", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_leads_vendedor",
+                table: "leads",
+                column: "VendedorId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_usuarios_email",
+                table: "usuarios",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "usuarios");
+
+            migrationBuilder.DropIndex(
+                name: "ix_leads_vendedor",
+                table: "leads");
+
+            migrationBuilder.DropColumn(
+                name: "VendedorId",
+                table: "leads");
+        }
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,7 +1,10 @@
+using Copiloto.Api.Auth;
 using Copiloto.Api.Ia;
 using Copiloto.Api.Ingestao;
 using Copiloto.Api.Persistencia;
 using Copiloto.Dominio.Ia;
+using Copiloto.Dominio.Vendas;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -27,7 +30,42 @@ builder.Services.AddSingleton(_ => new ResolvedorDeLead(
     builder.Configuration["WHATSAPP_NUMERO_EMPRESA"] ?? "+55 11 3333-4444"));
 builder.Services.AddHostedService<ProcessadorDeMensagens>();
 
+// Auth (#49). O segredo vem SO de variavel de ambiente: sem ela, a aplicacao
+// nao sobe. Cair para um segredo embutido seria pior que nao ter auth — daria a
+// impressao de proteger enquanto qualquer um forja um token de gestor.
+var tokens = new Tokens(builder.Configuration["JWT_SEGREDO"] ?? "");
+builder.Services.AddSingleton(tokens);
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(o => o.TokenValidationParameters = tokens.Validacao());
+
+builder.Services.AddAuthorization(o =>
+    o.AddPolicy("gestor", p => p.RequireRole(nameof(PerfilDeAcesso.Gestor))));
+
 var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// O login e o unico caminho que aceita senha, e ele responde a mesma coisa para
+// email inexistente e senha errada: dizer "usuario nao encontrado" entrega ao
+// atacante metade do trabalho — quais emails existem.
+app.MapPost("/auth/login", async (
+    Credenciais entrada, CopilotoDbContext ctx, Tokens tokens, CancellationToken ct) =>
+{
+    var email = (entrada.Email ?? "").Trim().ToLowerInvariant();
+    var usuario = await ctx.Usuarios.FirstOrDefaultAsync(u => u.Email == email, ct);
+
+    if (usuario is null || !Senhas.Confere(entrada.Senha ?? "", usuario.SenhaHash))
+        return Results.Unauthorized();
+
+    return Results.Ok(new
+    {
+        token = tokens.Emitir(usuario, DateTimeOffset.UtcNow),
+        expiraEm = DateTimeOffset.UtcNow + Tokens.Validade,
+        perfil = usuario.Perfil.ToString(),
+    });
+});
 
 app.MapGet("/saude", () => Results.Ok(new { ok = true }));
 
@@ -54,3 +92,6 @@ app.Run();
 
 /// <summary>Torna a classe gerada visivel para o WebApplicationFactory da suite.</summary>
 public partial class Program;
+
+/// <summary>O que chega no login. A senha nao passa disto para dentro.</summary>
+public record Credenciais(string? Email, string? Senha);

--- a/src/Copiloto.Dominio/Acesso/EscopoDeLeitura.cs
+++ b/src/Copiloto.Dominio/Acesso/EscopoDeLeitura.cs
@@ -1,0 +1,49 @@
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Dominio.Acesso;
+
+/// <summary>
+/// Quem pode ver o dado de quem (#49).
+///
+/// A regra mora no dominio, e nao no controller, pelo mesmo motivo das
+/// transicoes do Deal: regra em controller so e alcancada por teste que sobe a
+/// aplicacao, e a que decide se um vendedor le a carteira do colega precisa ser
+/// alcancavel por teste barato — senao ela e conferida uma vez, no dia em que
+/// foi escrita.
+/// </summary>
+public static class EscopoDeLeitura
+{
+    /// <summary>
+    /// Gestor ve tudo. Vendedor ve o que e dele e o que ainda nao tem dono.
+    ///
+    /// O lead SEM dono ser visivel e decisao de produto, nao descuido: ele
+    /// chega pelo WhatsApp sem atribuicao, e esconde-lo ate alguem assumir
+    /// significaria que a primeira mensagem de um cliente novo nao aparece para
+    /// ninguem. O preco e que a fila de entrada e comum — e ela e comum de
+    /// verdade, porque qualquer um pode assumir.
+    /// </summary>
+    public static bool PodeVer(Usuario usuario, Lead lead)
+    {
+        ArgumentNullException.ThrowIfNull(usuario);
+        ArgumentNullException.ThrowIfNull(lead);
+
+        if (usuario.EhGestor) return true;
+
+        return lead.VendedorId is null || lead.VendedorId == usuario.Id;
+    }
+
+    /// <summary>
+    /// O filtro equivalente, para a consulta nao trazer o que sera descartado
+    /// depois. Filtrar em memoria funcionaria e seria pior: o dado do outro
+    /// vendedor teria saido do banco, passado pela rede e chegado ao processo —
+    /// tres lugares a mais onde ele pode aparecer num log.
+    /// </summary>
+    public static IQueryable<Lead> Visiveis(IQueryable<Lead> leads, Usuario usuario)
+    {
+        ArgumentNullException.ThrowIfNull(usuario);
+
+        return usuario.EhGestor
+            ? leads
+            : leads.Where(l => l.VendedorId == null || l.VendedorId == usuario.Id);
+    }
+}

--- a/src/Copiloto.Dominio/Vendas/Lead.cs
+++ b/src/Copiloto.Dominio/Vendas/Lead.cs
@@ -27,6 +27,34 @@ public class Lead
     public string? Nome { get; private set; }
     public DateTimeOffset CriadoEm { get; }
 
+    /// <summary>
+    /// O vendedor dono deste lead (#49). Nulo enquanto ninguem assumiu.
+    ///
+    /// Lead entra pelo WhatsApp sem dono — nao ha formulario nem atribuicao no
+    /// caminho —, e por isso o nulo NAO pode significar "de ninguem": um lead
+    /// que so aparece depois de alguem atribuir e um lead que ninguem atende.
+    /// Sem dono, ele e da equipe; com dono, e de quem assumiu.
+    /// </summary>
+    public Guid? VendedorId { get; private set; }
+
+    /// <summary>
+    /// Assume o lead. Nao rouba: quem ja tem dono precisa ser liberado antes,
+    /// senao dois vendedores atendem o mesmo cliente sem saber um do outro.
+    /// </summary>
+    public string? Assumir(Guid vendedorId)
+    {
+        if (vendedorId == Guid.Empty)
+            throw new ArgumentException("Sem vendedor.", nameof(vendedorId));
+
+        if (VendedorId is { } dono && dono != vendedorId)
+            return "Este lead ja e de outro vendedor. Peca para ele liberar.";
+
+        VendedorId = vendedorId;
+        return null;
+    }
+
+    public void Liberar() => VendedorId = null;
+
     /// <summary>Nome descoberto no meio da conversa, que e como ele costuma chegar.</summary>
     public void Identificar(string nome)
     {

--- a/src/Copiloto.Dominio/Vendas/Usuario.cs
+++ b/src/Copiloto.Dominio/Vendas/Usuario.cs
@@ -1,9 +1,36 @@
 namespace Copiloto.Dominio.Vendas;
 
+/// <summary>
+/// O que a pessoa pode ver no CRM (#49).
+///
+/// Dois perfis, e nao uma lista de permissoes: a empresa que usa isto tem cinco
+/// vendedores e um dono. Permissao granular esta fora de escopo por decisao, e
+/// inventar niveis que ninguem pediu produz tela de administracao que ninguem
+/// configura — e, na duvida, todo mundo vira gestor.
+/// </summary>
+public enum PerfilDeAcesso
+{
+    /// <summary>Ve os proprios leads.</summary>
+    Vendedor = 0,
+
+    /// <summary>Ve tudo, e e quem enxerga a conta de IA.</summary>
+    Gestor = 1,
+}
+
 /// <summary>O vendedor. Quem decide, e a quem o dossie se dirige.</summary>
 public class Usuario
 {
-    public Usuario(Guid id, string nome, string email)
+    /// <summary>
+    /// Tamanho abaixo do qual o "hash" nao e hash de senha moderno.
+    ///
+    /// MD5 tem 32 caracteres em hexadecimal e SHA-1 tem 40; BCrypt gera 60 com
+    /// prefixo `$2`. A checagem existe porque trocar o algoritmo e uma linha, e
+    /// o efeito de trocar para o errado nao aparece em teste nenhum — aparece
+    /// no vazamento, anos depois, quando a base inteira e quebrada em horas.
+    /// </summary>
+    public const int TamanhoMinimoDoHash = 50;
+
+    public Usuario(Guid id, string nome, string email, string senhaHash, PerfilDeAcesso perfil)
     {
         if (id == Guid.Empty) throw new ArgumentException("Usuario sem id.", nameof(id));
         if (string.IsNullOrWhiteSpace(nome))
@@ -11,12 +38,43 @@ public class Usuario
         if (string.IsNullOrWhiteSpace(email))
             throw new ArgumentException("Usuario sem email.", nameof(email));
 
+        if (string.IsNullOrWhiteSpace(senhaHash) || senhaHash.Length < TamanhoMinimoDoHash)
+            throw new ArgumentException(
+                "Hash de senha curto demais para ser BCrypt ou Argon2. MD5 (32) e SHA-1 "
+                + "(40) nao servem para senha: sao rapidos de calcular, e e justamente a "
+                + "lentidao que protege a base depois de um vazamento.",
+                nameof(senhaHash));
+
         Id = id;
         Nome = nome.Trim();
-        Email = email.Trim();
+        Email = email.Trim().ToLowerInvariant();
+        SenhaHash = senhaHash;
+        Perfil = perfil;
     }
 
     public Guid Id { get; }
     public string Nome { get; }
+
+    /// <summary>Guardado em minusculas: e por ele que o login procura.</summary>
     public string Email { get; }
+
+    /// <summary>O hash. A senha em si nunca entra neste objeto.</summary>
+    public string SenhaHash { get; private set; }
+
+    /// <summary>
+    /// O tipo se chama `PerfilDeAcesso` e a propriedade `Perfil` de proposito:
+    /// com o mesmo nome nos dois, `Perfil == Perfil.Gestor` nao compila — o
+    /// compilador resolve o identificador como a propriedade.
+    /// </summary>
+    public PerfilDeAcesso Perfil { get; private set; }
+
+    public bool EhGestor => Perfil == PerfilDeAcesso.Gestor;
+
+    public void TrocarSenha(string novoHash)
+    {
+        if (string.IsNullOrWhiteSpace(novoHash) || novoHash.Length < TamanhoMinimoDoHash)
+            throw new ArgumentException("Hash curto demais.", nameof(novoHash));
+
+        SenhaHash = novoHash;
+    }
 }

--- a/testes/Copiloto.Testes/AuthTeste.cs
+++ b/testes/Copiloto.Testes/AuthTeste.cs
@@ -1,0 +1,251 @@
+using Copiloto.Api.Auth;
+using Copiloto.Dominio.Acesso;
+using Copiloto.Dominio.Vendas;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Auth com dois perfis (#49).
+///
+/// E o minimo para o painel por vendedor fazer sentido — e para o projeto nao
+/// ter uma falha obvia numa vitrine publica.
+/// </summary>
+public class AuthTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+    private const string Segredo = "segredo-de-teste-com-tamanho-suficiente-aqui";
+
+    private static Usuario Vendedor(Guid? id = null) => new(
+        id ?? Guid.NewGuid(), "Marina", "marina@torrefacao.com.br",
+        Senhas.Hash("senha-boa-de-verdade"), PerfilDeAcesso.Vendedor);
+
+    private static Usuario Gestor() => new(
+        Guid.NewGuid(), "Lucas", "lucas@torrefacao.com.br",
+        Senhas.Hash("outra-senha-boa"), PerfilDeAcesso.Gestor);
+
+    // --- Senha ---
+
+    [Fact]
+    public void A_senha_vira_hash_BCrypt_e_nunca_e_guardada()
+    {
+        var hash = Senhas.Hash("senha-boa-de-verdade");
+
+        Assert.StartsWith("$2", hash);                      // prefixo do BCrypt
+        Assert.DoesNotContain("senha-boa-de-verdade", hash);
+        Assert.True(hash.Length >= Usuario.TamanhoMinimoDoHash);
+    }
+
+    [Fact]
+    public void O_mesmo_texto_gera_hashes_diferentes()
+    {
+        // Sal por hash: sem isso, senhas iguais aparecem iguais no banco, e um
+        // vazamento entrega de graca quem usa "123456".
+        Assert.NotEqual(Senhas.Hash("mesma-senha"), Senhas.Hash("mesma-senha"));
+    }
+
+    [Fact]
+    public void A_senha_certa_confere_e_a_errada_nao()
+    {
+        var hash = Senhas.Hash("senha-boa-de-verdade");
+
+        Assert.True(Senhas.Confere("senha-boa-de-verdade", hash));
+        Assert.False(Senhas.Confere("senha-boa-de-verdad", hash));
+        Assert.False(Senhas.Confere("", hash));
+    }
+
+    [Fact]
+    public void Hash_corrompido_devolve_false_em_vez_de_explodir()
+    {
+        // Excecao aqui viraria erro 500 no login — e 500 conta ao atacante que
+        // aquele usuario tem algo diferente dos outros.
+        Assert.False(Senhas.Confere("qualquer", "isto-nao-e-um-hash"));
+    }
+
+    [Fact]
+    public void O_dominio_recusa_hash_com_cara_de_MD5_ou_SHA1()
+    {
+        // MD5 tem 32 caracteres, SHA-1 tem 40. Trocar o algoritmo e uma linha,
+        // e o efeito de trocar para o errado so aparece no vazamento.
+        var md5 = new string('a', 32);
+        var sha1 = new string('b', 40);
+
+        foreach (var fraco in new[] { md5, sha1 })
+        {
+            var erro = Assert.Throws<ArgumentException>(() => new Usuario(
+                Guid.NewGuid(), "Marina", "m@x.com", fraco, PerfilDeAcesso.Vendedor));
+
+            Assert.Contains("MD5", erro.Message);
+        }
+    }
+
+    // --- Token ---
+
+    [Fact]
+    public void O_token_carrega_quem_e_e_o_perfil()
+    {
+        var tokens = new Tokens(Segredo);
+        var gestor = Gestor();
+
+        var lido = tokens.Ler(tokens.Emitir(gestor, T0));
+
+        Assert.NotNull(lido);
+        Assert.Equal(gestor.Id, lido!.Value.UsuarioId);
+        Assert.Equal(PerfilDeAcesso.Gestor, lido.Value.Perfil);
+    }
+
+    [Fact]
+    public void O_token_nao_leva_email_nem_hash()
+    {
+        // Ele fica no navegador e viaja em header: carrega o minimo que o
+        // servidor precisa para decidir.
+        var tokens = new Tokens(Segredo);
+        var usuario = Vendedor();
+
+        var token = tokens.Emitir(usuario, T0);
+
+        Assert.DoesNotContain(usuario.Email, token);
+        Assert.DoesNotContain(usuario.SenhaHash, token);
+    }
+
+    [Fact]
+    public void Token_expirado_nao_vale()
+    {
+        var tokens = new Tokens(Segredo);
+
+        // Emitido ontem, com validade de oito horas.
+        var token = tokens.Emitir(Vendedor(), DateTimeOffset.UtcNow.AddDays(-1));
+
+        Assert.Null(tokens.Ler(token));
+    }
+
+    [Fact]
+    public void Token_assinado_com_outro_segredo_nao_vale()
+    {
+        // O caso que decide se a assinatura serve para alguma coisa.
+        var deles = new Tokens("outro-segredo-completamente-diferente-aqui");
+        var nosso = new Tokens(Segredo);
+
+        var forjado = deles.Emitir(Gestor(), DateTimeOffset.UtcNow);
+
+        Assert.Null(nosso.Ler(forjado));
+    }
+
+    [Fact]
+    public void Texto_qualquer_no_lugar_do_token_nao_derruba_a_leitura()
+    {
+        Assert.Null(new Tokens(Segredo).Ler("nao-e-um-token"));
+    }
+
+    [Fact]
+    public void Segredo_fraco_ou_ausente_derruba_a_subida()
+    {
+        // Cair para um segredo embutido seria pior que nao ter auth: daria a
+        // impressao de proteger enquanto qualquer um forja um token de gestor.
+        Assert.Throws<ArgumentException>(() => new Tokens(""));
+        Assert.Throws<ArgumentException>(() => new Tokens("curto-demais"));
+    }
+
+    [Fact]
+    public void A_validade_do_token_e_um_turno_e_nao_um_ano()
+    {
+        Assert.True(Tokens.Validade <= TimeSpan.FromHours(12));
+        Assert.True(Tokens.Validade >= TimeSpan.FromHours(1));
+    }
+
+    [Fact]
+    public void Nao_ha_tolerancia_silenciosa_de_relogio()
+    {
+        // O padrao da biblioteca sao cinco minutos: "expira em oito horas" com
+        // bonus que ninguem escreveu e regra que ninguem sabe que existe.
+        Assert.Equal(TimeSpan.Zero, new Tokens(Segredo).Validacao().ClockSkew);
+    }
+
+    // --- Escopo ---
+
+    [Fact]
+    public void Vendedor_nao_ve_lead_de_outro_vendedor()
+    {
+        // O criterio de aceite que existe para o projeto nao ter falha obvia.
+        var marina = Vendedor();
+        var doOutro = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+        doOutro.Assumir(Guid.NewGuid());
+
+        Assert.False(EscopoDeLeitura.PodeVer(marina, doOutro));
+    }
+
+    [Fact]
+    public void Vendedor_ve_o_proprio_lead()
+    {
+        var marina = Vendedor();
+        var dela = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+        dela.Assumir(marina.Id);
+
+        Assert.True(EscopoDeLeitura.PodeVer(marina, dela));
+    }
+
+    [Fact]
+    public void Lead_sem_dono_e_da_equipe()
+    {
+        // Decisao de produto: o lead chega pelo WhatsApp sem atribuicao, e
+        // esconde-lo ate alguem assumir faria a primeira mensagem de um cliente
+        // novo nao aparecer para ninguem.
+        var semDono = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+
+        Assert.True(EscopoDeLeitura.PodeVer(Vendedor(), semDono));
+    }
+
+    [Fact]
+    public void Gestor_ve_tudo()
+    {
+        var doVendedor = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+        doVendedor.Assumir(Guid.NewGuid());
+
+        Assert.True(EscopoDeLeitura.PodeVer(Gestor(), doVendedor));
+    }
+
+    [Fact]
+    public void O_filtro_da_consulta_concorda_com_a_regra()
+    {
+        // Duas formas da mesma regra divergindo e o jeito classico de vazar:
+        // a tela filtra certo e o relatorio, escrito depois, nao.
+        var marina = Vendedor();
+        var dela = new Lead(Guid.NewGuid(), "+5511900000001", T0);
+        dela.Assumir(marina.Id);
+        var doOutro = new Lead(Guid.NewGuid(), "+5511900000002", T0);
+        doOutro.Assumir(Guid.NewGuid());
+        var semDono = new Lead(Guid.NewGuid(), "+5511900000003", T0);
+
+        var todos = new[] { dela, doOutro, semDono }.AsQueryable();
+
+        var visiveis = EscopoDeLeitura.Visiveis(todos, marina).ToList();
+
+        Assert.Equal(2, visiveis.Count);
+        Assert.DoesNotContain(doOutro, visiveis);
+        Assert.All(visiveis, l => Assert.True(EscopoDeLeitura.PodeVer(marina, l)));
+        Assert.Equal(3, EscopoDeLeitura.Visiveis(todos, Gestor()).Count());
+    }
+
+    [Fact]
+    public void Assumir_lead_de_outro_e_recusado_com_motivo()
+    {
+        // Dois vendedores no mesmo cliente sem saber um do outro e pior que
+        // ninguem atender: o cliente recebe duas propostas diferentes.
+        var lead = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+        lead.Assumir(Guid.NewGuid());
+
+        var recusa = lead.Assumir(Guid.NewGuid());
+
+        Assert.NotNull(recusa);
+        Assert.Contains("liberar", recusa);
+    }
+
+    [Fact]
+    public void Assumir_o_que_ja_e_seu_nao_e_erro()
+    {
+        var vendedor = Guid.NewGuid();
+        var lead = new Lead(Guid.NewGuid(), "+5511988887777", T0);
+        lead.Assumir(vendedor);
+
+        Assert.Null(lead.Assumir(vendedor));
+    }
+}

--- a/testes/Copiloto.Testes/AuthTeste.cs
+++ b/testes/Copiloto.Testes/AuthTeste.cs
@@ -83,10 +83,14 @@ public class AuthTeste
     [Fact]
     public void O_token_carrega_quem_e_e_o_perfil()
     {
+        // Emitido AGORA, e nao num T0 fixo: a validacao usa o relogio do
+        // sistema, entao um token datado de 10:00 UTC ainda nao vale as 05:00 —
+        // e o teste falharia so em certas horas do dia, que e a pior forma de
+        // teste intermitente.
         var tokens = new Tokens(Segredo);
         var gestor = Gestor();
 
-        var lido = tokens.Ler(tokens.Emitir(gestor, T0));
+        var lido = tokens.Ler(tokens.Emitir(gestor, DateTimeOffset.UtcNow));
 
         Assert.NotNull(lido);
         Assert.Equal(gestor.Id, lido!.Value.UsuarioId);
@@ -101,7 +105,7 @@ public class AuthTeste
         var tokens = new Tokens(Segredo);
         var usuario = Vendedor();
 
-        var token = tokens.Emitir(usuario, T0);
+        var token = tokens.Emitir(usuario, DateTimeOffset.UtcNow);
 
         Assert.DoesNotContain(usuario.Email, token);
         Assert.DoesNotContain(usuario.SenhaHash, token);

--- a/testes/Copiloto.Testes/Copiloto.Testes.csproj
+++ b/testes/Copiloto.Testes/Copiloto.Testes.csproj
@@ -10,6 +10,9 @@
          suite continua rodando offline como o CLAUDE.md manda. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- O teste de auth confere hash e token de verdade (#49). -->
+    <PackageReference Include="BCrypt.Net-Next" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
## O que muda
Login com JWT, dois perfis (vendedor/gestor), senha com BCrypt e escopo de leitura no dominio.

## Decisoes
- **Sem `JWT_SEGREDO` (32+ chars) a aplicacao nao sobe.** Cair para segredo embutido seria pior que nao ter auth: daria impressao de proteger enquanto qualquer um forja token de gestor.
- **O dominio recusa hash com cara de MD5/SHA-1** (menos de 50 caracteres). Ele nao pode usar BCrypt — nao tem PackageReference (#48) —, entao garante o que da para garantir sem pacote.
- **ClockSkew zero**, contra o padrao de 5 minutos da biblioteca: "expira em 8h" com bonus silencioso e regra que ninguem escreveu.
- **Lead sem dono e visivel a todos** — decisao de produto: ele chega pelo WhatsApp sem atribuicao, e esconde-lo faria a primeira mensagem de um cliente novo nao aparecer para ninguem.
- **Duas formas da mesma regra** (`PodeVer` e `Visiveis`) com teste comparando as duas: divergirem e o jeito classico de vazar — a tela filtra certo e o relatorio, escrito depois, nao.

## Efeito colateral que virou correcao
A validacao do segredo derrubou `dotnet ef migrations add`, que subia o `Program` inteiro. Entrou `IDesignTimeDbContextFactory` — a saida barata teria sido enfraquecer a validacao para a ferramenta voltar a funcionar.

## Dependencias conferidas
`dotnet package search` em 04/09/2026: JwtBearer **9.0.19** (mesma faixa do EF ja usado), BCrypt.Net-Next **4.2.0**.

## Fora deste PR
Proteger os endpoints existentes com `[Authorize]` e aplicar o escopo nas consultas do MCP: e a #58, que trata escopo, autenticacao e auditoria daquela superficie.

Closes #49