### PR TITLE
Embeddings e busca por similaridade no Postgres que ja existe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 # Esteira base: compila e testa. Os gates especializados (segredo #47, KISS/DRY
 # #75) sao workflows proprios e assumem este aqui de pe.
 #
-# Sem Postgres no job de proposito: a suite roda offline por decisao
-# (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=fake). Servico so entra junto com o
-# primeiro teste de integracao que precisar dele.
+# A suite roda offline por decisao (MODEL_PROVIDER=fake, CONVERSATION_SOURCE=
+# fake), e o mapeamento comum e conferido em SQLite na memoria.
+#
+# O Postgres entrou como servico na #60, seguindo a regra que ja estava aqui:
+# servico entra junto com o PRIMEIRO teste que precisa dele. E pgvector nao tem
+# equivalente em SQLite — sem o servico, os testes de similaridade pulariam, e
+# teste que pula em silencio na esteira e garantia que ninguem confere.
 name: CI
 
 on:
@@ -27,6 +31,24 @@ jobs:
     runs-on: ubuntu-latest
     # Job travado nao pode queimar minuto ate o teto da conta.
     timeout-minutes: 10
+
+    services:
+      # Postgres COM pgvector (#60). A mesma imagem do docker-compose: o teste
+      # que confere o indice de similaridade precisa da extensao, e SQLite nao
+      # substitui — fingir que substitui seria testar outra coisa.
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: copiloto
+          POSTGRES_PASSWORD: teste
+          POSTGRES_DB: copiloto
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U copiloto -d copiloto"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4
@@ -54,4 +76,7 @@ jobs:
         run: dotnet build --no-restore --configuration Release --nologo
 
       - name: Testar
+        env:
+          # Com esta variavel os testes de pgvector RODAM em vez de pular.
+          POSTGRES_URL: "Host=localhost;Port=5432;Database=copiloto;Username=copiloto;Password=teste"
         run: dotnet test --no-build --configuration Release --nologo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,23 +29,31 @@ a mensagem" esta fora de escopo por decisao, nao por falta de tempo.
 ## Estado real do repositorio
 
 > Esta secao envelhece rapido. **Quem fecha uma issue atualiza ela no mesmo PR.**
+> Conferido em 04/09/2026.
 
-- **Nao existe uma linha de C#.** Sem `.sln`, sem `.csproj`, sem front.
-- O que existe: `README.md`, `docs/ARQUITETURA.md` (13 secoes de decisao),
-  `docker-compose.yml`, `.env.example`, templates de issue.
-- `prompts/tecnicas/` e `seed/` existem e estao **vazias**.
-- **89 issues abertas, nenhuma fechada**, em 9 milestones (M0 Fundacao -> M8 LGPD).
+- **A solution esta de pe**: `Copiloto.sln` com `src/Copiloto.Dominio`,
+  `src/Copiloto.Api` e `testes/Copiloto.Testes`. **Front nenhum** — nao existe tela.
+- No backend ja tem: dominio POCO com as transicoes de estagio, ingestao por webhook
+  com fila, persistencia EF Core/Postgres, PII Shield com gate na esteira, router de
+  modelo com circuito, a ficha do vendedor e o RAG com `pgvector`.
+- `prompts/tecnicas/` continua **vazia**; `seed/conversas/` tem as tres conversas do
+  cenario de cafe.
+- **16 issues fechadas, 79 abertas**, em 9 milestones (M0 Fundacao -> M8 LGPD).
+- **29 PRs abertos** esperando merge: a `main` esta atras do que ja foi escrito.
+  Antes de comecar, conferir se o que voce precisa nao esta num PR aberto — refazer
+  na sua branch daria conflito e duas versoes da mesma decisao.
 - Ordem acordada: **alicerce antes de morador** — estrutura primeiro, funcionalidade
   depois.
 
-Enquanto nao houver `.sln`, `dotnet build` **nao tem o que compilar**, e isso e
-resposta valida (ver "nao deu pra checar" abaixo), nunca um erro a esconder.
+`dotnet build` e `dotnet test` ja tem o que rodar, mas quem roda e a esteira (ver
+"Quem confere o que"). Parte da suite **pula sem servico**: sem `POSTGRES_URL` os
+testes de pgvector ficam pulados, e teste pulado nao e teste verde.
 
 ---
 
 ## Comandos
 
-Passam a valer a partir do esqueleto da solution; antes disso, nao existem.
+Valem da raiz do repositorio, com a solution ja de pe.
 
 ```bash
 dotnet build                              # compila a solution
@@ -126,7 +134,7 @@ Excecao: limpeza trivial no arquivo ja tocado, em **commit separado**.
 
 ## Fluxo de trabalho
 
-**Uma issue por branch, uma branch por PR.** As 89 issues sao o plano; trabalho
+**Uma issue por branch, uma branch por PR.** As issues sao o plano; trabalho
 que nao tem issue, abre issue antes.
 
 ```bash
@@ -147,9 +155,10 @@ feat: Redis e RabbitMQ atras de interface, com in-memory como padrao
 
 ## Documento que afirma o que o codigo faz precisa de quem confira
 
