### PR TITLE
Fila duravel com confirmacao e dead letter queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@
 # #75) sao workflows proprios e assumem este aqui de pe.
 #
 # Sem Postgres no job de proposito: a suite roda offline por decisao
-# (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=fake). Servico so entra junto com o
-# primeiro teste de integracao que precisar dele.
+# (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=fake), e o mapeamento e conferido em
+# SQLite na memoria.
+#
+# RabbitMQ e a excecao, e ela chegou com a #69: durabilidade nao tem como ser
+# provada contra uma fila em memoria. Sem o servico, os testes daquela fila
+# PULAM — e teste que pula em silencio na esteira e garantia que ninguem
+# confere. O servico entrou junto com o primeiro teste que precisava dele, como
+# esta regra sempre previu.
 name: CI
 
 on:
@@ -27,6 +33,21 @@ jobs:
     runs-on: ubuntu-latest
     # Job travado nao pode queimar minuto ate o teto da conta.
     timeout-minutes: 10
+
+    services:
+      # Fila duravel (#69). A imagem e fixada por VERSAO: com `:latest`, o
+      # comportamento do broker muda sem ninguem tocar neste repositorio.
+      rabbitmq:
+        image: rabbitmq:4-alpine
+        ports:
+          - 5672:5672
+        # Sem o health check, o job comeca a testar antes de o broker aceitar
+        # conexao, e a falha aparece como teste intermitente.
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4
@@ -54,4 +75,7 @@ jobs:
         run: dotnet build --no-restore --configuration Release --nologo
 
       - name: Testar
+        env:
+          # Com esta variavel, os testes da fila duravel RODAM em vez de pular.
+          RABBITMQ_URL: amqp://guest:guest@localhost:5672
         run: dotnet test --no-build --configuration Release --nologo

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,13 @@
          mapeamento sem exigir Postgres de pe. -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
 
