### PR TITLE
Carga de 30s com autocannon, com os numeros no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,35 @@ Isto não é um wrapper de LLM. As peças que importam:
 | **PII Shield** | CPF, telefone e e-mail são mascarados antes de sair da rede. Teste falha se vazar. |
 | **Ledger + ROI** | Custo por invocação, ligado ao Deal. Responde quanto gastou **e quanto rendeu**. |
 
+### Carga: o número, e não "ficou rápido"
+
+Medido em 04/09/2026, 30s por cenário, com `./scripts/stress.sh`. **Sem provedor de IA
+configurado** — o teste mede esta aplicação, não a latência da API de um fornecedor.
+
+| Cenário | Conexões | RPS | p50 | p90 | p99 | máx | Erros |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `GET /saude` | 10 | 38.056 | 0 ms | 0 ms | 0 ms | 3 ms | 0 |
+| `GET /saude` | 100 | 12.016 | 8 ms | 10 ms | 17 ms | 71 ms | 0 |
+| `POST /webhook/whatsapp` | 10 | 17.237 | 0 ms | 1 ms | 2 ms | 49 ms | 0 |
+| `POST /webhook/whatsapp` | 100 | 22.465 | 4 ms | 6 ms | 9 ms | 75 ms | 0 |
+
+Máquina: i7-1355U (12 threads), 16 GB, .NET 9.0.203, Linux. **RPS sem máquina não compara
+com nada**, e é por isso que ela está aqui.
+
+O webhook sustenta **p99 de 9 ms com 100 conexões**, bem abaixo do limite de 100 ms que a
+issue pedia. Nenhum erro, nenhum timeout e nenhum não-2xx em 1,19 milhão de requisições: a
+fila absorveu tudo sem precisar recusar.
+
+Dois números que só aparecem medindo:
+
+- **O webhook rende mais com 100 conexões do que com 10** (22 mil RPS contra 17 mil). Com
+  poucas conexões o gargalo é o ida-e-volta, não o servidor.
+- **`/saude` com 100 conexões rendeu menos que o webhook**, o que parece absurdo para um
+  endpoint que devolve `{"ok":true}`. A explicação está no processo: o worker de ingestão
+  ainda drenava as 673 mil mensagens do cenário anterior, **e escreve uma linha de log por
+  mensagem**. O que a medição pegou foi o custo do log competindo por CPU com o servidor
+  HTTP — resultado sobre a aplicação, não sobre o endpoint.
+
 ### A parte que quase ninguém faz: a conta fechada
 
 Quase todo projeto de IA sabe dizer o que **gastou**. Praticamente nenhum sabe dizer o

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Carga de 30s nos endpoints que recebem trafego (#54).
+#
+# A IA fica com FakeProvider de proposito: com provedor real o teste mediria a
+# latencia da API do fornecedor, e nao este codigo. Aqui nao ha provedor nenhum
+# configurado — e esse e o ponto.
+#
+# Uso:
+#   dotnet run --project src/Copiloto.Api --urls http://localhost:5290 -c Release
+#   ./scripts/stress.sh [url]
+#
+# Release, e nao Debug: medir o binario com otimizacao desligada produz um
+# numero que nao existe em lugar nenhum.
+
+set -euo pipefail
+
+URL="${1:-http://localhost:5290}"
+SAIDA="${SAIDA:-$(mktemp -d)}"
+CORPO="$SAIDA/corpo.json"
+
+cat > "$CORPO" <<'JSON'
+{"providerMessageId":"wamid.carga","de":"+55 11 98888-1111","para":"+55 11 3333-4444","texto":"qual o valor do kg?","enviadaEm":"2026-09-04T13:00:00Z"}
+JSON
+
+if ! curl -sf -m 2 "$URL/saude" > /dev/null; then
+  echo "A aplicacao nao respondeu em $URL/saude. Suba antes de medir." >&2
+  exit 1
+fi
+
+medir() {  # nome conexoes [extras...]
+  local nome="$1" conexoes="$2"; shift 2
+  npx --yes autocannon@8 -c "$conexoes" -d 30 -j "$@" > "$SAIDA/$nome.json" 2>/dev/null
+  python3 - "$SAIDA/$nome.json" "$nome" "$conexoes" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1])); l = d["latency"]
+print(f"{sys.argv[2]:<10} c={sys.argv[3]:<4} "
+      f"RPS={d['requests']['average']:>10.0f}  "
+      f"p50={l['p50']:>3}ms p90={l.get('p90', '-'):>3}ms p99={l['p99']:>3}ms max={l['max']:>4}ms  "
+      f"erros={d['errors']} timeouts={d['timeouts']} non2xx={d['non2xx']}")
+PY
+}
+
+echo "Medindo $URL — 30s por cenario, resultados em $SAIDA"
+medir saude 10 "$URL/saude"
+medir saude 100 "$URL/saude"
+medir webhook 10 -m POST -H "Content-Type=application/json" -i "$CORPO" "$URL/webhook/whatsapp"
+medir webhook 100 -m POST -H "Content-Type=application/json" -i "$CORPO" "$URL/webhook/whatsapp"
+
+echo
+echo "Lembre de reportar a MAQUINA junto do numero: RPS sem maquina nao compara com nada."


### PR DESCRIPTION
## O que muda
`scripts/stress.sh` (quatro cenarios, 30s cada, 10 e 100 conexoes) e os resultados no README, com a maquina ao lado.

## O criterio, atendido com folga
Webhook com **p99 de 9 ms a 100 conexoes**, contra o limite de 100 ms da issue. **1,19 milhao de requisicoes sem um erro, um timeout ou um nao-2xx** — a fila absorveu tudo sem recusar.

Sem provedor de IA configurado, como a issue exige: com provedor real o teste mediria a API do fornecedor.

## Dois numeros que a intuicao nao dava
- **O webhook rende mais com 100 conexoes que com 10** (22 mil RPS contra 17 mil): com poucas conexoes o gargalo e o ida-e-volta. Medir so com 10 daria numero pessimista e conclusao errada sobre o limite.
- **`/saude` rendeu menos que o webhook a 100 conexoes**, devolvendo `{"ok":true}`. Nao e o endpoint: o worker ainda drenava 673 mil mensagens e **escreve uma linha de log por mensagem**. A carga pegou o log competindo por CPU com o servidor HTTP — resultado sobre a aplicacao, mais util que o do endpoint.

Closes #54