-`README.md` e `docs/ARQUITETURA.md` descrevem router, ledger, MCP e RAG que **ainda
-nao existem**. Hoje isso e tese declarada, e esta tudo bem. O que nao pode e virar
-promessa desatualizada em silencio.
+`README.md` e `docs/ARQUITETURA.md` afirmam o que o produto faz. Parte ja e codigo
+— router, ledger de custo e RAG —, parte ainda e tese declarada, e tese declarada
+esta tudo bem. O que nao pode e virar promessa desatualizada em silencio: cada
+merge move a fronteira entre as duas, e quem move corrige a frase.
 
 Regra: **ao fechar uma issue, se o documento passou a divergir do codigo, corrige
 no mesmo PR.** Esses dois arquivos circulam fora do produto — sao a primeira coisa

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,20 @@
          mapeamento sem exigir Postgres de pe. -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
 
+    <!-- pgvector (#60). Conferidos em 04/09/2026 via `dotnet package search`:
+         Pgvector 0.3.2 e Pgvector.EntityFrameworkCore 0.3.0. A extensao no
+         banco e a 0.8.6, da imagem pgvector/pgvector:pg16 que o compose ja usa.
+         Sem banco vetorial dedicado: o Postgres ja esta aqui, com o mesmo
+         backup, a mesma transacao e a mesma credencial. -->
+    <PackageVersion Include="Pgvector" Version="0.3.2" />
+    <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
+
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <!-- SkippableFact (conferido em 04/09/2026: 1.5.85). Existe para o teste que
+         precisa de servico externo PULAR em vez de passar quando ele nao esta
+         de pe: teste que passa por nao ter rodado e pior que teste vermelho. -->
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.85" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/src/Copiloto.Api/Copiloto.Api.csproj
+++ b/src/Copiloto.Api/Copiloto.Api.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Pgvector" />
+    <PackageReference Include="Pgvector.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
+++ b/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
@@ -35,11 +35,26 @@ public class CopilotoDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder b)
     {
+        b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);
+
+        // `vector` e tipo de coluna que so o Postgres tem, e o modelo inteiro e
+        // conferido em SQLite na memoria (#103) para a suite rodar offline. As
+        // duas coisas so convivem se o Precedente sair do modelo fora do
+        // Postgres — senao a validacao do EF derruba TODO teste de mapeamento,
+        // inclusive os que nao tem nada a ver com RAG.
+        //
+        // Quem confere o Precedente e o teste contra Postgres real (#60), e a
+        // ausencia aqui e afirmada por teste: exclusao que ninguem verifica
+        // vira cobertura que sumiu sem aviso.
+        if (!Database.IsNpgsql())
+        {
+            b.Ignore<Precedente>();
+            return;
+        }
+
         // A extensao entra pela MIGRATION, e nao por um comando solto: banco
         // novo sem `vector` habilitado quebra na primeira consulta, e o erro
         // aparece longe de quem esqueceu de rodar o comando (#60).
         b.HasPostgresExtension("vector");
-
-        b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);
     }
 }

--- a/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
+++ b/src/Copiloto.Api/Persistencia/CopilotoDbContext.cs
@@ -1,6 +1,7 @@
 using Copiloto.Dominio.Conversas;
 using Copiloto.Dominio.Fichas;
 using Copiloto.Dominio.Ia;
+using Copiloto.Dominio.Rag;
 using Copiloto.Dominio.Vendas;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,6 +30,16 @@ public class CopilotoDbContext : DbContext
     public DbSet<Mensagem> Mensagens => Set<Mensagem>();
     public DbSet<FichaCliente> Fichas => Set<FichaCliente>();
 
-    protected override void OnModelCreating(ModelBuilder b) =>
+    /// <summary>Trechos de conversa vetorizados, para recuperar por semelhanca (#60).</summary>
+    public DbSet<Precedente> Precedentes => Set<Precedente>();
+
+    protected override void OnModelCreating(ModelBuilder b)
+    {
+        // A extensao entra pela MIGRATION, e nao por um comando solto: banco
+        // novo sem `vector` habilitado quebra na primeira consulta, e o erro
+        // aparece longe de quem esqueceu de rodar o comando (#60).
+        b.HasPostgresExtension("vector");
+
         b.ApplyConfigurationsFromAssembly(typeof(CopilotoDbContext).Assembly);
+    }
 }