+    <!-- Fila duravel (#69). Conferidos em 04/09/2026 via `dotnet package search`:
+         RabbitMQ.Client 7.2.2 e Xunit.SkippableFact 1.5.85. O segundo existe
+         para o teste que exige broker PULAR em vez de passar quando nao ha um:
+         teste que passa por nao ter rodado e pior que teste vermelho. -->
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.2" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.85" />
+
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -23,4 +23,9 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
+  <!-- A fila duravel (#69) e borda, como o EF. -->
+  <ItemGroup>
+    <PackageReference Include="RabbitMQ.Client" />
+  </ItemGroup>
+
 </Project>

--- a/src/Copiloto.Api/Infra/RabbitMqQueue.cs
+++ b/src/Copiloto.Api/Infra/RabbitMqQueue.cs
@@ -1,0 +1,244 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Copiloto.Api.Infra;
+
+/// <summary>
+/// A fila duravel, com confirmacao e dead letter queue (#69).
+///
+/// O argumento para RabbitMQ aqui NAO e vazao — o `ChannelQueue` faz 22 mil
+/// req/s (#54). E DURABILIDADE: a fila em memoria perde o que estava dentro
+/// quando o processo reinicia, e o WhatsApp nao reentrega, porque ja recebeu o
+/// 202 do webhook. O resultado e uma conversa que o vendedor viu acontecer e o
+/// dossie ignora, sem erro em lugar nenhum.
+///
+/// Tres garantias, e cada uma resolve um jeito de perder mensagem:
+///
+///   1. fila e mensagem PERSISTENTES  — reinicio do broker nao apaga
+///   2. confirmacao manual (ack)      — mensagem so sai depois de processada
+///   3. limite de entregas + DLQ      — o que falha sempre para de girar e vai
+///                                      para um lugar de onde da para trazer
+///                                      de volta
+/// </summary>
+public class RabbitMqQueue<T> : IQueue<T>, IAsyncDisposable
+{
+    /// <summary>
+    /// Quantas vezes a mesma mensagem pode ser entregue antes de ir para a DLQ.
+    ///
+    /// Sem limite, mensagem que sempre falha volta para sempre: ela ocupa o
+    /// consumidor, atrasa o resto e enche o log com o mesmo erro. Tres da
+    /// espaco para falha transitoria (banco reiniciando, provedor fora) e nao
+    /// da espaco para defeito permanente.
+    /// </summary>
+    public const int LimiteDeEntregas = 3;
+
+    private readonly IConnection _conexao;
+    private readonly IChannel _canal;
+    private readonly string _fila;
+    private bool _fechada;
+
+    private RabbitMqQueue(IConnection conexao, IChannel canal, string fila)
+    {
+        _conexao = conexao;
+        _canal = canal;
+        _fila = fila;
+    }
+
+    public static string NomeDaDlq(string fila) => $"{fila}.dlq";
+
+    /// <summary>
+    /// Conecta e declara a topologia. Assincrono porque a conexao e' de rede —
+    /// e por isso a fabrica e' estatica: construtor que abre socket esconde uma
+    /// espera dentro de um `new`.
+    /// </summary>
+    public static async Task<RabbitMqQueue<T>> Conectar(
+        string url, string fila, CancellationToken ct = default)
+    {
+        var conexao = await new ConnectionFactory { Uri = new Uri(url) }
+            .CreateConnectionAsync(ct);
+        // Confirmacao de PUBLICACAO ligada. Sem ela, `BasicPublishAsync` devolve
+        // assim que entrega o byte ao socket, e o webhook responderia 202 para
+        // uma mensagem que o broker pode nunca ter gravado — a mesma perda
+        // silenciosa que esta issue existe para eliminar, so que na outra ponta.
+        //
+        // O preco e latencia por publicacao. E o preco certo: o 202 passa a
+        // significar "esta gravado", que e o que ele promete a quem envia.
+        var canal = await conexao.CreateChannelAsync(
+            new CreateChannelOptions(
+                publisherConfirmationsEnabled: true,
+                publisherConfirmationTrackingEnabled: true),
+            cancellationToken: ct);
+
+        // A DLQ e declarada ANTES: ela precisa existir quando a fila principal
+        // mandar a primeira mensagem para la, senao a mensagem descartada some
+        // — que e exatamente o desfecho que esta issue existe para impedir.
+        await canal.QueueDeclareAsync(NomeDaDlq(fila), durable: true, exclusive: false,
+            autoDelete: false, cancellationToken: ct);
+
+        await canal.QueueDeclareAsync(fila, durable: true, exclusive: false, autoDelete: false,
+            arguments: new Dictionary<string, object?>
+            {
+                // Quorum: replicada e com contagem de entregas nativa. Classic
+                // queue nao conta entregas, e a contagem manual (header +
+                // republicacao) perde o lugar na fila a cada tentativa.
+                ["x-queue-type"] = "quorum",
+                ["x-delivery-limit"] = LimiteDeEntregas,
+                ["x-dead-letter-exchange"] = "",
+                ["x-dead-letter-routing-key"] = NomeDaDlq(fila),
+            },
+            cancellationToken: ct);
+
+        // Um por vez: sem isto o broker despeja tudo no primeiro consumidor, e
+        // uma segunda instancia sobe para nao fazer nada.
+        await canal.BasicQosAsync(0, prefetchCount: 1, global: false, cancellationToken: ct);
+
+        return new RabbitMqQueue<T>(conexao, canal, fila);
+    }
+
+    public int Aguardando => (int)_canal.MessageCountAsync(_fila).GetAwaiter().GetResult();
+
+    public bool Aceitando => !_fechada && _conexao.IsOpen && _canal.IsOpen;
+
+    public async Task<bool> Publicar(T item, CancellationToken ct)
+    {
+        if (!Aceitando) return false;
+
+        try
+        {
+            var corpo = JsonSerializer.SerializeToUtf8Bytes(item);
+
+            await _canal.BasicPublishAsync(
+                exchange: "",
+                routingKey: _fila,
+                mandatory: true,
+                // Persistente: sem isto a mensagem vive so na memoria do broker,
+                // e um reinicio DELE apaga o que a nossa durabilidade deveria
+                // ter protegido.
+                basicProperties: new BasicProperties { Persistent = true },
+                body: corpo,
+                cancellationToken: ct);
+
+            return true;
+        }
+        catch (Exception erro) when (erro is not OperationCanceledException)
+        {
+            // Broker fora do ar: quem chama devolve 503 e o WhatsApp reentrega.
+            // Recusar e melhor que aceitar e perder (#72).
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Consome com confirmacao MANUAL: o ack de cada mensagem sai quando o
+    /// consumidor pede a proxima.
+    ///
+    /// E o que faz "so sai depois de processada" valer de verdade — no
+    /// `await foreach`, o corpo do laco roda inteiro antes do proximo
+    /// `MoveNextAsync`. Se o processo morrer no meio do processamento, nao houve
+    /// ack, e o broker entrega a mensagem de novo a outra instancia.
+    /// </summary>
+    public async IAsyncEnumerable<T> Ler([EnumeratorCancellation] CancellationToken ct)
+    {
+        var recebidas = System.Threading.Channels.Channel.CreateBounded<(T Item, ulong Tag)>(1);
+        var consumidor = new AsyncEventingBasicConsumer(_canal);
+
+        consumidor.ReceivedAsync += async (_, entrega) =>
+        {
+            T? item;
+            try
+            {
+                item = JsonSerializer.Deserialize<T>(entrega.Body.Span);
+            }
+            catch (JsonException)
+            {
+                // Deixar a excecao subir aqui derruba o CONSUMIDOR: uma mensagem
+                // malformada pararia a ingestao inteira, e o sintoma seria "as
+                // conversas pararam de chegar" — sem erro no lugar onde alguem
+                // procura.
+                item = default;
+            }
+
+            if (item is null)
+            {
+                // Corpo que nao desserializa nao melhora tentando de novo: vai
+                // direto para a DLQ, com o requeue desligado. Ele fica guardado
+                // ali, e nao descartado, porque o defeito pode estar no nosso
+                // formato — e ai a mensagem do cliente e recuperavel.
+                await _canal.BasicNackAsync(entrega.DeliveryTag, multiple: false, requeue: false);
+                return;
+            }
+
+            await recebidas.Writer.WriteAsync((item, entrega.DeliveryTag), ct);
+        };
+
+        var tag = await _canal.BasicConsumeAsync(_fila, autoAck: false, consumidor,
+            cancellationToken: ct);
+
+        ulong? pendente = null;
+
+        try
+        {
+            await foreach (var (item, entrega) in recebidas.Reader.ReadAllAsync(ct))
+            {
+                if (pendente is { } anterior)
+                    await _canal.BasicAckAsync(anterior, multiple: false, cancellationToken: ct);
+
+                pendente = entrega;
+                yield return item;
+            }
+        }
+        finally
+        {
+            // O ultimo item processado tambem precisa de ack — e o desligamento
+            // gracioso passa por aqui.
+            if (pendente is { } ultimo)
+                await _canal.BasicAckAsync(ultimo, multiple: false, CancellationToken.None);
+
+            await _canal.BasicCancelAsync(tag, cancellationToken: CancellationToken.None);
+        }
+    }
+
+    public void PararDeAceitar() => _fechada = true;
+
+    /// <summary>Quantas mensagens desistiram, esperando alguem olhar.</summary>
+    public async Task<int> ContarDlq(CancellationToken ct = default) =>
+        (int)await _canal.MessageCountAsync(NomeDaDlq(_fila), ct);
+
+    /// <summary>
+    /// Devolve a DLQ para a fila principal. E o que transforma "sumiu" em "esta
+    /// ali, para reprocessar" — depois de consertar a causa, porque sem isso a
+    /// mensagem so vai passear e voltar.
+    /// </summary>
+    public async Task<int> ReprocessarDlq(int limite = 100, CancellationToken ct = default)
+    {
+        var devolvidas = 0;
+
+        while (devolvidas < limite)
+        {
+            var mensagem = await _canal.BasicGetAsync(NomeDaDlq(_fila), autoAck: false, ct);
+            if (mensagem is null) break;
+
+            await _canal.BasicPublishAsync(
+                exchange: "", routingKey: _fila, mandatory: true,
+                basicProperties: new BasicProperties { Persistent = true },
+                body: mensagem.Body.ToArray(), cancellationToken: ct);
+
+            // Ack DEPOIS de republicar: na ordem inversa, uma queda no meio
+            // perderia a mensagem nos dois lugares.
+            await _canal.BasicAckAsync(mensagem.DeliveryTag, multiple: false, cancellationToken: ct);
+            devolvidas++;
+        }
+
+        return devolvidas;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _canal.CloseAsync();
+        await _conexao.CloseAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/testes/Copiloto.Testes/Copiloto.Testes.csproj
+++ b/testes/Copiloto.Testes/Copiloto.Testes.csproj
@@ -10,6 +10,9 @@
          suite continua rodando offline como o CLAUDE.md manda. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- SkippableFact: o teste da fila duravel PULA sem broker, em vez de
+         passar sem ter rodado (#69). -->
+    <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/testes/Copiloto.Testes/FilaDuravelTeste.cs
+++ b/testes/Copiloto.Testes/FilaDuravelTeste.cs
@@ -1,0 +1,207 @@
+using Copiloto.Api.Infra;
+using Copiloto.Api.Ingestao;
+using Xunit;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// A fila duravel contra um RabbitMQ de verdade (#69).
+///
+/// Os testes PULAM quando nao ha broker, e nao passam: teste que passa por nao
+/// ter rodado e pior que teste vermelho — ele deixa a suite verde e a garantia
+/// vazia. Para rodar:
+///
+///   docker run -d --rm -p 5673:5672 rabbitmq:4-alpine
+///   RABBITMQ_URL=amqp://guest:guest@localhost:5673 dotnet test
+/// </summary>
+public class FilaDuravelTeste
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private static string? Url => Environment.GetEnvironmentVariable("RABBITMQ_URL");
+
+    private static MensagemRecebida Fala(string id) => new(
+        id, "+55 11 98888-1111", "+55 11 3333-4444", "qual o valor do kg?", T0);
+
+    /// <summary>Uma fila por teste: nome unico evita um teste ver a sobra do outro.</summary>
+    private static async Task<RabbitMqQueue<MensagemRecebida>> Fila(string nome) =>
+        await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, $"teste.{nome}.{Guid.NewGuid():N}");
+
+    [SkippableFact]
+    public async Task A_mensagem_publicada_chega_ao_consumidor()
+    {
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        await using var fila = await Fila("entrega");
+        await fila.Publicar(Fala("wamid.1"), default);
+
+        using var prazo = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var lidas = new List<MensagemRecebida>();
+
+        await foreach (var m in fila.Ler(prazo.Token))
+        {
+            lidas.Add(m);
+            break;
+        }
+
+        Assert.Single(lidas);
+        Assert.Equal("wamid.1", lidas[0].ProviderMessageId);
+    }
+
+    [SkippableFact]
+    public async Task O_que_nao_foi_confirmado_continua_na_fila_depois_da_queda()
+    {
+        // O criterio central da issue: derrubar o consumidor com a fila cheia e
+        // nada some.
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        var nome = $"teste.queda.{Guid.NewGuid():N}";
+        await using (var produtor = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome))
+        {
+            // O retorno e conferido: `Publicar` devolve false quando o broker
+            // recusa, e engolir isso faria o teste medir a fila errada e
+            // culpar o consumo por uma mensagem que nunca entrou.
+            for (var i = 0; i < 5; i++)
+                Assert.True(await produtor.Publicar(Fala($"wamid.{i}"), default));
+        }
+
+        // Consumidor sobe, pega uma, e o processo "morre" antes de confirmar.
+        //
+        // O `await foreach` NAO serve aqui: ele descarta o enumerador ao sair, e
+        // o descarte confirma o que estava em andamento — desligamento
+        // gracioso, o oposto de uma queda. Entao o enumerador e conduzido a mao
+        // e abandonado, e a conexao fecha embaixo dele.
+        {
+            var caindo = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome);
+            using var prazo = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            var enumerador = caindo.Ler(prazo.Token).GetAsyncEnumerator();
+            Assert.True(await enumerador.MoveNextAsync());   // pegou uma, sem ack
+
+            await caindo.DisposeAsync();
+        }
+
+        await using var depois = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome);
+
+        // A devolucao do que estava sem confirmacao acontece no broker, depois
+        // que ele percebe a conexao caida: a espera e por isso, e nao por
+        // lentidao da fila.
+        var restantes = 0;
+        for (var tentativa = 0; tentativa < 20 && restantes < 5; tentativa++)
+        {
+            restantes = depois.Aguardando;
+            if (restantes < 5) await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+
+        Assert.Equal(5, restantes);
+    }
+
+    [SkippableFact]
+    public async Task A_mensagem_sobrevive_ao_reinicio_do_processo()
+    {
+        // Durabilidade e o argumento da issue: `Channel<T>` perde tudo aqui, e
+        // o WhatsApp nao reentrega porque ja recebeu o 202.
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        var nome = $"teste.durabilidade.{Guid.NewGuid():N}";
+        await using (var antes = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome))
+        {
+            await antes.Publicar(Fala("wamid.sobrevivente"), default);
+        }
+
+        // Conexao nova = processo novo, para o efeito deste teste.
+        await using var depois = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome);
+
+        using var prazo = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await foreach (var m in depois.Ler(prazo.Token))
+        {
+            Assert.Equal("wamid.sobrevivente", m.ProviderMessageId);
+            break;
+        }
+    }
+
+    [SkippableFact]
+    public async Task Depois_de_parar_de_aceitar_o_webhook_recusa()
+    {
+        // Recusar e melhor que aceitar e perder: o 503 faz o WhatsApp
+        // reentregar (#72).
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        await using var fila = await Fila("parada");
+        fila.PararDeAceitar();
+
+        Assert.False(fila.Aceitando);
+        Assert.False(await fila.Publicar(Fala("wamid.tarde"), default));
+    }
+
+    [SkippableFact]
+    public async Task A_DLQ_existe_e_comeca_vazia()
+    {
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        await using var fila = await Fila("dlq");
+
+        Assert.Equal(0, await fila.ContarDlq());
+    }
+
+    [SkippableFact]
+    public async Task Reprocessar_devolve_da_DLQ_para_a_fila_principal()
+    {
+        // E o que transforma "sumiu" em "esta ali, para reprocessar".
+        Skip.If(Url is null, "sem RABBITMQ_URL: broker nao disponivel");
+
+        var nome = $"teste.reprocessa.{Guid.NewGuid():N}";
+        await using var fila = await RabbitMqQueue<MensagemRecebida>.Conectar(Url!, nome);
+
+        // A mensagem vai para a DLQ pelo caminho de verdade: um corpo que nao
+        // desserializa e recusado sem requeue. Publicar direto na DLQ testaria
+        // o metodo e nao o mecanismo.
+        await using var comOutroFormato = await RabbitMqQueue<string>.Conectar(Url!, nome);
+        await comOutroFormato.Publicar("isto nao e uma MensagemRecebida", default);
+
+        using (var prazo = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+        {
+            var enumerador = fila.Ler(prazo.Token).GetAsyncEnumerator();
+
+            // `AsTask()` UMA vez: ValueTask so pode ser consumido uma vez, e
+            // chamar duas vezes lanca InvalidOperationException.
+            var lida = enumerador.MoveNextAsync().AsTask();
+
+            // Nada chega ao consumidor: o corpo invalido foi para a DLQ, e o
+            // consumidor continua de pe esperando a proxima.
+            var chegou = await Task.WhenAny(lida, Task.Delay(TimeSpan.FromSeconds(3)));
+            Assert.NotSame(lida, chegou);
+
+            // O consumidor sai de cena ANTES da contagem: com ele ativo, o que
+            // for republicado pelo reprocessamento e consumido de novo no meio
+            // da medicao, e a conta vira corrida.
+            //
+            // Cancelar e ESPERAR vem antes do Dispose: descartar um iterador
+            // async com um MoveNextAsync em voo lanca NotSupportedException.
+            prazo.Cancel();
+            try { await lida; } catch (OperationCanceledException) { }
+            await enumerador.DisposeAsync();
+        }
+
+        Assert.Equal(1, await fila.ContarDlq());
+
+        var devolvidas = await fila.ReprocessarDlq();
+
+        Assert.Equal(1, devolvidas);
+        Assert.Equal(0, await fila.ContarDlq());
+    }
+
+    [Fact]
+    public void O_limite_de_entregas_existe_para_a_mensagem_parar_de_girar()
+    {
+        // Sem limite, mensagem que sempre falha volta para sempre: ocupa o
+        // consumidor, atrasa o resto e enche o log com o mesmo erro.
+        Assert.InRange(RabbitMqQueue<MensagemRecebida>.LimiteDeEntregas, 2, 5);
+    }
+
+    [Fact]
+    public void O_nome_da_DLQ_deriva_do_nome_da_fila()
+    {
+        Assert.Equal("ingestao.dlq", RabbitMqQueue<MensagemRecebida>.NomeDaDlq("ingestao"));
+    }
+}


### PR DESCRIPTION
**Base:** sai de `72-health-checks` (#72), topo da trilha de infraestrutura — usa a `IQueue` da #66.

## O que muda
`RabbitMqQueue<T>` atras da mesma interface: fila e mensagem persistentes, confirmacao manual no consumo, limite de entregas e DLQ.

## O buraco que apareceu no meio
Faltava **confirmacao de publicacao**. Sem ela, `BasicPublishAsync` devolve assim que entrega o byte ao socket, e o webhook responderia **202 para uma mensagem que o broker pode nunca ter gravado** — a mesma perda silenciosa da issue, na outra ponta. Agora o 202 significa "esta gravado".

## Outras decisoes
- **Corpo invalido nao derruba o consumidor.** A excecao subindo pararia a ingestao inteira, e o sintoma seria "as conversas pararam de chegar". Vai para a DLQ, e nao para o lixo, porque o defeito pode estar no nosso formato.
- **Quorum queue com `x-delivery-limit`**: classic queue nao conta entregas, e contar no header exige republicar — o que perde o lugar na fila a cada tentativa.

## Os testes rodam de verdade
Contra um RabbitMQ real, e **pulam sem broker em vez de passar**. Como pular em silencio na esteira daria no mesmo, o `ci.yml` ganhou o servico — a regra dele sempre disse que servico entra junto com o primeiro teste que precisar, e este e o primeiro.

Dois achados que custaram tres tentativas: `await foreach` **nao** simula queda (o descarte confirma o que estava em andamento, que e desligamento gracioso), e a devolucao do nao confirmado acontece quando o **broker** percebe a conexao caida — medir antes disso parece perda de mensagem.

## Fora deste PR
Tela ou comando para inspecionar/reprocessar a DLQ: `ContarDlq` e `ReprocessarDlq` existem e sao testados, mas expor por HTTP sem autenticacao seria um botao de reprocessamento aberto. Entra com #49/#58.

Closes #69