--- a/src/Copiloto.Api/Persistencia/FabricaDeContextoParaMigrations.cs
+++ b/src/Copiloto.Api/Persistencia/FabricaDeContextoParaMigrations.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Copiloto.Api.Persistencia;
+
+/// <summary>
+/// O contexto que o `dotnet ef` usa para gerar migration.
+///
+/// Sem isto, a ferramenta sobe o `Program` inteiro so para descobrir o
+/// DbContext, e passa a depender de tudo que a aplicacao exige para subir.
+/// </summary>
+public class FabricaDeContextoParaMigrations : IDesignTimeDbContextFactory<CopilotoDbContext>
+{
+    public CopilotoDbContext CreateDbContext(string[] args)
+    {
+        var cadeia = Environment.GetEnvironmentVariable("ConnectionStrings__Postgres")
+                     ?? "Host=localhost;Database=copiloto;Username=copiloto";
+
+        return new CopilotoDbContext(
+            new DbContextOptionsBuilder<CopilotoDbContext>()
+                .UseNpgsql(cadeia, o => o.UseVector())
+                .Options);
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Mapeamentos/PrecedenteMap.cs
+++ b/src/Copiloto.Api/Persistencia/Mapeamentos/PrecedenteMap.cs
@@ -1,0 +1,40 @@
+using Copiloto.Dominio.Rag;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Pgvector;
+using Pgvector.EntityFrameworkCore;
+
+namespace Copiloto.Api.Persistencia.Mapeamentos;
+
+public class PrecedenteMap : IEntityTypeConfiguration<Precedente>
+{
+    public void Configure(EntityTypeBuilder<Precedente> e)
+    {
+        e.ToTable("precedentes");
+        e.HasKey(p => p.Id);
+        e.Property(p => p.LeadId).IsRequired();
+        e.Property(p => p.Trecho).IsRequired();
+        e.Property(p => p.CriadoEm).IsRequired();
+
+        // float[] no dominio, `vector` na coluna: a conversao mora aqui porque
+        // o dominio nao tem pacote (#48) e nao pode conhecer o tipo do pgvector.
+        e.Property(p => p.Vetor)
+            .HasColumnType($"vector({Embedding.Dimensoes})")
+            .HasConversion(
+                v => new Vector(v),
+                v => v.ToArray().ToArray())
+            .IsRequired();
+
+        // Indice HNSW com distancia de COSSENO — a mesma que a consulta usa. Um
+        // indice criado com outro operador simplesmente nao e usado pela
+        // consulta, e o sintoma e lentidao silenciosa, nao erro.
+        e.HasIndex(p => p.Vetor)
+            .HasMethod("hnsw")
+            .HasOperators("vector_cosine_ops")
+            .HasDatabaseName("ix_precedentes_vetor");
+
+        // O expurgo por titular (#46) roda por aqui: sem indice, apagar o que e
+        // de uma pessoa varre a tabela inteira — no dia em que ela pediu.
+        e.HasIndex(p => p.LeadId).HasDatabaseName("ix_precedentes_lead");
+    }
+}

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904054427_PrecedentesComPgvector.Designer.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904054427_PrecedentesComPgvector.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Copiloto.Api.Persistencia;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Copiloto.Api.Persistencia.Migrations
 {
     [DbContext(typeof(CopilotoDbContext))]
-    partial class CopilotoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904054427_PrecedentesComPgvector")]
+    partial class PrecedentesComPgvector
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Copiloto.Api/Persistencia/Migrations/20260904054427_PrecedentesComPgvector.cs
+++ b/src/Copiloto.Api/Persistencia/Migrations/20260904054427_PrecedentesComPgvector.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace Copiloto.Api.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class PrecedentesComPgvector : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:vector", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "precedentes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    LeadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Trecho = table.Column<string>(type: "text", nullable: false),
+                    Vetor = table.Column<Vector>(type: "vector(1536)", nullable: false),
+                    CriadoEm = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_precedentes", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_precedentes_lead",
+                table: "precedentes",
+                column: "LeadId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_precedentes_vetor",
+                table: "precedentes",
+                column: "Vetor")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "precedentes");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:vector", ",,");
+        }
+    }
+}

--- a/src/Copiloto.Api/Program.cs
+++ b/src/Copiloto.Api/Program.cs
@@ -1,7 +1,9 @@
 using Copiloto.Api.Ia;
 using Copiloto.Api.Ingestao;
 using Copiloto.Api.Persistencia;
+using Copiloto.Api.Rag;
 using Copiloto.Dominio.Ia;
+using Copiloto.Dominio.Rag;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,9 +13,18 @@ var builder = WebApplication.CreateBuilder(args);
 // "funciona na minha maquina" que vira incidente.
 builder.Services.AddDbContext<CopilotoDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("Postgres")
-                ?? "Host=localhost;Database=copiloto;Username=copiloto"));
+                ?? "Host=localhost;Database=copiloto;Username=copiloto",
+        // `UseVector` precisa estar aqui E na fabrica de migrations: sem ele o
+        // Npgsql nao sabe traduzir o tipo `vector`, e a falha aparece so na
+        // primeira consulta de similaridade (#60).
+        npg => npg.UseVector()));
 
 builder.Services.AddScoped<IRepositorioDeLeads, LeadsNoBanco>();
+
+// Embedding fake e o padrao (#60), pela mesma razao do FakeSource: a suite e a
+// demo rodam offline e de graca. O provedor real entra atras da mesma interface.
+builder.Services.AddSingleton<IEmbeddingProvider, FakeEmbeddingProvider>();
+builder.Services.AddScoped<IBuscaPorSimilaridade, BuscaComPgvector>();
 
 // O router e a tabela dele: a tabela vem do appsettings, nunca de codigo.
 builder.Services.AddSingleton(_ => new RoteadorDeModelo(

--- a/src/Copiloto.Api/Rag/BuscaComPgvector.cs
+++ b/src/Copiloto.Api/Rag/BuscaComPgvector.cs
@@ -1,0 +1,61 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Dominio.Rag;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+using Pgvector.EntityFrameworkCore;
+
+namespace Copiloto.Api.Rag;
+
+/// <summary>
+/// Busca por semelhanca no Postgres que ja existe (#60).
+///
+/// Sem banco vetorial dedicado, e a decisao esta no ARQUITETURA: Qdrant ou
+/// Pinecone seriam um segundo banco para operar, com backup proprio, credencial
+/// propria e consistencia propria — em troca de nada nesta escala. O que a
+/// gente ganharia em vazao nao tem quem consuma; o que a gente perderia em
+/// transacao apareceria no primeiro expurgo pela metade.
+/// </summary>
+public class BuscaComPgvector : IBuscaPorSimilaridade
+{
+    private readonly CopilotoDbContext _ctx;
+
+    public BuscaComPgvector(CopilotoDbContext ctx) => _ctx = ctx;
+
+    public async Task Guardar(Precedente precedente, CancellationToken ct)
+    {
+        _ctx.Precedentes.Add(precedente);
+        await _ctx.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Os mais parecidos, com a distancia junto.
+    ///
+    /// A ordenacao e a distancia saem do BANCO, na mesma consulta: trazer tudo
+    /// e ordenar em memoria funcionaria com mil linhas e deixaria de funcionar
+    /// exatamente quando o indice passasse a importar.
+    /// </summary>
+    public async Task<IReadOnlyList<PrecedenteSemelhante>> MaisParecidos(
+        float[] consulta, int quantos, CancellationToken ct)
+    {
+        if (consulta.Length != Embedding.Dimensoes)
+            throw new ArgumentException(
+                $"Consulta com {consulta.Length} dimensoes contra coluna de "
+                + $"{Embedding.Dimensoes}.", nameof(consulta));
+
+        var alvo = new Vector(consulta);
+
+        var achados = await _ctx.Precedentes
+            .AsNoTracking()
+            .Select(p => new { Precedente = p, Distancia = p.Vetor.CosineDistance(alvo) })
+            .OrderBy(x => x.Distancia)
+            .Take(Math.Clamp(quantos, 1, 50))
+            .ToListAsync(ct);
+
+        return achados
+            .Select(x => new PrecedenteSemelhante(x.Precedente, x.Distancia))
+            .ToList();
+    }
+
+    public async Task<int> EsquecerTitular(Guid leadId, CancellationToken ct) =>
+        await _ctx.Precedentes.Where(p => p.LeadId == leadId).ExecuteDeleteAsync(ct);
+}

--- a/src/Copiloto.Api/Rag/FakeEmbeddingProvider.cs
+++ b/src/Copiloto.Api/Rag/FakeEmbeddingProvider.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Text;
+using Copiloto.Dominio.Rag;
+
+namespace Copiloto.Api.Rag;
+
+/// <summary>
+/// Embedding deterministico a partir do texto, sem rede e sem custo (#60).
+///
+/// E o padrao, pela mesma razao do FakeSource e do FakeProvider: a suite roda
+/// offline e de graca, e teste que precisa de chave de provedor para passar
+/// quebra no primeiro clone.
+///
+/// O que ele NAO e: uma aproximacao de semantica. Textos com sentido parecido
+/// nao ficam proximos aqui — quem fica proximo e o texto parecido no BYTE. Isso
+/// basta para o que a #60 precisa provar (guardar, indexar, recuperar por
+/// distancia, expurgar), e nao basta para avaliar qualidade de recuperacao, que
+/// e a #65 e exige provedor real.
+/// </summary>
+public class FakeEmbeddingProvider : IEmbeddingProvider
+{
+    public string Modelo => "fake-deterministico-v1";
+
+    public Task<float[]> Vetorizar(string texto, CancellationToken ct)
+    {
+        var vetor = new float[Embedding.Dimensoes];
+        var semente = SHA256.HashData(Encoding.UTF8.GetBytes(texto ?? ""));
+
+        // Gerador simples alimentado pelo hash: mesmo texto, mesmo vetor,
+        // sempre — em qualquer maquina e em qualquer execucao. Um Random sem
+        // semente fixa daria um teste que passa uma vez e nunca mais.
+        var estado = BitConverter.ToUInt64(semente, 0) | 1UL;
+
+        for (var i = 0; i < vetor.Length; i++)
+        {
+            estado = (estado * 6364136223846793005UL) + 1442695040888963407UL;
+            vetor[i] = ((estado >> 33) / (float)uint.MaxValue) - 0.5f;
+        }
+
+        // Normalizado: com vetores de norma 1, a distancia de cosseno fica
+        // comparavel entre consultas, e o numero que sobe com o resultado quer
+        // dizer a mesma coisa sempre.
+        var norma = MathF.Sqrt(vetor.Sum(v => v * v));
+        if (norma > 0)
+            for (var i = 0; i < vetor.Length; i++) vetor[i] /= norma;
+
+        return Task.FromResult(vetor);
+    }
+}

--- a/src/Copiloto.Dominio/Rag/Precedente.cs
+++ b/src/Copiloto.Dominio/Rag/Precedente.cs
@@ -1,0 +1,102 @@
+namespace Copiloto.Dominio.Rag;
+
+/// <summary>
+/// Um trecho de conversa passada, guardado para ser recuperado por semelhanca
+/// (#60, #61).
+///
+/// O vetor mora como `float[]` porque o dominio nao tem pacote (#48): o tipo do
+/// pgvector e a conversao ficam no mapeamento, que e borda. O dominio sabe que
+/// existe um vetor e o que ele representa; nao sabe em que banco ele cabe.
+/// </summary>
+public class Precedente
+{
+    public Precedente(
+        Guid id, Guid leadId, string trecho, float[] vetor, DateTimeOffset criadoEm)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Precedente sem id.", nameof(id));
+        if (leadId == Guid.Empty)
+            throw new ArgumentException(
+                "Precedente sem titular nao tem como ser expurgado quando ele pedir "
+                + "exclusao — e vetor que sobrevive ao Lead e dado pessoal vivo depois "
+                + "do pedido (#46, #62).", nameof(leadId));
+
+        if (string.IsNullOrWhiteSpace(trecho))
+            throw new ArgumentException("Precedente sem texto.", nameof(trecho));
+
+        if (vetor.Length != Embedding.Dimensoes)
+            throw new ArgumentException(
+                $"Vetor com {vetor.Length} dimensoes; a coluna tem {Embedding.Dimensoes}. "
+                + "Dimensao errada nao e detalhe: a busca por similaridade compararia "
+                + "coisas de espacos diferentes, e o resultado pareceria plausivel.",
+                nameof(vetor));
+
+        Id = id;
+        LeadId = leadId;
+        Trecho = trecho.Trim();
+        Vetor = vetor;
+        CriadoEm = criadoEm;
+    }
+
+    public Guid Id { get; }
+
+    /// <summary>De quem e o texto. E por aqui que o expurgo alcanca o vetor.</summary>
+    public Guid LeadId { get; }
+
+    public string Trecho { get; }
+    public float[] Vetor { get; }
+    public DateTimeOffset CriadoEm { get; }
+}
+
+/// <summary>
+/// Quem transforma texto em vetor.
+///
+/// Interface porque o provedor real custa dinheiro e rede, e a suite roda
+/// offline por decisao — o fake vive ao lado, com vetor DETERMINISTICO a partir
+/// do texto (#60).
+/// </summary>
+public interface IEmbeddingProvider
+{
+    /// <summary>O nome vai junto do vetor no ledger: comparar modelos exige saber qual gerou.</summary>
+    string Modelo { get; }
+
+    Task<float[]> Vetorizar(string texto, CancellationToken ct);
+}
+
+/// <summary>O que vale para qualquer provedor de embedding.</summary>
+public static class Embedding
+{
+    /// <summary>
+    /// A largura do vetor, fixada na coluna.
+    ///
+    /// 1536 e a dimensao dos modelos pequenos de embedding mais usados. O numero
+    /// mora aqui, e nao no mapeamento, porque trocar de modelo por um de outra
+    /// dimensao NAO e configuracao: e reindexar tudo. Deixar isso implicito
+    /// produziria uma base com vetores de dois espacos misturados, onde a busca
+    /// devolve vizinho errado com cara de certo.
+    /// </summary>
+    public const int Dimensoes = 1536;
+}
+
+/// <summary>
+/// Um vizinho encontrado, com a distancia que o trouxe.
+///
+/// A distancia sobe junto de proposito: sem ela, quem consome nao tem como
+/// dizer se recuperou um precedente parecido ou o menos ruim de uma base que
+/// nao tinha nada a ver.
+/// </summary>
+public record PrecedenteSemelhante(Precedente Precedente, double Distancia);
+
+/// <summary>
+/// A busca por semelhanca, atras de interface — para trocar o backend se a
+/// escala exigir, sem mexer em quem pergunta (#60).
+/// </summary>
+public interface IBuscaPorSimilaridade
+{
+    Task Guardar(Precedente precedente, CancellationToken ct);
+
+    Task<IReadOnlyList<PrecedenteSemelhante>> MaisParecidos(
+        float[] consulta, int quantos, CancellationToken ct);
+
+    /// <summary>Apaga o que e do titular. E o expurgo em cascata do art. 18 (#46).</summary>
+    Task<int> EsquecerTitular(Guid leadId, CancellationToken ct);
+}

--- a/testes/Copiloto.Testes/Copiloto.Testes.csproj
+++ b/testes/Copiloto.Testes/Copiloto.Testes.csproj
@@ -10,6 +10,8 @@
          suite continua rodando offline como o CLAUDE.md manda. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- Os testes de pgvector pulam sem banco, em vez de passar (#60). -->
+    <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/testes/Copiloto.Testes/PgvectorTeste.cs
+++ b/testes/Copiloto.Testes/PgvectorTeste.cs
@@ -1,0 +1,230 @@
+using Copiloto.Api.Persistencia;
+using Copiloto.Api.Rag;
+using Copiloto.Dominio.Rag;
+using Microsoft.EntityFrameworkCore;
+using Pgvector.EntityFrameworkCore;
+using Xunit;
+
+namespace Copiloto.Testes;
+
+/// <summary>
+/// Embedding e busca por semelhanca no Postgres que ja existe (#60).
+///
+/// Estes testes exigem Postgres COM a extensao vector — SQLite nao serve, e
+/// fingir que serve seria testar outra coisa. Sem banco, eles PULAM em vez de
+/// passar. Para rodar:
+///
+///   docker run -d --rm -p 5443:5432 -e POSTGRES_PASSWORD=teste \
+///     -e POSTGRES_USER=copiloto -e POSTGRES_DB=copiloto pgvector/pgvector:pg16
+///   POSTGRES_URL="Host=localhost;Port=5443;Database=copiloto;Username=copiloto;Password=teste" dotnet test
+/// </summary>
+public class PgvectorTeste : IAsyncLifetime
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 4, 10, 0, 0, TimeSpan.Zero);
+
+    private static string? Url => Environment.GetEnvironmentVariable("POSTGRES_URL");
+
+    private readonly FakeEmbeddingProvider _embedder = new();
+    private CopilotoDbContext? _ctx;
+
+    public async Task InitializeAsync()
+    {
+        if (Url is null) return;
+
+        _ctx = new CopilotoDbContext(new DbContextOptionsBuilder<CopilotoDbContext>()
+            .UseNpgsql(Url, npg => npg.UseVector()).Options);
+
+        // Recria do zero: teste que herda linha de execucao anterior mede o que
+        // sobrou, e nao o que ele escreveu.
+        await _ctx.Database.EnsureDeletedAsync();
+        await _ctx.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_ctx is not null) await _ctx.DisposeAsync();
+    }
+
+    private BuscaComPgvector Busca() => new(_ctx!);
+
+    private async Task<Precedente> Guardar(string trecho, Guid? lead = null)
+    {
+        var precedente = new Precedente(
+            Guid.NewGuid(), lead ?? Guid.NewGuid(), trecho,
+            await _embedder.Vetorizar(trecho, default), T0);
+
+        await Busca().Guardar(precedente, default);
+        return precedente;
+    }
+
+    // --- O provedor fake ---
+
+    [Fact]
+    public async Task O_mesmo_texto_gera_sempre_o_mesmo_vetor()
+    {
+        // Deterministico em qualquer maquina e execucao: um Random sem semente
+        // fixa daria um teste que passa uma vez e nunca mais.
+        var a = await _embedder.Vetorizar("cliente travou no preco", default);
+        var b = await _embedder.Vetorizar("cliente travou no preco", default);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public async Task Textos_diferentes_geram_vetores_diferentes()
+    {
+        var a = await _embedder.Vetorizar("cliente travou no preco", default);
+        var b = await _embedder.Vetorizar("cliente pediu prazo", default);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public async Task O_vetor_tem_a_largura_da_coluna()
+    {
+        // Dimensao errada nao e detalhe: a busca compararia coisas de espacos
+        // diferentes, e o resultado pareceria plausivel.
+        var vetor = await _embedder.Vetorizar("qualquer coisa", default);
+
+        Assert.Equal(Embedding.Dimensoes, vetor.Length);
+    }
+
+    [Fact]
+    public void Vetor_de_dimensao_errada_e_recusado_no_dominio()
+    {
+        Assert.Throws<ArgumentException>(() => new Precedente(
+            Guid.NewGuid(), Guid.NewGuid(), "trecho", new float[8], T0));
+    }
+
+    [Fact]
+    public void Precedente_sem_titular_nao_existe()
+    {
+        // Vetor que sobrevive ao Lead e dado pessoal vivo depois do pedido de
+        // exclusao (#46, #62).
+        Assert.Throws<ArgumentException>(() => new Precedente(
+            Guid.NewGuid(), Guid.Empty, "trecho", new float[Embedding.Dimensoes], T0));
+    }
+
+    // --- O banco ---
+
+    [SkippableFact]
+    public async Task O_precedente_atravessa_o_banco_com_o_vetor_inteiro()
+    {
+        Skip.If(Url is null, "sem POSTGRES_URL: banco com pgvector nao disponivel");
+
+        var guardado = await Guardar("o cliente travou no preco e fechou com 8%");
+
+        var lido = await _ctx!.Precedentes.AsNoTracking()
+            .FirstAsync(p => p.Id == guardado.Id);
+
+        Assert.Equal(guardado.Trecho, lido.Trecho);
+        Assert.Equal(Embedding.Dimensoes, lido.Vetor.Length);
+        Assert.Equal(guardado.Vetor[0], lido.Vetor[0], 5);
+    }
+
+    [SkippableFact]
+    public async Task A_busca_devolve_o_mais_parecido_primeiro()
+    {
+        Skip.If(Url is null, "sem POSTGRES_URL: banco com pgvector nao disponivel");
+
+        await Guardar("o cliente travou no preco e fechou com 8%");
+        await Guardar("prazo de entrega para a zona sul");
+        await Guardar("pediu amostra antes de decidir");
+
+        var consulta = await _embedder.Vetorizar("o cliente travou no preco e fechou com 8%", default);
+        var achados = await Busca().MaisParecidos(consulta, quantos: 2, default);
+
+        Assert.Equal(2, achados.Count);
+        Assert.Contains("travou no preco", achados[0].Precedente.Trecho);
+
+        // A distancia sobe junto: sem ela, quem consome nao distingue "achei um
+        // parecido" de "achei o menos ruim de uma base que nao tinha nada a ver".
+        Assert.True(achados[0].Distancia < achados[1].Distancia);
+        Assert.InRange(achados[0].Distancia, 0, 0.0001);
+    }
+
+    [SkippableFact]
+    public async Task A_busca_respeita_o_limite_pedido()
+    {
+        Skip.If(Url is null, "sem POSTGRES_URL: banco com pgvector nao disponivel");
+
+        for (var i = 0; i < 5; i++) await Guardar($"conversa numero {i}");
+
+        var consulta = await _embedder.Vetorizar("conversa numero 1", default);
+
+        Assert.Equal(2, (await Busca().MaisParecidos(consulta, quantos: 2, default)).Count);
+    }
+
+    [SkippableFact]
+    public async Task Esquecer_o_titular_apaga_os_vetores_dele_e_so_os_dele()
+    {
+        // O expurgo em cascata do art. 18: apagar o Lead sem apagar o vetor
+        // deixa o dado vivo depois de o titular pedir exclusao (#46, #62).
+        Skip.If(Url is null, "sem POSTGRES_URL: banco com pgvector nao disponivel");
+
+        var marina = Guid.NewGuid();
+        var outro = Guid.NewGuid();
+        await Guardar("marina travou no preco", marina);
+        await Guardar("marina pediu prazo", marina);
+        await Guardar("outro cliente qualquer", outro);
+
+        var apagados = await Busca().EsquecerTitular(marina, default);
+
+        Assert.Equal(2, apagados);
+        Assert.Equal(0, await _ctx!.Precedentes.CountAsync(p => p.LeadId == marina));
+        Assert.Equal(1, await _ctx.Precedentes.CountAsync(p => p.LeadId == outro));
+    }
+
+    [SkippableFact]
+    public async Task O_indice_de_similaridade_e_usado_pela_consulta()
+    {
+        // Criterio de aceite: verificar o PLANO. Um indice criado com operador
+        // diferente do da consulta simplesmente nao e usado, e o sintoma e
+        // lentidao silenciosa — nao erro.
+        Skip.If(Url is null, "sem POSTGRES_URL: banco com pgvector nao disponivel");
+
+        for (var i = 0; i < 20; i++) await Guardar($"conversa {i}");
+
+        var alvo = new Pgvector.Vector(await _embedder.Vetorizar("conversa 7", default));
+
+        var plano = new List<string>();
+        var conexao = _ctx!.Database.GetDbConnection();
+        await conexao.OpenAsync();
+        try
+        {
+            // `enable_seqscan = off` na MESMA conexao do EXPLAIN: o ajuste vale
+            // por sessao, e mandar em outra conexao nao chega aqui — foi o que
+            // fez a primeira versao deste teste medir o plano sem o ajuste.
+            //
+            // Ele e necessario porque com vinte linhas a varredura sequencial e
+            // MESMO mais rapida, e o planejador esta certo em escolher ela. O
+            // que se prova aqui e que o indice E UTILIZAVEL por esta consulta —
+            // e e isso que deixa de valer quando o operador do indice nao bate
+            // com o da consulta, sem erro nenhum aparecer.
+            await using (var ajuste = conexao.CreateCommand())
+            {
+                ajuste.CommandText = "SET enable_seqscan = off";
+                await ajuste.ExecuteNonQueryAsync();
+            }
+
+            await using var cmd = conexao.CreateCommand();
+            cmd.CommandText =
+                // Nomes entre aspas: as colunas foram criadas com maiuscula, e sem
+                // as aspas o Postgres procura por `id` minusculo e nao acha.
+                "EXPLAIN SELECT \"Id\" FROM precedentes ORDER BY \"Vetor\" <=> $1 LIMIT 3";
+            var p = cmd.CreateParameter();
+            p.Value = alvo;
+            cmd.Parameters.Add(p);
+
+            await using var leitura = await cmd.ExecuteReaderAsync();
+            while (await leitura.ReadAsync()) plano.Add(leitura.GetString(0));
+        }
+        finally
+        {
+            await conexao.CloseAsync();
+        }
+
+        var texto = string.Join("\n", plano);
+        Assert.Contains("ix_precedentes_vetor", texto);
+    }
+}

--- a/testes/Copiloto.Testes/PgvectorTeste.cs
+++ b/testes/Copiloto.Testes/PgvectorTeste.cs
@@ -1,6 +1,8 @@
 using Copiloto.Api.Persistencia;
 using Copiloto.Api.Rag;
 using Copiloto.Dominio.Rag;
+using Copiloto.Dominio.Vendas;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Pgvector.EntityFrameworkCore;
 using Xunit;
@@ -226,5 +228,28 @@ public class PgvectorTeste : IAsyncLifetime
 
         var texto = string.Join("\n", plano);
         Assert.Contains("ix_precedentes_vetor", texto);
+    }
+
+    // --- O modelo fora do Postgres ---
+
+    [Fact]
+    public void Fora_do_Postgres_o_Precedente_sai_do_modelo_de_proposito()
+    {
+        // `vector(1536)` nao existe em SQLite, e o EF nao ignora isso em
+        // silencio: ele recusa o modelo INTEIRO, derrubando junto todo teste de
+        // mapeamento que nao tem nada a ver com RAG.
+        //
+        // A exclusao e por provedor, e este teste e o que impede ela de virar
+        // cobertura sumida sem aviso: se alguem tirar o `Ignore`, o vermelho
+        // aparece aqui, com o motivo escrito, e nao em quatorze testes alheios
+        // com um erro de mapeamento que nao fala do assunto.
+        using var conexao = new SqliteConnection("DataSource=:memory:");
+        conexao.Open();
+
+        using var ctx = new CopilotoDbContext(
+            new DbContextOptionsBuilder<CopilotoDbContext>().UseSqlite(conexao).Options);
+
+        Assert.Null(ctx.Model.FindEntityType(typeof(Precedente)));
+        Assert.NotNull(ctx.Model.FindEntityType(typeof(Lead)));
     }
 }


### PR DESCRIPTION
**Base:** sai da `main`. Fecha a #60, primeira issue de codigo do M6.

## O que muda
Tabela `precedentes` com coluna `vector(1536)`, indice HNSW de distancia de cosseno, extensao `vector` habilitada **por migration**, e a busca por semelhanca atras de `IBuscaPorSimilaridade`. Sem banco vetorial dedicado, como o ARQUITETURA decidiu: Qdrant ou Pinecone seriam um segundo banco para operar — com backup proprio, credencial propria e consistencia propria — em troca de nada nesta escala.

A extensao entra por migration de proposito. Banco novo sem `vector` quebra na primeira consulta, e o erro aparece longe de quem esqueceu de rodar o comando.

## Tres decisoes que o codigo carrega
- **A dimensao mora no dominio, nao no mapeamento** (`Embedding.Dimensoes`). Trocar de modelo por um de outra dimensao nao e configuracao: e reindexar tudo. Implicito, produziria uma base com vetores de dois espacos misturados, onde a busca devolve vizinho errado com cara de certo.
- **Precedente sem titular nao existe.** O construtor recusa `LeadId` vazio: vetor que sobrevive ao Lead e dado pessoal vivo depois do pedido de exclusao (#46, #62). O expurgo tem indice proprio porque ele roda no dia em que a pessoa pediu.
- **A distancia sobe junto do resultado.** Sem ela, quem consome nao distingue "achei um precedente parecido" de "achei o menos ruim de uma base que nao tinha nada a ver".

## O provedor fake, e o que ele nao e
Vetor **deterministico** a partir do texto, com semente derivada do hash: mesmo texto, mesmo vetor, em qualquer maquina — `Random` sem semente fixa daria teste que passa uma vez e nunca mais.

O que ele **nao** e esta escrito na classe: aproximacao de semantica. Textos com sentido parecido NAO ficam proximos; quem fica proximo e o texto parecido no byte. Isso basta para provar guardar, indexar, recuperar e expurgar, e nao basta para avaliar qualidade de recuperacao — que e a #65 e exige provedor real.

## O teste do indice conferiu o plano, e custou duas correcoes
`SET enable_seqscan = off` numa conexao diferente da do `EXPLAIN` nao chega la: o ajuste vale por sessao. E sem ele o planejador escolhe varredura sequencial — corretamente, porque com vinte linhas ela e mais rapida.

O que o teste prova e que o indice **e utilizavel** pela consulta. E isso que deixa de valer quando o operador do indice nao bate com o da consulta, sem erro nenhum aparecer.

## Esteira
`ci.yml` ganhou o servico pgvector pela mesma regra que trouxe o RabbitMQ: servico entra junto com o primeiro teste que precisa dele, e pgvector nao tem equivalente em SQLite. Sem o servico os testes de similaridade pulariam, e teste que pula em silencio na esteira e garantia que ninguem confere.

## O que a esteira pegou
Primeiro push: 14 testes vermelhos **sem relacao com RAG** — ficha, resolvedor de telefone, mapeamento. O EF valida o modelo INTEIRO na primeira consulta ao contexto, e `vector(1536)` em SQLite recusa o modelo todo; o sintoma caiu longe da causa.

Fora do Npgsql o `Precedente` sai do modelo (`b.Ignore<Precedente>()`), e quem confere ele e o teste contra Postgres real. A ausencia e **afirmada por teste offline**: tirar o `Ignore` acende vermelho em `Fora_do_Postgres_o_Precedente_sai_do_modelo_de_proposito`, com o motivo escrito ali. Exclusao que ninguem verifica e cobertura que sumiu sem aviso. Registrado como IMPL-009 na issue, porque vale para a proxima coluna que so um provedor entende.

Verde agora: **156 passaram, 0 pulados** — os testes de pgvector rodaram contra o servico de verdade.

## Fora deste PR
Indexar conversa real para virar precedente (#61) e avaliar qualidade de recuperacao (#65). Aqui e so a infraestrutura.

## Junto vai o CLAUDE.md
A secao "Estado real do repositorio" dizia "nao existe uma linha de C#" e "89 issues abertas, nenhuma fechada". A propria secao manda quem fecha issue atualizar ela no mesmo PR — esta e a primeira a pagar a conta acumulada. Documento de orientacao errado e pior que ausente: o ausente faz o agente ir olhar.

## Dependencias conferidas no terminal em 04/09/2026
`Pgvector` 0.3.2, `Pgvector.EntityFrameworkCore` 0.3.0, extensao 0.8.6 na imagem `pgvector/pgvector:pg16` do compose.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJumPBwkFMcjJwtuxQ8CbX
